### PR TITLE
refactor(meet): use ephemeral guest access

### DIFF
--- a/e2e/meet/specs/restricted-meeting.spec.ts
+++ b/e2e/meet/specs/restricted-meeting.spec.ts
@@ -78,10 +78,7 @@ test.describe("Restricted meeting", { tag: "@meet-group-1" }, () => {
 
 		await guest.page.goto(appUrl(`/meet/${meetingId}`));
 		await expect(guest.page.getByRole("heading", { name: "Ready to join?" })).toBeVisible();
-		await expect(
-			guest.page.getByText("Your previous join request was denied."),
-		).toBeVisible();
-		await guest.page.getByRole("button", { name: "Use a new guest identity" }).click();
+		await guest.page.getByPlaceholder("John Doe").fill(guestName);
 		await guest.page.getByRole("button", { name: "Join Meeting" }).click();
 
 		await expect(

--- a/e2e/meet/specs/restricted-meeting.spec.ts
+++ b/e2e/meet/specs/restricted-meeting.spec.ts
@@ -72,9 +72,16 @@ test.describe("Restricted meeting", { tag: "@meet-group-1" }, () => {
 		await expect(joinRequest).toHaveCount(0, {
 			timeout: lobbyTransitionTimeout,
 		});
+		await expect(
+			guest.page.getByText("Your join request was denied by the meeting host"),
+		).toBeVisible({ timeout: lobbyTransitionTimeout });
 
 		await guest.page.goto(appUrl(`/meet/${meetingId}`));
 		await expect(guest.page.getByRole("heading", { name: "Ready to join?" })).toBeVisible();
+		await expect(
+			guest.page.getByText("Your previous join request was denied."),
+		).toBeVisible();
+		await guest.page.getByRole("button", { name: "Use a new guest identity" }).click();
 		await guest.page.getByRole("button", { name: "Join Meeting" }).click();
 
 		await expect(

--- a/frontend/src/apps/meet/components/KickParticipantDialog.test.ts
+++ b/frontend/src/apps/meet/components/KickParticipantDialog.test.ts
@@ -1,0 +1,98 @@
+import { createApp, defineComponent, h, nextTick, ref } from "vue";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("frappe-ui", async () => {
+	const { defineComponent, h } = await import("vue");
+	return {
+		Button: defineComponent({
+			setup(_props, { attrs, slots }) {
+				return () => h("button", attrs, slots.default?.());
+			},
+		}),
+		Dialog: defineComponent({
+			setup(_props, { slots }) {
+				return () => h("div", [slots.default?.(), slots.actions?.()]);
+			},
+		}),
+		FormControl: defineComponent({
+			props: { modelValue: Boolean, label: String },
+			emits: ["update:modelValue"],
+			setup(props, { emit }) {
+				return () =>
+					h("input", {
+						label: props.label,
+						type: "checkbox",
+						checked: props.modelValue,
+						onChange: (event: Event) =>
+							emit("update:modelValue", (event.target as HTMLInputElement).checked),
+					});
+			},
+		}),
+	};
+});
+
+import KickParticipantDialog from "./KickParticipantDialog.vue";
+
+function render(canBan: boolean) {
+	const root = document.createElement("div");
+	const open = ref(true);
+	const confirm = vi.fn();
+	const app = createApp(
+		defineComponent({
+			setup() {
+				return () =>
+					h(KickParticipantDialog, {
+						modelValue: open.value,
+						participantName: "Participant",
+						canBan,
+						"onUpdate:modelValue": (value: boolean) => {
+							open.value = value;
+						},
+						onConfirm: confirm,
+					});
+			},
+		}),
+	);
+	app.mount(root);
+	return { app, confirm, open, root };
+}
+
+function button(root: HTMLElement, text: string): HTMLButtonElement {
+	const match = [...root.querySelectorAll("button")].find(
+		(candidate) => candidate.textContent === text,
+	);
+	if (!match) throw new Error(`Button not found: ${text}`);
+	return match;
+}
+
+describe("KickParticipantDialog", () => {
+	it("offers Ban for a guest", () => {
+		const { app, root } = render(true);
+		expect(root.querySelector('input[label="Ban from this meeting?"]')).not.toBeNull();
+		app.unmount();
+	});
+
+	it("keeps authenticated participant removal remove-only", () => {
+		const { app, root } = render(false);
+		expect(root.querySelector('input[label="Ban from this meeting?"]')).toBeNull();
+		app.unmount();
+	});
+
+	it.each(["cancel", "external close"])(
+		"resets Ban after %s",
+		async (closeMethod) => {
+			const { app, confirm, open, root } = render(true);
+			root.querySelector<HTMLInputElement>('input[type="checkbox"]')?.click();
+			if (closeMethod === "cancel") button(root, "Cancel").click();
+			else open.value = false;
+			await nextTick();
+			open.value = true;
+			await nextTick();
+
+			button(root, "Remove").click();
+
+			expect(confirm).toHaveBeenCalledWith(false);
+			app.unmount();
+		},
+	);
+});

--- a/frontend/src/apps/meet/components/KickParticipantDialog.vue
+++ b/frontend/src/apps/meet/components/KickParticipantDialog.vue
@@ -10,6 +10,7 @@
 					Are you sure you want to remove <strong>{{ participantName }}</strong> from the meeting?
 				</p>
 				<FormControl
+					v-if="canBan"
 					label="Ban from this meeting?"
 					type="checkbox"
 					v-model="banFromMeeting"
@@ -27,11 +28,12 @@
 
 <script setup lang="ts">
 import { Button, Dialog, FormControl } from "frappe-ui";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 interface Props {
 	participantName: string;
 	modelValue?: boolean;
+	canBan?: boolean;
 }
 
 interface Emits {
@@ -41,6 +43,7 @@ interface Emits {
 
 const props = withDefaults(defineProps<Props>(), {
 	modelValue: false,
+	canBan: false,
 });
 
 const emit = defineEmits<Emits>();
@@ -49,8 +52,18 @@ const banFromMeeting = ref(false);
 
 const showDialog = computed({
 	get: () => props.modelValue,
-	set: (value: boolean) => emit("update:modelValue", value),
+	set: (value: boolean) => {
+		if (!value) banFromMeeting.value = false;
+		emit("update:modelValue", value);
+	},
 });
+
+watch(
+	() => props.modelValue,
+	(open) => {
+		if (!open) banFromMeeting.value = false;
+	},
+);
 
 const handleKickConfirm = () => {
 	emit("confirm", banFromMeeting.value);

--- a/frontend/src/apps/meet/components/MeetingPreview.vue
+++ b/frontend/src/apps/meet/components/MeetingPreview.vue
@@ -67,15 +67,7 @@
 						v-if="terminalGuestSession"
 						class="mt-7 rounded-6 border border-outline-gray-2 bg-surface-gray-1 p-4"
 					>
-						<p class="text-sm text-ink-gray-7">{{ terminalGuestMessage }}</p>
-						<Button
-							v-if="canRetryTerminalGuest"
-							class="mt-3"
-							variant="subtle"
-							@click="clearTerminalGuestForRetry"
-						>
-							Use a new guest identity
-						</Button>
+						<p class="text-sm text-ink-gray-7">You can’t join this meeting.</p>
 					</div>
 
 					<form v-else class="mt-7 space-y-3" @submit.prevent="handleJoin">
@@ -167,11 +159,11 @@ onMounted(() => {
 	if (savedGuestName && !session.isLoggedIn) {
 		guestName.value = savedGuestName;
 	}
-	if (
-		guestSession?.status === "rejected" ||
-		guestSession?.status === "expired" ||
-		guestSession?.status === "banned"
-	) terminalGuestSession.value = guestSession;
+	if (guestSession?.status === "rejected" || guestSession?.status === "expired") {
+		clearRetryableGuestSession(props.meetingId);
+	} else if (guestSession?.status === "banned") {
+		terminalGuestSession.value = guestSession;
+	}
 });
 const guestNameInputRef = ref<VideoElement | null>(null);
 
@@ -193,29 +185,6 @@ const joinGuestAPI = createResource({
 });
 
 const isGuest = computed(() => !session.isLoggedIn && !props.guestAuthToken);
-
-const terminalGuestMessage = computed(() => {
-	switch (terminalGuestSession.value?.status) {
-		case "rejected":
-			return "Your previous join request was denied. Clear it before requesting to join again.";
-		case "expired":
-			return "Your guest session expired. Clear it before starting a new guest session.";
-		case "banned":
-			return "You are banned from joining this meeting in this browser session.";
-		default:
-			return "";
-	}
-});
-const canRetryTerminalGuest = computed(
-	() =>
-		terminalGuestSession.value?.status === "rejected" ||
-		terminalGuestSession.value?.status === "expired",
-);
-const clearTerminalGuestForRetry = () => {
-	if (!clearRetryableGuestSession(props.meetingId)) return;
-	terminalGuestSession.value = null;
-	toast.success("Guest session cleared. You can now request to join again.");
-};
 
 const previewName = computed(() => {
 	if (isGuest.value && guestName.value.trim()) {
@@ -264,13 +233,11 @@ const handleJoin = async () => {
 
 	if (isGuest.value) {
 		const storedSession = readGuestSession(props.meetingId);
-		if (
-			storedSession?.status === "rejected" ||
-			storedSession?.status === "expired" ||
-			storedSession?.status === "banned"
-		) {
+		if (storedSession?.status === "rejected" || storedSession?.status === "expired") {
+			clearRetryableGuestSession(props.meetingId);
+		} else if (storedSession?.status === "banned") {
 			terminalGuestSession.value = storedSession;
-			toast.error(terminalGuestMessage.value);
+			toast.error("You can’t join this meeting.");
 			return;
 		}
 		if (!guestName.value.trim()) {

--- a/frontend/src/apps/meet/components/MeetingPreview.vue
+++ b/frontend/src/apps/meet/components/MeetingPreview.vue
@@ -63,7 +63,22 @@
 						alignment="left"
 					/>
 
-					<form class="mt-7 space-y-3" @submit.prevent="handleJoin">
+					<div
+						v-if="terminalGuestSession"
+						class="mt-7 rounded-6 border border-outline-gray-2 bg-surface-gray-1 p-4"
+					>
+						<p class="text-sm text-ink-gray-7">{{ terminalGuestMessage }}</p>
+						<Button
+							v-if="canRetryTerminalGuest"
+							class="mt-3"
+							variant="subtle"
+							@click="clearTerminalGuestForRetry"
+						>
+							Use a new guest identity
+						</Button>
+					</div>
+
+					<form v-else class="mt-7 space-y-3" @submit.prevent="handleJoin">
 						<FormControl
 							v-if="isGuest"
 							ref="guestNameInputRef"
@@ -103,6 +118,12 @@ import AvatarGroup from "../components/AvatarGroup.vue";
 import ParticipantTile from "../components/ParticipantTile.vue";
 import PreviewToolbar from "../components/PreviewToolbar.vue";
 import { useMeetingPreviewPresence } from "../composables/useMeetingPreviewPresence";
+import {
+	clearRetryableGuestSession,
+	readActiveGuestSession,
+	readGuestSession,
+	type StoredGuestSession,
+} from "../composables/useConnectionState";
 import { session } from "@/boot/session";
 import { getErrorMessage } from "../utils/error";
 import { getInitials } from "../utils/text";
@@ -138,26 +159,63 @@ const emit = defineEmits<{
 }>();
 
 const guestName = ref("");
+const terminalGuestSession = ref<StoredGuestSession | null>(null);
 
 onMounted(() => {
-	const savedGuestName = localStorage.getItem("guest_name");
+	const guestSession = readGuestSession(props.meetingId);
+	const savedGuestName = guestSession?.guestName;
 	if (savedGuestName && !session.isLoggedIn) {
 		guestName.value = savedGuestName;
 	}
+	if (
+		guestSession?.status === "rejected" ||
+		guestSession?.status === "expired" ||
+		guestSession?.status === "banned"
+	) terminalGuestSession.value = guestSession;
 });
 const guestNameInputRef = ref<VideoElement | null>(null);
 
 const joinGuestAPI = createResource({
 	url: "suite.meet.api.meeting.join_meeting_as_guest",
 	makeParams: () => {
+		const guestSession = readActiveGuestSession(props.meetingId);
 		return {
 			meeting_id: props.meetingId,
 			guest_name: guestName.value.trim(),
+			...(guestSession
+				? {
+						guest_id: guestSession.guestId,
+						guest_session_token: guestSession.guestSessionToken,
+					}
+				: {}),
 		};
 	},
 });
 
 const isGuest = computed(() => !session.isLoggedIn && !props.guestAuthToken);
+
+const terminalGuestMessage = computed(() => {
+	switch (terminalGuestSession.value?.status) {
+		case "rejected":
+			return "Your previous join request was denied. Clear it before requesting to join again.";
+		case "expired":
+			return "Your guest session expired. Clear it before starting a new guest session.";
+		case "banned":
+			return "You are banned from joining this meeting in this browser session.";
+		default:
+			return "";
+	}
+});
+const canRetryTerminalGuest = computed(
+	() =>
+		terminalGuestSession.value?.status === "rejected" ||
+		terminalGuestSession.value?.status === "expired",
+);
+const clearTerminalGuestForRetry = () => {
+	if (!clearRetryableGuestSession(props.meetingId)) return;
+	terminalGuestSession.value = null;
+	toast.success("Guest session cleared. You can now request to join again.");
+};
 
 const previewName = computed(() => {
 	if (isGuest.value && guestName.value.trim()) {
@@ -205,14 +263,22 @@ const handleJoin = async () => {
 	}
 
 	if (isGuest.value) {
+		const storedSession = readGuestSession(props.meetingId);
+		if (
+			storedSession?.status === "rejected" ||
+			storedSession?.status === "expired" ||
+			storedSession?.status === "banned"
+		) {
+			terminalGuestSession.value = storedSession;
+			toast.error(terminalGuestMessage.value);
+			return;
+		}
 		if (!guestName.value.trim()) {
 			return;
 		}
 
 		try {
 			const result = await joinGuestAPI.submit();
-
-			localStorage.setItem("guest_name", guestName.value.trim());
 
 			emit("guest-join-complete", {
 				guestName: guestName.value.trim(),

--- a/frontend/src/apps/meet/components/ParticipantTile.vue
+++ b/frontend/src/apps/meet/components/ParticipantTile.vue
@@ -150,6 +150,7 @@
 			v-if="canShowHostControls"
 			v-model="showKickDialog"
 			:participant-name="resolvedDisplayName || 'this participant'"
+			:can-ban="participant.is_guest === true"
 			@confirm="handleKick"
 		/>
 	</div>
@@ -337,7 +338,7 @@ const handleMute = () => {
 	hostControls?.muteParticipant(props.participant.user_id);
 };
 
-const handleKick = (ban) => {
+const handleKick = (ban: boolean) => {
 	hostControls?.kickParticipant(props.participant.user_id, ban);
 	showKickDialog.value = false;
 };

--- a/frontend/src/apps/meet/components/PeopleParticipantTile.vue
+++ b/frontend/src/apps/meet/components/PeopleParticipantTile.vue
@@ -82,6 +82,7 @@
 	<KickParticipantDialog
 		v-model="showKickDialog"
 		:participant-name="participant.user_name || 'this participant'"
+		:can-ban="participant.is_guest === true"
 		@confirm="handleKickConfirm"
 	/>
 </template>

--- a/frontend/src/apps/meet/composables/useConnectionState.test.ts
+++ b/frontend/src/apps/meet/composables/useConnectionState.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	clearGuestSession,
+	clearRetryableGuestSession,
+	readActiveGuestSession,
+	readGuestSession,
+	setCurrentGuestIdentity,
+	shouldAutoConnectAdmittedGuest,
+	writeGuestSession,
+} from "./useConnectionState";
+
+describe("guest browser session", () => {
+	beforeEach(() => sessionStorage.clear());
+
+	it("reuses a complete room-scoped guest session", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "pending",
+		});
+
+		expect(readGuestSession("room-1")).toEqual({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "pending",
+		});
+	});
+
+	it("does not disclose a session to another room", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "admitted",
+		});
+
+		expect(readGuestSession("room-2")).toBeNull();
+	});
+
+	it("never returns terminal proof as an active guest session", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "expired",
+		});
+
+		expect(readActiveGuestSession("room-1")).toBeNull();
+	});
+
+	it("returns admitted proof for an explicit preview Join", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "admitted",
+		});
+
+		expect(readActiveGuestSession("room-1")).toMatchObject({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			status: "admitted",
+		});
+	});
+
+	it.each(["pending", "admitted", "rejected", "banned", "expired"] as const)(
+		"preserves %s status across reload",
+		(status) => {
+			writeGuestSession({
+				guestId: "guest_1",
+				guestSessionToken: "proof-1",
+				meetingId: "room-1",
+				guestName: "Guest One",
+				status,
+			});
+			expect(readGuestSession("room-1")?.status).toBe(status);
+		},
+	);
+
+	it("clears proof only on an explicit clear", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "admitted",
+		});
+
+		clearGuestSession();
+
+		expect(readGuestSession("room-1")).toBeNull();
+	});
+
+	it("restores the stored guest identity before automatic connection setup", () => {
+		const setCurrentUser = vi.fn();
+		setCurrentGuestIdentity(
+			{ setCurrentUser },
+			{
+				guestId: "guest_reload",
+				guestSessionToken: "proof-1",
+				meetingId: "room-1",
+				guestName: "Reloaded Guest",
+				status: "admitted",
+			},
+		);
+
+		expect(setCurrentUser).toHaveBeenCalledWith({
+			user_id: "guest_reload",
+			userId: "guest_reload",
+			name: "Reloaded Guest",
+			full_name: "Reloaded Guest",
+			is_guest: true,
+		});
+	});
+
+	it.each(["rejected", "expired"] as const)(
+		"clears a %s session only through explicit retry",
+		(status) => {
+			writeGuestSession({
+				guestId: "guest_1",
+				guestSessionToken: "proof-1",
+				meetingId: "room-1",
+				guestName: "Guest One",
+				status,
+			});
+
+			expect(clearRetryableGuestSession("room-1")).toBe(true);
+			expect(readGuestSession("room-1")).toBeNull();
+		},
+	);
+
+	it("does not clear a banned tombstone for retry", () => {
+		writeGuestSession({
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "banned",
+		});
+
+		expect(clearRetryableGuestSession("room-1")).toBe(false);
+		expect(readGuestSession("room-1")?.status).toBe("banned");
+	});
+
+	it("auto-connects only when admission completes a pending join request", () => {
+		const admittedSession = {
+			guestId: "guest_1",
+			guestSessionToken: "proof-1",
+			meetingId: "room-1",
+			guestName: "Guest One",
+			status: "admitted" as const,
+		};
+
+		expect(
+			shouldAutoConnectAdmittedGuest({
+				...admittedSession,
+				status: "pending",
+			}),
+		).toBe(true);
+		expect(shouldAutoConnectAdmittedGuest(admittedSession)).toBe(false);
+	});
+});

--- a/frontend/src/apps/meet/composables/useConnectionState.ts
+++ b/frontend/src/apps/meet/composables/useConnectionState.ts
@@ -1,5 +1,114 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
+import type { CurrentUser } from "./useCurrentUser";
+
+export type GuestSessionStatus =
+	| "pending"
+	| "admitted"
+	| "rejected"
+	| "banned"
+	| "expired";
+
+export interface StoredGuestSession {
+	guestId: string;
+	guestSessionToken: string;
+	meetingId: string;
+	guestName: string;
+	status: GuestSessionStatus;
+}
+
+const GUEST_SESSION_KEYS = {
+	guestId: "guest_id",
+	guestSessionToken: "guest_session_token",
+	meetingId: "guest_meeting_id",
+	guestName: "guest_name",
+	status: "guest_status",
+} as const;
+
+export function readGuestSession(meetingId: string): StoredGuestSession | null {
+	const guestId = sessionStorage.getItem(GUEST_SESSION_KEYS.guestId);
+	const guestSessionToken = sessionStorage.getItem(
+		GUEST_SESSION_KEYS.guestSessionToken,
+	);
+	const storedMeetingId = sessionStorage.getItem(GUEST_SESSION_KEYS.meetingId);
+	const guestName = sessionStorage.getItem(GUEST_SESSION_KEYS.guestName);
+	const status = sessionStorage.getItem(GUEST_SESSION_KEYS.status);
+	if (
+		!guestId ||
+		!guestSessionToken ||
+		storedMeetingId !== meetingId ||
+		!guestName ||
+		!status ||
+		!["pending", "admitted", "rejected", "banned", "expired"].includes(status)
+	) {
+		return null;
+	}
+	return {
+		guestId,
+		guestSessionToken,
+		meetingId: storedMeetingId,
+		guestName,
+		status: status as GuestSessionStatus,
+	};
+}
+
+export function readActiveGuestSession(
+	meetingId: string,
+): StoredGuestSession | null {
+	const session = readGuestSession(meetingId);
+	return session?.status === "pending" || session?.status === "admitted"
+		? session
+		: null;
+}
+
+export function writeGuestSession(session: StoredGuestSession): void {
+	sessionStorage.setItem(GUEST_SESSION_KEYS.guestId, session.guestId);
+	sessionStorage.setItem(
+		GUEST_SESSION_KEYS.guestSessionToken,
+		session.guestSessionToken,
+	);
+	sessionStorage.setItem(GUEST_SESSION_KEYS.meetingId, session.meetingId);
+	sessionStorage.setItem(GUEST_SESSION_KEYS.guestName, session.guestName);
+	sessionStorage.setItem(GUEST_SESSION_KEYS.status, session.status);
+}
+
+export function clearGuestSession(): void {
+	for (const key of Object.values(GUEST_SESSION_KEYS)) {
+		sessionStorage.removeItem(key);
+	}
+}
+
+export function clearRetryableGuestSession(meetingId: string): boolean {
+	const session = readGuestSession(meetingId);
+	if (session?.status !== "rejected" && session?.status !== "expired") {
+		return false;
+	}
+	clearGuestSession();
+	return true;
+}
+
+export function clearGuestSessionForExit(meetingId: string): void {
+	if (readGuestSession(meetingId)?.status !== "banned") clearGuestSession();
+}
+
+export function setCurrentGuestIdentity(
+	currentUser: Pick<CurrentUser, "setCurrentUser">,
+	guestSession: StoredGuestSession,
+): void {
+	currentUser.setCurrentUser({
+		user_id: guestSession.guestId,
+		userId: guestSession.guestId,
+		name: guestSession.guestName,
+		full_name: guestSession.guestName,
+		is_guest: true,
+	});
+}
+
+export function shouldAutoConnectAdmittedGuest(
+	subscribedSession: StoredGuestSession,
+): boolean {
+	return subscribedSession.status === "pending";
+}
 
 export interface ConnectionState {
 	connectionError: string | null;

--- a/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
@@ -1,0 +1,226 @@
+import { frappeRequest } from "frappe-ui";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Socket } from "socket.io-client";
+import {
+	createGuestRealtimeLifecycle,
+	getApprovedGuestConnectionDetails,
+} from "./useGuestRealtime";
+
+vi.mock("frappe-ui", () => ({ frappeRequest: vi.fn() }));
+
+const session = {
+	guestId: "guest_private",
+	guestSessionToken: "private-proof",
+	meetingId: "room-1",
+	guestName: "Guest One",
+	status: "pending" as const,
+};
+
+function createSocket() {
+	const listeners = new Map<string, (...args: unknown[]) => void>();
+	const emit = vi.fn();
+	return {
+		listeners,
+		socket: {
+			on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+				listeners.set(event, listener);
+			}),
+			off: vi.fn((event: string) => listeners.delete(event)),
+			emit,
+		} as unknown as Socket,
+		emit,
+	};
+}
+
+function createLifecycle(
+	socket: Socket,
+	readSession = () => session,
+	callbacks = {
+		onActiveStatus: vi.fn(),
+		onTerminalStatus: vi.fn(),
+		onError: vi.fn(),
+	},
+) {
+	return {
+		callbacks,
+		lifecycle: createGuestRealtimeLifecycle({
+			socket,
+			meetingId: "room-1",
+			readSession,
+			...callbacks,
+		}),
+	};
+}
+
+describe("guest realtime lifecycle", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("fetches admitted credentials through the POST-only proof-bound endpoint", async () => {
+		vi.mocked(frappeRequest).mockResolvedValue({
+			status: "joined",
+			guest_id: "guest_private",
+			auth_token: "guest-jwt",
+		});
+
+		await getApprovedGuestConnectionDetails(session);
+
+		expect(frappeRequest).toHaveBeenCalledWith({
+			url: "suite.meet.api.meeting.get_approved_guest_connection_details",
+			method: "POST",
+			params: {
+				meeting_id: "room-1",
+				guest_id: "guest_private",
+				guest_session_token: "private-proof",
+			},
+		});
+	});
+
+	it.each(["pending", "admitted"] as const)(
+		"subscribes a stored %s guest with private proof and resubscribes on reconnect",
+		(status) => {
+			const { socket, emit, listeners } = createSocket();
+			const { lifecycle } = createLifecycle(socket, () => ({ ...session, status }));
+
+			lifecycle.start();
+			listeners.get("connect")?.();
+
+			expect(emit).toHaveBeenNthCalledWith(
+				1,
+				"guest_subscribe",
+				{
+					guest_id: "guest_private",
+					meeting_id: "room-1",
+					guest_session_token: "private-proof",
+				},
+				expect.any(Function),
+			);
+			expect(emit).toHaveBeenCalledTimes(2);
+		},
+	);
+
+	it.each([
+		["pending", true],
+		["admitted", false],
+	] as const)(
+		"preserves prior %s state when an admitted acknowledgement arrives",
+		(priorStatus, wasPending) => {
+			const { socket, emit } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket, () => ({
+				...session,
+				status: priorStatus,
+			}));
+			lifecycle.start();
+
+			const acknowledge = emit.mock.calls[0][2] as (response: unknown) => void;
+			acknowledge({ ok: true, status: "admitted" });
+
+			expect(callbacks.onActiveStatus).toHaveBeenCalledWith(
+				"admitted",
+				expect.objectContaining({ status: wasPending ? "pending" : "admitted" }),
+			);
+		},
+	);
+
+	it("does not duplicate listeners or subscription when start is repeated", () => {
+		const { socket, emit } = createSocket();
+		const { lifecycle } = createLifecycle(socket);
+
+		lifecycle.start();
+		lifecycle.start();
+
+		expect(socket.on).toHaveBeenCalledTimes(3);
+		expect(emit).toHaveBeenCalledTimes(1);
+	});
+
+	it.each(["pending", "admitted"] as const)(
+		"uses active %s status from the acknowledgement without an API request",
+		(status) => {
+			const { socket, emit } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket);
+			lifecycle.start();
+
+			const acknowledge = emit.mock.calls[0][2] as (response: unknown) => void;
+			acknowledge({ ok: true, status });
+
+			expect(callbacks.onActiveStatus).toHaveBeenCalledWith(status, session);
+			expect(callbacks.onTerminalStatus).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["rejected", "banned", "expired"] as const)(
+		"handles terminal %s status and unsubscribes",
+		(status) => {
+			const { socket, emit } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket);
+			lifecycle.start();
+
+			const acknowledge = emit.mock.calls[0][2] as (response: unknown) => void;
+			acknowledge({ ok: false, error: "unauthorized", status });
+
+			expect(callbacks.onTerminalStatus).toHaveBeenCalledWith(status);
+			expect(emit).toHaveBeenLastCalledWith("guest_unsubscribe", {
+				guest_id: "guest_private",
+				meeting_id: "room-1",
+				guest_session_token: "private-proof",
+			});
+		},
+	);
+
+	it.each(["invalid_request", "validation_failed"])(
+		"surfaces %s acknowledgement failures",
+		(error) => {
+			const { socket, emit } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket);
+			lifecycle.start();
+
+			const acknowledge = emit.mock.calls[0][2] as (response: unknown) => void;
+			acknowledge({ ok: false, error });
+
+			expect(callbacks.onError).toHaveBeenCalledWith(
+				expect.objectContaining({ message: expect.stringContaining(error) }),
+			);
+		},
+	);
+
+	it("fetches admitted details through the active-status callback after approval", () => {
+		const { socket, listeners } = createSocket();
+		const { lifecycle, callbacks } = createLifecycle(socket);
+		lifecycle.start();
+
+		listeners.get("meet:guest_join_approved")?.({
+			guest_id: "guest_private",
+			meeting_id: "room-1",
+		});
+
+		expect(callbacks.onActiveStatus).toHaveBeenCalledWith("admitted", session);
+	});
+
+	it("uses the cached session to unsubscribe after storage is cleared", () => {
+		const { socket, emit } = createSocket();
+		let storedSession: typeof session | null = session;
+		const { lifecycle } = createLifecycle(socket, () => storedSession);
+		lifecycle.start();
+		storedSession = null;
+
+		lifecycle.stop();
+
+		expect(emit).toHaveBeenLastCalledWith("guest_unsubscribe", {
+			guest_id: "guest_private",
+			meeting_id: "room-1",
+			guest_session_token: "private-proof",
+		});
+		expect(socket.off).toHaveBeenCalledTimes(3);
+	});
+
+	it.each(["rejected", "banned", "expired"] as const)(
+		"does not subscribe a terminal %s session",
+		(status) => {
+			const { socket, emit } = createSocket();
+			const { lifecycle } = createLifecycle(socket, () => ({ ...session, status }));
+
+			lifecycle.start();
+
+			expect(emit).not.toHaveBeenCalled();
+		},
+	);
+});

--- a/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
@@ -166,6 +166,34 @@ describe("guest realtime lifecycle", () => {
 		},
 	);
 
+	it("reconciles a terminal status over HTTP when its realtime event is missed", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.mocked(frappeRequest).mockResolvedValue({
+				valid: false,
+				status: "rejected",
+			});
+			const { socket } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket);
+			lifecycle.start();
+
+			await vi.advanceTimersByTimeAsync(5_000);
+
+			expect(callbacks.onTerminalStatus).toHaveBeenCalledWith("rejected");
+			expect(frappeRequest).toHaveBeenCalledWith({
+				url: "suite.meet.api.meeting.validate_guest_session",
+				method: "POST",
+				params: {
+					meeting_id: "room-1",
+					guest_id: "guest_private",
+					guest_session_token: "private-proof",
+				},
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it.each(["invalid_request", "validation_failed"])(
 		"surfaces %s acknowledgement failures",
 		(error) => {

--- a/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.test.ts
@@ -194,6 +194,22 @@ describe("guest realtime lifecycle", () => {
 		}
 	});
 
+	it("expires a stored guest when reconciliation can no longer find its lease", async () => {
+		vi.useFakeTimers();
+		try {
+			vi.mocked(frappeRequest).mockResolvedValue({ valid: false });
+			const { socket } = createSocket();
+			const { lifecycle, callbacks } = createLifecycle(socket);
+			lifecycle.start();
+
+			await vi.advanceTimersByTimeAsync(5_000);
+
+			expect(callbacks.onTerminalStatus).toHaveBeenCalledWith("expired");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it.each(["invalid_request", "validation_failed"])(
 		"surfaces %s acknowledgement failures",
 		(error) => {

--- a/frontend/src/apps/meet/composables/useGuestRealtime.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.ts
@@ -24,6 +24,8 @@ interface GuestRealtimeEvent {
 	meetingId: string;
 }
 
+const GUEST_STATUS_RECONCILIATION_INTERVAL = 5_000;
+
 interface GuestRealtimeLifecycleOptions {
 	socket: Socket | null;
 	meetingId: string;
@@ -96,6 +98,8 @@ export function createGuestRealtimeLifecycle({
 }: GuestRealtimeLifecycleOptions) {
 	let setup = false;
 	let subscribedSession: StoredGuestSession | null = null;
+	let reconciliationInterval: ReturnType<typeof setInterval> | null = null;
+	let reconciliationInProgress = false;
 
 	const matchesSubscribedSession = (value: unknown) => {
 		const event = normalizeGuestRealtimeEvent(value);
@@ -118,6 +122,10 @@ export function createGuestRealtimeLifecycle({
 
 	const stop = () => {
 		unsubscribe();
+		if (reconciliationInterval) {
+			clearInterval(reconciliationInterval);
+			reconciliationInterval = null;
+		}
 		if (!socket || !setup) return;
 		socket.off("meet:guest_join_approved", handleApproved);
 		socket.off("meet:guest_join_rejected", handleRejected);
@@ -172,6 +180,34 @@ export function createGuestRealtimeLifecycle({
 		);
 	};
 
+	const reconcile = async () => {
+		const session = readSession();
+		if (!isActiveSession(session) || reconciliationInProgress) return;
+		reconciliationInProgress = true;
+		try {
+			const response = await frappeRequest({
+				url: "suite.meet.api.meeting.validate_guest_session",
+				method: "POST",
+				params: {
+					meeting_id: meetingId,
+					guest_id: session.guestId,
+					guest_session_token: session.guestSessionToken,
+				},
+			});
+			if (!isUnknownRecord(response)) return;
+			const status = normalizeStatus(response.status);
+			if (response.valid === true && (status === "pending" || status === "admitted")) {
+				await onActiveStatus(status, session);
+			} else if (status === "rejected" || status === "banned" || status === "expired") {
+				handleTerminalStatus(status);
+			}
+		} catch {
+			// Realtime remains the primary path; retry transient reconciliation failures.
+		} finally {
+			reconciliationInProgress = false;
+		}
+	};
+
 	function handleApproved(value: unknown) {
 		if (matchesSubscribedSession(value) && subscribedSession) {
 			void onActiveStatus("admitted", subscribedSession);
@@ -197,6 +233,10 @@ export function createGuestRealtimeLifecycle({
 			socket.on("meet:guest_join_rejected", handleRejected);
 			socket.on("connect", handleReconnect);
 			setup = true;
+			reconciliationInterval = setInterval(
+				() => void reconcile(),
+				GUEST_STATUS_RECONCILIATION_INTERVAL,
+			);
 		}
 		subscribe();
 	};

--- a/frontend/src/apps/meet/composables/useGuestRealtime.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.ts
@@ -200,6 +200,8 @@ export function createGuestRealtimeLifecycle({
 				await onActiveStatus(status, session);
 			} else if (status === "rejected" || status === "banned" || status === "expired") {
 				handleTerminalStatus(status);
+			} else if (response.valid === false) {
+				handleTerminalStatus("expired");
 			}
 		} catch {
 			// Realtime remains the primary path; retry transient reconciliation failures.

--- a/frontend/src/apps/meet/composables/useGuestRealtime.ts
+++ b/frontend/src/apps/meet/composables/useGuestRealtime.ts
@@ -1,0 +1,205 @@
+import { frappeRequest } from "frappe-ui";
+import type { Socket } from "socket.io-client";
+import {
+	isUnknownRecord,
+	type JoinPayload,
+	normalizeJoinPayload,
+} from "../types";
+import type {
+	GuestSessionStatus,
+	StoredGuestSession,
+} from "./useConnectionState";
+
+type ActiveGuestSessionStatus = Extract<
+	GuestSessionStatus,
+	"pending" | "admitted"
+>;
+type TerminalGuestSessionStatus = Exclude<
+	GuestSessionStatus,
+	ActiveGuestSessionStatus
+>;
+
+interface GuestRealtimeEvent {
+	guestId: string;
+	meetingId: string;
+}
+
+interface GuestRealtimeLifecycleOptions {
+	socket: Socket | null;
+	meetingId: string;
+	readSession: () => StoredGuestSession | null;
+	onActiveStatus: (
+		status: ActiveGuestSessionStatus,
+		session: StoredGuestSession,
+	) => void | Promise<void>;
+	onTerminalStatus: (status: TerminalGuestSessionStatus) => void;
+	onError: (error: Error) => void;
+}
+
+function isActiveSession(
+	session: StoredGuestSession | null,
+): session is StoredGuestSession & { status: ActiveGuestSessionStatus } {
+	return session?.status === "pending" || session?.status === "admitted";
+}
+
+function normalizeGuestRealtimeEvent(value: unknown): GuestRealtimeEvent | null {
+	if (
+		!isUnknownRecord(value) ||
+		typeof value.guest_id !== "string" ||
+		typeof value.meeting_id !== "string"
+	) return null;
+	return { guestId: value.guest_id, meetingId: value.meeting_id };
+}
+
+function normalizeStatus(
+	value: unknown,
+): ActiveGuestSessionStatus | TerminalGuestSessionStatus | null {
+	return value === "pending" ||
+		value === "admitted" ||
+		value === "rejected" ||
+		value === "banned" ||
+		value === "expired"
+		? value
+		: null;
+}
+
+export async function getApprovedGuestConnectionDetails(
+	session: StoredGuestSession,
+): Promise<JoinPayload> {
+	const response = normalizeJoinPayload(
+		await frappeRequest({
+			url: "suite.meet.api.meeting.get_approved_guest_connection_details",
+			method: "POST",
+			params: {
+				meeting_id: session.meetingId,
+				guest_id: session.guestId,
+				guest_session_token: session.guestSessionToken,
+			},
+		}),
+	);
+	if (response?.status !== "joined" || !response.auth_token) {
+		throw new Error("Guest is not admitted to this meeting");
+	}
+	if (response.guest_id && response.guest_id !== session.guestId) {
+		throw new Error("Approved guest identity does not match the stored session");
+	}
+	return response;
+}
+
+export function createGuestRealtimeLifecycle({
+	socket,
+	meetingId,
+	readSession,
+	onActiveStatus,
+	onTerminalStatus,
+	onError,
+}: GuestRealtimeLifecycleOptions) {
+	let setup = false;
+	let subscribedSession: StoredGuestSession | null = null;
+
+	const matchesSubscribedSession = (value: unknown) => {
+		const event = normalizeGuestRealtimeEvent(value);
+		return Boolean(
+			subscribedSession &&
+				event?.guestId === subscribedSession.guestId &&
+				event.meetingId === meetingId,
+		);
+	};
+
+	const unsubscribe = () => {
+		if (!socket || !subscribedSession) return;
+		socket.emit("guest_unsubscribe", {
+			guest_id: subscribedSession.guestId,
+			meeting_id: meetingId,
+			guest_session_token: subscribedSession.guestSessionToken,
+		});
+		subscribedSession = null;
+	};
+
+	const stop = () => {
+		unsubscribe();
+		if (!socket || !setup) return;
+		socket.off("meet:guest_join_approved", handleApproved);
+		socket.off("meet:guest_join_rejected", handleRejected);
+		socket.off("connect", handleReconnect);
+		setup = false;
+	};
+
+	const handleTerminalStatus = (status: TerminalGuestSessionStatus) => {
+		onTerminalStatus(status);
+		stop();
+	};
+
+	const handleAcknowledgement = (value: unknown) => {
+		if (!isUnknownRecord(value) || typeof value.ok !== "boolean") {
+			onError(new Error("Invalid guest subscription acknowledgement"));
+			return;
+		}
+		const status = normalizeStatus(value.status);
+		if (value.ok) {
+			if (!status || status === "rejected" || status === "banned" || status === "expired") {
+				onError(new Error("Invalid guest subscription status"));
+				return;
+			}
+			if (subscribedSession) void onActiveStatus(status, subscribedSession);
+			return;
+		}
+		if (status === "rejected" || status === "banned" || status === "expired") {
+			handleTerminalStatus(status);
+			return;
+		}
+		const reason = typeof value.error === "string" ? value.error : "invalid_request";
+		onError(new Error(`Guest realtime subscription failed: ${reason}`));
+	};
+
+	const subscribe = () => {
+		const session = readSession();
+		if (!socket || !isActiveSession(session)) return;
+		if (
+			subscribedSession &&
+			(subscribedSession.guestId !== session.guestId ||
+				subscribedSession.guestSessionToken !== session.guestSessionToken)
+		) unsubscribe();
+		subscribedSession = { ...session };
+		socket.emit(
+			"guest_subscribe",
+			{
+				guest_id: session.guestId,
+				meeting_id: meetingId,
+				guest_session_token: session.guestSessionToken,
+			},
+			handleAcknowledgement,
+		);
+	};
+
+	function handleApproved(value: unknown) {
+		if (matchesSubscribedSession(value) && subscribedSession) {
+			void onActiveStatus("admitted", subscribedSession);
+		}
+	}
+	function handleRejected(value: unknown) {
+		if (matchesSubscribedSession(value)) handleTerminalStatus("rejected");
+	}
+	function handleReconnect() {
+		subscribe();
+	}
+
+	const start = () => {
+		const session = readSession();
+		if (!socket || !isActiveSession(session)) return;
+		if (
+			setup &&
+			subscribedSession?.guestId === session.guestId &&
+			subscribedSession.guestSessionToken === session.guestSessionToken
+		) return;
+		if (!setup) {
+			socket.on("meet:guest_join_approved", handleApproved);
+			socket.on("meet:guest_join_rejected", handleRejected);
+			socket.on("connect", handleReconnect);
+			setup = true;
+		}
+		subscribe();
+	};
+
+	return { start, stop };
+}

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.test.ts
@@ -1,8 +1,17 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 import { useMeetingHandlers } from "./useMeetingHandlers";
 
+vi.mock("frappe-ui", () => ({
+	frappeRequest: vi.fn(),
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { frappeRequest, toast } from "frappe-ui";
+
 describe("useMeetingHandlers", () => {
+	beforeEach(() => vi.clearAllMocks());
+
 	it("cleans up the failed manager before returning to preview", async () => {
 		const cleanup = vi.fn().mockResolvedValue(undefined);
 		const sfuManager = ref({ cleanup });
@@ -47,5 +56,67 @@ describe("useMeetingHandlers", () => {
 		await handlers[handler]("participant-1");
 
 		expect(sendHostControl).toHaveBeenCalledWith(action, "participant-1");
+	});
+
+	it("records a guest ban before sending the distinct SFU ban action", async () => {
+		vi.mocked(frappeRequest).mockResolvedValue({ status: "banned" });
+		const sendHostControl = vi.fn();
+		const handlers = useMeetingHandlers({
+			meetingId: "room-1",
+			sfuConnection: { sfuManager: ref({ sendHostControl }) },
+		} as never);
+
+		await handlers.handleKickParticipant("guest_1", true);
+
+		expect(frappeRequest).toHaveBeenCalledWith({
+			url: "suite.meet.api.meeting.ban_guest",
+			params: { meeting_id: "room-1", guest_id: "guest_1" },
+		});
+		expect(sendHostControl).toHaveBeenCalledWith("ban_participant", "guest_1");
+	});
+
+	it("does not record a backend ban without an SFU manager", async () => {
+		const handlers = useMeetingHandlers({
+			meetingId: "room-1",
+			sfuConnection: { sfuManager: ref(null) },
+		} as never);
+
+		await handlers.handleKickParticipant("guest_1", true);
+
+		expect(frappeRequest).not.toHaveBeenCalled();
+		expect(toast.error).toHaveBeenCalledWith(
+			expect.stringContaining("Reconnect"),
+		);
+	});
+
+	it("surfaces an acknowledged ban failure after backend revocation", async () => {
+		vi.mocked(frappeRequest).mockResolvedValue({ status: "banned" });
+		const sendHostControl = vi.fn().mockRejectedValue(new Error("SFU rejected"));
+		const handlers = useMeetingHandlers({
+			meetingId: "room-1",
+			sfuConnection: { sfuManager: ref({ sendHostControl }) },
+		} as never);
+
+		await handlers.handleKickParticipant("guest_1", true);
+
+		expect(toast.error).toHaveBeenCalledWith(
+			expect.stringContaining("Use Remove to retry"),
+		);
+	});
+
+	it("keeps authenticated participant removal remove-only", async () => {
+		const sendHostControl = vi.fn();
+		const handlers = useMeetingHandlers({
+			meetingId: "room-1",
+			sfuConnection: { sfuManager: ref({ sendHostControl }) },
+		} as never);
+
+		await handlers.handleKickParticipant("member@example.com", true);
+
+		expect(frappeRequest).not.toHaveBeenCalled();
+		expect(sendHostControl).toHaveBeenCalledWith(
+			"kick_participant",
+			"member@example.com",
+		);
 	});
 });

--- a/frontend/src/apps/meet/composables/useMeetingHandlers.ts
+++ b/frontend/src/apps/meet/composables/useMeetingHandlers.ts
@@ -3,7 +3,11 @@ import type { Ref } from "vue";
 import type { Router } from "vue-router";
 import type { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import type { ChatStore } from "./useChatStore";
-import type { ConnectionState } from "./useConnectionState";
+import {
+	clearGuestSessionForExit,
+	readGuestSession,
+	type ConnectionState,
+} from "./useConnectionState";
 import type { CurrentUser } from "./useCurrentUser";
 import type { GridLayout } from "./useGridLayout";
 import type { LobbyStore } from "./useLobbyStore";
@@ -98,7 +102,8 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 		const guestId =
 			normalizedJoinResult.guest_id ||
 			(deps.connectionState.guestId as string);
-		const resolvedGuestName = guestName || localStorage.getItem("guest_name");
+		const resolvedGuestName =
+			guestName || readGuestSession(deps.meetingId)?.guestName;
 
 		if (guestId && resolvedGuestName) {
 			deps.currentUser.setCurrentUser({
@@ -117,12 +122,14 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 	};
 
 	const leaveWaitingRoom = () => {
+		clearGuestSessionForExit(deps.meetingId);
 		deps.lobbyStore.isWaitingForApproval = false;
 		deps.lobbyStore.isJoinRequestRejected = false;
 		deps.router.push({ name: "meet-home" });
 	};
 
 	const leaveLobby = async () => {
+		clearGuestSessionForExit(deps.meetingId);
 		deps.lobbyStore.isInLobby = false;
 		deps.lobbyStore.isWaitingForApproval = false;
 		deps.lobbyStore.lobbyParticipantCount = 0;
@@ -130,6 +137,7 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 	};
 
 	const goHome = () => {
+		clearGuestSessionForExit(deps.meetingId);
 		deps.lobbyStore.isJoinRequestRejected = false;
 		deps.lobbyStore.isInLobby = false;
 		deps.router.push({ name: "meet-home" });
@@ -159,7 +167,7 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 
 	const handleMuteParticipant = async (participantId: string) => {
 		try {
-			deps.sfuConnection.sfuManager.value?.sendHostControl(
+			await deps.sfuConnection.sfuManager.value?.sendHostControl(
 				"mute_participant",
 				participantId,
 			);
@@ -169,28 +177,42 @@ export function useMeetingHandlers(deps: MeetingHandlersDeps) {
 	};
 
 	const handleKickParticipant = async (participantId: string, ban = false) => {
+		let backendBanRecorded = false;
 		try {
-			if (ban) {
-				await deps.meetingDoc.setValue.submit({
-					banned_users: [
-						...(deps.meetingDoc.doc?.banned_users || []),
-						{ user: participantId },
-					],
+			const shouldBan = ban && participantId.startsWith("guest_");
+			const manager = deps.sfuConnection.sfuManager.value;
+			if (!manager) {
+				toast.error("Cannot remove this participant while disconnected. Reconnect and try again.");
+				return;
+			}
+			if (shouldBan) {
+				await frappeRequest({
+					url: "suite.meet.api.meeting.ban_guest",
+					params: {
+						meeting_id: deps.meetingId,
+						guest_id: participantId,
+					},
 				});
+				backendBanRecorded = true;
 			}
 
-			deps.sfuConnection.sfuManager.value?.sendHostControl(
-				"kick_participant",
+			await manager.sendHostControl(
+				shouldBan ? "ban_participant" : "kick_participant",
 				participantId,
 			);
 		} catch (error) {
 			console.error("Failed to kick participant:", error);
+			toast.error(
+				backendBanRecorded
+					? "Guest was banned but could not be disconnected. Use Remove to retry the live removal."
+					: "Could not remove this participant. Please try again.",
+			);
 		}
 	};
 
 	const handleLowerHand = async (participantId: string) => {
 		try {
-			deps.sfuConnection.sfuManager.value?.sendHostControl(
+			await deps.sfuConnection.sfuManager.value?.sendHostControl(
 				"lower_hand",
 				participantId,
 			);

--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -26,7 +26,20 @@ import {
 import { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import { getClientTelemetry } from "../utils/telemetry/ClientTelemetry";
 import { useChatStore } from "./useChatStore";
-import type { ConnectionState } from "./useConnectionState";
+import {
+	clearGuestSession,
+	readGuestSession,
+	setCurrentGuestIdentity,
+	shouldAutoConnectAdmittedGuest,
+	type StoredGuestSession,
+	writeGuestSession,
+	type ConnectionState,
+	type GuestSessionStatus,
+} from "./useConnectionState";
+import {
+	createGuestRealtimeLifecycle,
+	getApprovedGuestConnectionDetails,
+} from "./useGuestRealtime";
 import type { CurrentUser } from "./useCurrentUser";
 import {
 	type E2EEConnectionHandshake,
@@ -84,17 +97,6 @@ function normalizeMeetingRealtimeEvent(value: unknown): MeetingRealtimeEvent | n
 		userName: typeof value.user_name === "string" ? value.user_name : undefined,
 		userImage: typeof value.user_image === "string" ? value.user_image : undefined,
 	};
-}
-
-function normalizeGuestRealtimeEvent(
-	value: unknown,
-): { guestId: string; meetingId: string } | null {
-	if (
-		!isUnknownRecord(value) ||
-		typeof value.guest_id !== "string" ||
-		typeof value.meeting_id !== "string"
-	) return null;
-	return { guestId: value.guest_id, meetingId: value.meeting_id };
 }
 
 function normalizeWaitingRoomResponse(value: unknown): WaitingRoomResponse | null {
@@ -272,6 +274,14 @@ export function useSFUConnection(deps: {
 		() => participantConnectionState.isSetupComplete,
 	);
 	let stabilityCheckTimeout: ReturnType<typeof setTimeout> | null = null;
+	let preserveGuestSessionOnEnd = false;
+
+	const markGuestSessionStatus = (status: GuestSessionStatus) => {
+		const guestSession = readGuestSession(meetingId);
+		if (guestSession) writeGuestSession({ ...guestSession, status });
+		lobbyStore.isJoinRequestRejected = true;
+		lobbyStore.isWaitingForApproval = false;
+	};
 
 	const handleParticipantJoined = (participant: Participant) => {
 		const participantName = participant?.user_name || participant?.user_id;
@@ -471,8 +481,14 @@ export function useSFUConnection(deps: {
 				}
 			},
 			onHostMutedYou: onHostMutedYou,
-			onHostKickedYou: (_data: unknown) => {
-				toast.error("You have been removed from the meeting by the host");
+			onHostKickedYou: (data: { hostId?: string; banned?: boolean }) => {
+				if (data.banned) {
+					preserveGuestSessionOnEnd = true;
+					markGuestSessionStatus("banned");
+					toast.error("You have been banned from this meeting by the host");
+				} else {
+					toast.error("You have been removed from the meeting by the host");
+				}
 				onHostKickedYou();
 			},
 			onParticipantConnectionReplaced: async () => {
@@ -709,116 +725,111 @@ export function useSFUConnection(deps: {
 		}
 	};
 
-	const setupGuestApprovalListener = (guestName: string) => {
-		const guestId = sessionStorage.getItem("guest_id");
-
-		if (!guestId) {
-			console.error("No guest_id found for realtime listener");
-			return;
-		}
-
-		if (!socket) {
-			console.error("Socket not available for guest approval listener");
-			return;
-		}
-
-		socket.on("meet:guest_join_approved", handleGuestApproved);
-		socket.on("meet:guest_join_rejected", handleGuestRejected);
-
-		async function handleGuestApproved(value: unknown) {
-			const event = normalizeGuestRealtimeEvent(value);
-			if (event?.guestId !== guestId || event.meetingId !== meetingId) {
-				return;
-			}
-
-			removeGuestApprovalListeners();
-
-			lobbyStore.isWaitingForApproval = false;
+	let approvedGuestConnectionPromise: Promise<void> | null = null;
+	const connectAdmittedGuest = (guestSession: StoredGuestSession) => {
+		if (approvedGuestConnectionPromise) return approvedGuestConnectionPromise;
+		approvedGuestConnectionPromise = (async () => {
 			joiningInProgress.value = true;
-
 			try {
-				const resolvedGuestName =
-					guestName || sessionStorage.getItem("guest_name") || "Guest";
-				const response = normalizeJoinPayload(await frappeRequest({
-					url: "suite.meet.api.meeting.get_approved_guest_connection_details",
-					params: {
-						meeting_id: meetingId,
-						guest_id: guestId,
-					},
-				}));
+				const response = await getApprovedGuestConnectionDetails(guestSession);
+				const currentSession = readGuestSession(meetingId);
 				if (
-					response?.status === "joined" &&
-					response.auth_token
-				) {
-					if (response.host_only_chat !== undefined) {
-						chatStore.hostOnlyChat = response.host_only_chat;
-					}
-
-					if (response.recording !== undefined)
-						onRecordingState?.(response.recording);
-					connectionState.guestAuthToken = response.auth_token;
-					connectionState.guestSfuUrl = response.sfu_url || null;
-					connectionState.guestSfuPort =
-						response.sfu_port == null ? null : String(response.sfu_port);
-
-					const prefetched = connectionDetailsFromJoinPayload(response, {
-						guestAuthToken: response.auth_token,
-						guestId,
-						guestName: resolvedGuestName,
-						expectedMeetingId: meetingId,
-					});
-					await setupSFUConnection(
-						resolvedGuestName,
-						false,
-						false,
-						prefetched,
-					);
-				} else {
-					console.error(
-						"Failed to get connection details after approval:",
-						response,
-					);
-					connectionState.connectionError =
-						"Failed to get authorization token after approval";
+					!currentSession ||
+					currentSession.guestId !== guestSession.guestId ||
+					currentSession.guestSessionToken !== guestSession.guestSessionToken ||
+					currentSession.status === "rejected" ||
+					currentSession.status === "banned" ||
+					currentSession.status === "expired"
+				) return;
+				const admittedSession = {
+					...guestSession,
+					guestName: response.guest_name || guestSession.guestName,
+					status: "admitted" as const,
+				};
+				writeGuestSession(admittedSession);
+				setCurrentGuestIdentity(currentUser, admittedSession);
+				lobbyStore.isWaitingForApproval = false;
+				connectionState.guestId = admittedSession.guestId;
+				connectionState.guestSessionToken = admittedSession.guestSessionToken;
+				connectionState.guestAuthToken = response.auth_token;
+				connectionState.guestSfuUrl = response.sfu_url || null;
+				connectionState.guestSfuPort =
+					response.sfu_port == null ? null : String(response.sfu_port);
+				if (response.host_only_chat !== undefined) {
+					chatStore.hostOnlyChat = response.host_only_chat;
 				}
-			} catch (error) {
-				console.error(
-					"Error fetching connection details after approval:",
-					error,
+				if (response.recording !== undefined) onRecordingState?.(response.recording);
+				if (participantConnectionState.isSetupComplete) return;
+
+				const prefetched = connectionDetailsFromJoinPayload(response, {
+					guestAuthToken: response.auth_token,
+					guestId: admittedSession.guestId,
+					guestName: admittedSession.guestName,
+					expectedMeetingId: meetingId,
+				});
+				await setupSFUConnection(
+					admittedSession.guestName,
+					false,
+					false,
+					prefetched,
 				);
-				connectionState.connectionError = "Failed to connect after approval";
+			} catch (error) {
+				console.error("Error connecting admitted guest:", error);
+				connectionState.connectionError = getErrorMessage(error);
+				toast.error("Could not verify your guest admission. Please try again.");
 			} finally {
 				joiningInProgress.value = false;
+				approvedGuestConnectionPromise = null;
 			}
-		}
+		})();
+		return approvedGuestConnectionPromise;
+	};
 
-		function handleGuestRejected(value: unknown) {
-			const event = normalizeGuestRealtimeEvent(value);
-			if (event?.guestId !== guestId || event.meetingId !== meetingId) {
-				return;
+	const handleGuestStatus = (
+		status: "pending" | "admitted",
+		guestSession: StoredGuestSession,
+	) => {
+		if (status === "admitted") {
+			if (shouldAutoConnectAdmittedGuest(guestSession)) {
+				return connectAdmittedGuest(guestSession);
 			}
-
-			removeGuestApprovalListeners();
-			unsubscribeGuestRealtime();
-
-			lobbyStore.isJoinRequestRejected = true;
-			lobbyStore.isWaitingForApproval = false;
-
-			toast.error("Your join request was denied by the meeting host");
+			const admittedSession = { ...guestSession, status: "admitted" as const };
+			writeGuestSession(admittedSession);
+			setCurrentGuestIdentity(currentUser, admittedSession);
+			connectionState.guestId = admittedSession.guestId;
+			connectionState.guestSessionToken = admittedSession.guestSessionToken;
+			return;
 		}
+		writeGuestSession({ ...guestSession, status: "pending" });
+		setCurrentGuestIdentity(currentUser, guestSession);
+		lobbyStore.isWaitingForApproval = true;
 	};
 
-	const removeGuestApprovalListeners = () => {
-		if (!socket) return;
-
-		socket.off("meet:guest_join_approved");
-		socket.off("meet:guest_join_rejected");
+	const handleTerminalGuestStatus = (
+		status: "rejected" | "banned" | "expired",
+	) => {
+		markGuestSessionStatus(status);
+		const messages = {
+			rejected: "Your join request was denied by the meeting host",
+			banned: "You have been banned from this meeting",
+			expired: "Your guest session has expired",
+		};
+		toast.error(messages[status]);
 	};
 
-	const unsubscribeGuestRealtime = () => {
-		const guestId = sessionStorage.getItem("guest_id");
-		if (socket && guestId) socket.emit("guest_unsubscribe", guestId);
-	};
+	const guestRealtime = createGuestRealtimeLifecycle({
+		socket,
+		meetingId,
+		readSession: () => readGuestSession(meetingId),
+		onActiveStatus: handleGuestStatus,
+		onTerminalStatus: handleTerminalGuestStatus,
+		onError: (error) => {
+			console.error("Guest realtime subscription failed:", error);
+			connectionState.connectionError = error.message;
+			toast.error("Could not verify your guest session. Please reconnect.");
+		},
+	});
+	guestRealtime.start();
 
 	const handleMeetingJoinRequest = (value: unknown) => {
 		const data = normalizeMeetingRealtimeEvent(value);
@@ -963,7 +974,7 @@ export function useSFUConnection(deps: {
 		joinResult: JoinPayload,
 		guestName: string,
 	) => {
-		if (!guestName || !joinResult?.guest_id) {
+		if (!guestName || !joinResult?.guest_id || !joinResult.guest_session_token) {
 			connectionState.connectionError =
 				"Guest session not found. Please try joining again.";
 			return;
@@ -971,14 +982,39 @@ export function useSFUConnection(deps: {
 
 		try {
 			connectionState.connectionError = null;
+			if (
+				joinResult.status === "rejected" ||
+				joinResult.status === "banned" ||
+				joinResult.status === "expired"
+			) {
+				const terminalSession = {
+					guestId: joinResult.guest_id,
+					guestSessionToken: joinResult.guest_session_token,
+					meetingId,
+					guestName: joinResult.guest_name || guestName,
+					status: joinResult.status,
+				};
+				writeGuestSession(terminalSession);
+				setCurrentGuestIdentity(currentUser, terminalSession);
+				handleTerminalGuestStatus(joinResult.status);
+				return;
+			}
 
-			sessionStorage.setItem("guest_id", joinResult.guest_id);
-			sessionStorage.setItem("guest_name", guestName);
-			sessionStorage.setItem("guest_meeting_id", meetingId);
-			sessionStorage.setItem("guest_status", joinResult.status || "joined");
-			socket?.emit("guest_subscribe", joinResult.guest_id);
+			const guestSession = {
+				guestId: joinResult.guest_id,
+				guestSessionToken: joinResult.guest_session_token,
+				meetingId,
+				guestName: joinResult.guest_name || guestName,
+				status:
+					joinResult.status === "waiting_for_approval"
+						? ("pending" as const)
+						: ("admitted" as const),
+			};
+			writeGuestSession(guestSession);
+			setCurrentGuestIdentity(currentUser, guestSession);
 
 			connectionState.guestId = joinResult.guest_id;
+			connectionState.guestSessionToken = joinResult.guest_session_token;
 			connectionState.guestAuthToken =
 				joinResult.auth_token || null;
 			connectionState.guestSfuUrl = joinResult.sfu_url || null;
@@ -990,10 +1026,10 @@ export function useSFUConnection(deps: {
 			}
 
 			if (joinResult.status === "waiting_for_approval") {
+				guestRealtime.start();
 				lobbyStore.isWaitingForApproval = true;
 				connectionState.isInPreview = false;
 				connectionState.guestAuthToken = null;
-				setupGuestApprovalListener(guestName);
 				return;
 			}
 			if (joinResult.recording !== undefined)
@@ -1005,10 +1041,11 @@ export function useSFUConnection(deps: {
 			const prefetched = connectionDetailsFromJoinPayload(joinResult, {
 				guestAuthToken: connectionState.guestAuthToken,
 				guestId: connectionState.guestId,
-				guestName,
+				guestName: guestSession.guestName,
 				expectedMeetingId: meetingId,
 			});
-			await setupSFUConnection(guestName, false, false, prefetched);
+			await setupSFUConnection(guestSession.guestName, false, false, prefetched);
+			guestRealtime.start();
 			setupFrappeRealtimeEventListeners();
 		} catch (error) {
 			console.error("Failed to complete guest join:", error);
@@ -1070,8 +1107,7 @@ export function useSFUConnection(deps: {
 
 	const endCall = async () => {
 		try {
-			removeGuestApprovalListeners();
-			unsubscribeGuestRealtime();
+			guestRealtime.stop();
 
 			if (activeSpeakerTimeout.value) {
 				clearTimeout(activeSpeakerTimeout.value);
@@ -1085,6 +1121,10 @@ export function useSFUConnection(deps: {
 			}
 
 			sfuManager.value = null;
+			if (
+				!preserveGuestSessionOnEnd &&
+				readGuestSession(meetingId)?.status !== "banned"
+			) clearGuestSession();
 
 			router.push({ name: "meet-home" });
 		} catch (error) {
@@ -1105,8 +1145,7 @@ export function useSFUConnection(deps: {
 			stabilityCheckTimeout = null;
 		}
 
-		removeGuestApprovalListeners();
-		unsubscribeGuestRealtime();
+		guestRealtime.stop();
 		removeFrappeRealtimeEventListeners();
 
 		try {

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -517,7 +517,9 @@ function getE2EEJoinPendingMessage(detail: {
 const isGuestSession = computed(
 	() =>
 		!session.isLoggedIn &&
-		(!!connectionState.guestAuthToken || lobbyStore.isWaitingForApproval),
+		(!!connectionState.guestAuthToken ||
+			lobbyStore.isWaitingForApproval ||
+			currentUser.currentUser.value?.is_guest === true),
 );
 
 // --- SFU Connection ---
@@ -771,10 +773,6 @@ const showPreview = computed(() => {
 	const isUnauthenticatedGuest = !session.isLoggedIn && !isGuestSession.value;
 	if (isUnauthenticatedGuest) {
 		return true;
-	}
-
-	if (isGuestSession.value) {
-		return false;
 	}
 	if (lobbyStore.isInLobby) {
 		return false;

--- a/frontend/src/apps/meet/types.ts
+++ b/frontend/src/apps/meet/types.ts
@@ -69,11 +69,12 @@ export interface JoinUserData {
 }
 
 export interface JoinPayload {
-	status?: string;
+	status?: JoinStatus;
 	lobby_token?: string;
 	auth_token?: string;
 	guest_id?: string;
 	guest_name?: string;
+	guest_session_token?: string;
 	meeting_id?: string;
 	user_id?: string;
 	sfu_url?: string;
@@ -112,12 +113,20 @@ export interface DeviceChangedEvent {
 	type: "camera" | "microphone" | "speaker";
 	deviceId: string;
 }
-
 export function isUnknownRecord(
 	value: unknown,
 ): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
+
+export type JoinStatus =
+	| "waiting_for_approval"
+	| "pending"
+	| "joined"
+	| "admitted"
+	| "rejected"
+	| "banned"
+	| "expired";
 
 function optionalString(value: unknown): string | undefined {
 	return typeof value === "string" ? value : undefined;
@@ -125,6 +134,21 @@ function optionalString(value: unknown): string | undefined {
 
 function optionalBoolean(value: unknown): boolean | undefined {
 	return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalJoinStatus(value: unknown): JoinPayload["status"] {
+	return typeof value === "string" &&
+		[
+			"waiting_for_approval",
+			"pending",
+			"joined",
+			"admitted",
+			"rejected",
+			"banned",
+			"expired",
+		].includes(value)
+		? (value as JoinPayload["status"])
+		: undefined;
 }
 
 function normalizeJoinUserData(value: unknown): JoinUserData | undefined {
@@ -181,11 +205,12 @@ export function normalizeJoinPayload(value: unknown): JoinPayload | null {
 			? value.sfu_port
 			: undefined;
 	return {
-		status: optionalString(value.status),
+		status: optionalJoinStatus(value.status),
 		lobby_token: optionalString(value.lobby_token),
 		auth_token: optionalString(value.auth_token),
 		guest_id: optionalString(value.guest_id),
 		guest_name: optionalString(value.guest_name),
+		guest_session_token: optionalString(value.guest_session_token),
 		meeting_id: optionalString(value.meeting_id),
 		user_id: optionalString(value.user_id),
 		sfu_url: optionalString(value.sfu_url),

--- a/frontend/src/apps/meet/utils/SFUClient.ts
+++ b/frontend/src/apps/meet/utils/SFUClient.ts
@@ -88,14 +88,11 @@ export function connectionDetailsFromJoinPayload(
 	const expiresInSeconds =
 		typeof payload.expires_in === "number" && payload.expires_in > 0
 			? payload.expires_in
-			: 3600;
+			: isGuestPayload(payload, options)
+				? 300
+				: 3600;
 
-	const isGuest = Boolean(
-		options.guestId ||
-			options.guestAuthToken ||
-			payload.guest_id ||
-			payload.user_data?.is_guest,
-	);
+	const isGuest = isGuestPayload(payload, options);
 
 	if (options.guestId) {
 		const payloadGuestId =
@@ -134,6 +131,9 @@ export function connectionDetailsFromJoinPayload(
 	};
 }
 
+function isGuestPayload(payload: JoinPayload, options: { guestAuthToken?: string | null; guestId?: string | null }): boolean {
+	return Boolean(options.guestId || options.guestAuthToken || payload.guest_id || payload.user_data?.is_guest);
+}
 interface ConnectionStatus {
 	connected: boolean;
 	meetingId: string | null;
@@ -255,6 +255,16 @@ function requireString(value: unknown, field: string, context: string): string {
 function requireObject(value: unknown, context: string): Record<string, unknown> {
 	if (!isUnknownRecord(value)) throw new Error(`Invalid ${context} response`);
 	return value;
+}
+
+function tokenLifetimeSeconds(response: JoinPayload, isGuest: boolean): number {
+	return typeof response.expires_in === "number" &&
+		Number.isFinite(response.expires_in) &&
+		response.expires_in > 0
+		? response.expires_in
+		: isGuest
+			? 300
+			: 3600;
 }
 
 function normalizeExistingProducer(value: unknown): SFUExistingProducer | null {
@@ -439,19 +449,26 @@ export class SFUClient {
 			const guestId = sessionStorage.getItem("guest_id");
 			const guestName = sessionStorage.getItem("guest_name");
 			const guestMeetingId = sessionStorage.getItem("guest_meeting_id");
+			const guestSessionToken = sessionStorage.getItem("guest_session_token");
 
-			if (!guestId || guestMeetingId !== meetingId) {
+			if (!guestId || !guestSessionToken || guestMeetingId !== meetingId) {
 				throw new Error("Guest session incomplete or invalid for this meeting");
 			}
 
 			try {
 				const response = requireJoinPayload(await frappeRequest({
-					url: "suite.meet.api.meeting.get_guest_sfu_connection_details",
+					url: "suite.meet.api.meeting.refresh_guest_sfu_token",
 					params: {
 						meeting_id: meetingId,
-						guest_token: guestAuthToken,
+						guest_id: guestId,
+						guest_session_token: guestSessionToken,
 					},
 				}), "guest SFU connection details");
+				const authToken = requireString(
+					response.auth_token,
+					"auth_token",
+					"guest SFU connection details",
+				);
 				const sfuUrl = requireString(
 					response.sfu_url,
 					"sfu_url",
@@ -459,7 +476,7 @@ export class SFUClient {
 				);
 
 				return {
-					authToken: guestAuthToken,
+					authToken,
 					meetingId: meetingId,
 					userId: guestId,
 					sfuUrl,
@@ -468,7 +485,7 @@ export class SFUClient {
 						name: guestName ?? undefined,
 						is_guest: true,
 					},
-					tokenExpiresAt: Date.now() + 24 * 60 * 60 * 1000,
+					tokenExpiresAt: Date.now() + tokenLifetimeSeconds(response, true) * 1000,
 					codecStrategy: response.codec_strategy || "svc",
 					e2eeRequired: Boolean(response.e2ee_required),
 					isHost: Boolean(response.is_host),
@@ -578,8 +595,7 @@ export class SFUClient {
 		}
 	}
 
-	scheduleTokenRefresh(bufferMs = 5 * 60 * 1000): void {
-		// 5 minutes before expiry
+	scheduleTokenRefresh(bufferMs = 60 * 1000): void {
 		this.clearTokenRefreshTimer();
 
 		const { tokenExpiresAt, meetingId } = this.connectionDetails;
@@ -589,6 +605,7 @@ export class SFUClient {
 		}
 
 		const delay = tokenExpiresAt - Date.now() - bufferMs;
+		if (tokenExpiresAt <= Date.now()) return;
 
 		if (delay <= 0) {
 			this.refreshToken().catch((error: unknown) => {
@@ -602,8 +619,23 @@ export class SFUClient {
 				await this.refreshToken();
 			} catch (error: unknown) {
 				console.error("Scheduled token refresh failed:", error);
+				this.scheduleTokenRefreshRetry();
 			}
 		}, delay);
+	}
+
+	private scheduleTokenRefreshRetry(): void {
+		const expiresAt = this.connectionDetails.tokenExpiresAt;
+		if (!expiresAt) return;
+		const remaining = expiresAt - Date.now();
+		if (remaining <= 1000) return;
+		this.clearTokenRefreshTimer();
+		this.tokenRefreshTimer = setTimeout(() => {
+			this.refreshToken().catch((error: unknown) => {
+				console.error("Token refresh retry failed:", error);
+				this.scheduleTokenRefreshRetry();
+			});
+		}, Math.min(10_000, remaining - 1000));
 	}
 
 	async refreshToken(
@@ -627,10 +659,23 @@ export class SFUClient {
 			const refreshGeneration = this.tokenRefreshGeneration;
 			refreshPromise = (async () => {
 				try {
+					const guestSessionToken = sessionStorage.getItem("guest_session_token");
+					const isGuest = this.connectionDetails.userData?.is_guest === true;
+					if (isGuest && !guestSessionToken) {
+						throw new Error("Guest session proof required for token refresh");
+					}
 					const response = requireJoinPayload(
 						await frappeRequest({
-							url: "suite.meet.api.meeting.refresh_sfu_token",
-							params: { meeting_id: this.connectionDetails.meetingId },
+							url: isGuest
+								? "suite.meet.api.meeting.refresh_guest_sfu_token"
+								: "suite.meet.api.meeting.refresh_sfu_token",
+							params: isGuest
+								? {
+										meeting_id: this.connectionDetails.meetingId,
+										guest_id: this.connectionDetails.userId,
+										guest_session_token: guestSessionToken,
+									}
+								: { meeting_id: this.connectionDetails.meetingId },
 						}),
 						"SFU token refresh",
 					);
@@ -643,8 +688,7 @@ export class SFUClient {
 						throw new Error("Token refresh superseded by disconnect");
 					}
 
-					const expiresInSeconds =
-						typeof response.expires_in === "number" ? response.expires_in : 3600;
+					const expiresInSeconds = tokenLifetimeSeconds(response, isGuest);
 
 					this.connectionDetails.authToken = authToken;
 					this.connectionDetails.tokenExpiresAt =
@@ -688,27 +732,31 @@ export class SFUClient {
 	}
 
 	isTokenExpiringSoon(): boolean {
-		const { tokenExpiresAt, authToken } = this.connectionDetails;
+		const expiryTime = this.getTokenExpiryTime();
+		if (expiryTime === null) return false;
+		const timeUntilExpiry = expiryTime - Date.now();
+		return timeUntilExpiry > 0 && timeUntilExpiry <= 60 * 1000;
+	}
 
-		if (tokenExpiresAt) {
-			return tokenExpiresAt - Date.now() < 5 * 60 * 1000; // 5 minutes
+	isTokenExpired(): boolean {
+		const expiryTime = this.getTokenExpiryTime();
+		return expiryTime !== null && expiryTime <= Date.now();
+	}
+
+	private getTokenExpiryTime(): number | null {
+		if (this.connectionDetails.tokenExpiresAt !== null) {
+			return this.connectionDetails.tokenExpiresAt;
 		}
-
-		if (!authToken) {
-			return false;
-		}
-
+		const authToken = this.connectionDetails.authToken;
+		if (!authToken) return null;
 		try {
-			const payload = JSON.parse(atob(authToken.split(".")[1])) as {
-				exp: number;
-			};
-			const expiryTime = payload.exp * 1000;
-			const timeUntilExpiry = expiryTime - Date.now();
-
-			return timeUntilExpiry < 5 * 60 * 1000;
+			const payload: unknown = JSON.parse(atob(authToken.split(".")[1]));
+			return isUnknownRecord(payload) && typeof payload.exp === "number"
+				? payload.exp * 1000
+				: null;
 		} catch (error: unknown) {
 			console.warn("Could not check token expiry:", error);
-			return false;
+			return null;
 		}
 	}
 
@@ -734,7 +782,7 @@ export class SFUClient {
 				console.error("SFU reconnection failed:", error);
 			},
 			reconnect_attempt: async () => {
-				if (this.isTokenExpiringSoon()) {
+				if (this.isTokenExpiringSoon() || this.isTokenExpired()) {
 					try {
 						const newToken = await this.refreshToken({
 							skipServerUpdate: true,
@@ -749,6 +797,13 @@ export class SFUClient {
 							error,
 						);
 					}
+				}
+			},
+			"auth:expired": async () => {
+				try {
+					await this.refreshToken({ forceNewRequest: true });
+				} catch (error: unknown) {
+					console.error("Failed to recover expired SFU authorization:", error);
 				}
 			},
 			participant_joined: () => {},

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -692,10 +692,17 @@ export class SFUMeetingManager implements MediaAttachmentFacade {
 	}
 
 	sendHostControl(
-		action: "mute_participant" | "kick_participant" | "lower_hand",
+		action:
+			| "mute_participant"
+			| "kick_participant"
+			| "ban_participant"
+			| "lower_hand",
 		targetParticipantId: string,
-	): void {
-		this.sfuClient.sendEvent("host_control", { action, targetParticipantId });
+	): Promise<unknown> {
+		return this.sfuClient.sendRequest("host_control", {
+			action,
+			targetParticipantId,
+		});
 	}
 
 	getRemoteAudioTrack(participantId: string): MediaStreamTrack | null {

--- a/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUClient.test.ts
@@ -26,6 +26,7 @@ import { frappeRequest } from "frappe-ui";
 beforeEach(() => {
 	vi.clearAllMocks();
 	vi.useFakeTimers();
+	sessionStorage.clear();
 });
 
 afterEach(() => {
@@ -128,7 +129,7 @@ describe("isTokenExpiringSoon", () => {
 		expect(client.isTokenExpiringSoon()).toBe(false);
 	});
 
-	it("returns true when tokenExpiresAt is within 5 minutes", () => {
+	it("returns true when tokenExpiresAt is within the one-minute refresh buffer", () => {
 		const client = createClient();
 		client.connectionDetails.tokenExpiresAt = Date.now() + 60_000;
 		expect(client.isTokenExpiringSoon()).toBe(true);
@@ -137,7 +138,8 @@ describe("isTokenExpiringSoon", () => {
 	it("returns false when tokenExpiresAt is past", () => {
 		const client = createClient();
 		client.connectionDetails.tokenExpiresAt = Date.now() - 60_000;
-		expect(client.isTokenExpiringSoon()).toBe(true);
+		expect(client.isTokenExpiringSoon()).toBe(false);
+		expect(client.isTokenExpired()).toBe(true);
 	});
 
 	it("parses JWT exp claim when tokenExpiresAt is null", () => {
@@ -149,10 +151,10 @@ describe("isTokenExpiringSoon", () => {
 		expect(client.isTokenExpiringSoon()).toBe(false);
 	});
 
-	it("returns true for JWT expiring within 5 min", () => {
+	it("returns true for JWT expiring within the one-minute refresh buffer", () => {
 		const client = createClient();
 		client.connectionDetails.tokenExpiresAt = null;
-		const soon = Math.floor(Date.now() / 1000) + 120;
+		const soon = Math.floor(Date.now() / 1000) + 30;
 		const payload = btoa(JSON.stringify({ exp: soon }));
 		client.connectionDetails.authToken = `header.${payload}.sig`;
 		expect(client.isTokenExpiringSoon()).toBe(true);
@@ -489,6 +491,28 @@ describe("scheduleTokenRefresh", () => {
 		expect(frappeRequest).toHaveBeenCalled();
 	});
 
+	it("does not refresh an already-expired token", () => {
+		const client = createClient();
+		client.connectionDetails.tokenExpiresAt = Date.now() - 1;
+		client.connectionDetails.meetingId = "meet-1";
+
+		client.scheduleTokenRefresh();
+
+		expect(frappeRequest).not.toHaveBeenCalled();
+		expect(client.tokenRefreshTimer).toBeNull();
+	});
+
+	it("schedules a five-minute guest token one minute before expiry", () => {
+		const client = createClient();
+		client.connectionDetails.tokenExpiresAt = Date.now() + 300_000;
+		client.connectionDetails.meetingId = "meet-1";
+		client.scheduleTokenRefresh();
+
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(239_999);
+		expect(frappeRequest).not.toHaveBeenCalled();
+	});
+
 	it("clears existing timer before scheduling", () => {
 		const client = createClient();
 		client.connectionDetails.tokenExpiresAt = Date.now() + 600_000;
@@ -615,8 +639,11 @@ describe("getConnectionDetails", () => {
 		sessionStorage.setItem("guest_id", "guest-1");
 		sessionStorage.setItem("guest_name", "Guest Alice");
 		sessionStorage.setItem("guest_meeting_id", "meet-2");
+		sessionStorage.setItem("guest_session_token", "private-proof");
 
 		vi.mocked(frappeRequest).mockResolvedValue({
+			auth_token: "fresh-guest-token",
+			expires_in: 300,
 			sfu_url: "https://sfu.example.com",
 			sfu_port: "443",
 			codec_strategy: "svc",
@@ -624,10 +651,18 @@ describe("getConnectionDetails", () => {
 		});
 		const client = createClient();
 		const details = await client.getConnectionDetails("meet-2", "guest-token");
-		expect(details.authToken).toBe("guest-token");
+		expect(details.authToken).toBe("fresh-guest-token");
 		expect(details.userId).toBe("guest-1");
 		expect(details.userData?.is_guest).toBe(true);
 		expect(details.e2eeRequired).toBe(true);
+		expect(frappeRequest).toHaveBeenCalledWith({
+			url: "suite.meet.api.meeting.refresh_guest_sfu_token",
+			params: {
+				meeting_id: "meet-2",
+				guest_id: "guest-1",
+				guest_session_token: "private-proof",
+			},
+		});
 	});
 });
 
@@ -676,6 +711,7 @@ describe("connect refresh", () => {
 		sessionStorage.setItem("guest_id", "guest-2");
 		sessionStorage.setItem("guest_name", "Guest Bob");
 		sessionStorage.setItem("guest_meeting_id", "meet-2");
+		sessionStorage.setItem("guest_session_token", "private-proof-2");
 
 		const client = createClient();
 		client.connected = true;
@@ -693,6 +729,8 @@ describe("connect refresh", () => {
 		};
 
 		vi.mocked(frappeRequest).mockResolvedValue({
+			auth_token: "fresh-guest-token-2",
+			expires_in: 300,
 			sfu_url: "https://sfu.example.com",
 			sfu_port: "443",
 			codec_strategy: "svc",
@@ -925,6 +963,42 @@ describe("E2EE signaling payloads", () => {
 		expect(client.connectionDetails.e2eeRequired).toBe(true);
 	});
 
+	it("refreshes guests only with their private session proof", async () => {
+		sessionStorage.setItem("guest_session_token", "private-proof");
+		vi.mocked(frappeRequest).mockResolvedValue({
+			auth_token: "guest-token-2",
+			expires_in: 300,
+		});
+		const client = createClient();
+		client.connectionDetails.meetingId = "meet-2";
+		client.connectionDetails.userId = "guest-2";
+		client.connectionDetails.userData = { is_guest: true };
+
+		await client.refreshToken();
+
+		expect(frappeRequest).toHaveBeenCalledWith({
+			url: "suite.meet.api.meeting.refresh_guest_sfu_token",
+			params: {
+				meeting_id: "meet-2",
+				guest_id: "guest-2",
+				guest_session_token: "private-proof",
+			},
+		});
+		expect(client.connectionDetails.tokenExpiresAt).toBe(Date.now() + 300_000);
+	});
+
+	it("fails guest refresh closed without proof", async () => {
+		const client = createClient();
+		client.connectionDetails.meetingId = "meet-2";
+		client.connectionDetails.userId = "guest-2";
+		client.connectionDetails.userData = { is_guest: true };
+
+		await expect(client.refreshToken()).rejects.toThrow(
+			"Guest session proof required",
+		);
+		expect(frappeRequest).not.toHaveBeenCalled();
+	});
+
 	it("does not downgrade local e2ee requirement during token refresh", async () => {
 		vi.mocked(frappeRequest).mockResolvedValue({
 			auth_token: "tok-2",
@@ -1044,6 +1118,7 @@ describe("setupDefaultHandlers", () => {
 			"reconnect",
 			"reconnect_error",
 			"reconnect_attempt",
+			"auth:expired",
 			"participant_joined",
 			"participant_left",
 			"producer_created",
@@ -1081,6 +1156,45 @@ describe("setupDefaultHandlers", () => {
 		const handler = client.eventHandlers.get("disconnect");
 		handler();
 		expect(client.connected).toBe(false);
+	});
+
+	it("recovers auth:expired through token refresh and server token update", async () => {
+		vi.mocked(frappeRequest).mockResolvedValue({
+			auth_token: "fresh-token",
+			expires_in: 3600,
+		});
+		const client = createClient();
+		client.connected = true;
+		client.connectionDetails.meetingId = "meet-1";
+		const sendRequest = vi
+			.spyOn(client, "sendRequest")
+			.mockResolvedValue({ success: true });
+
+		client.eventHandlers.get("auth:expired")?.();
+
+		await vi.waitFor(() =>
+			expect(sendRequest).toHaveBeenCalledWith("auth:update_token", {
+				token: "fresh-token",
+			}),
+		);
+	});
+
+	it("refreshes an already-expired token before a reconnect attempt", async () => {
+		vi.mocked(frappeRequest).mockResolvedValue({
+			auth_token: "reconnect-token",
+			expires_in: 3600,
+		});
+		const client = createClient();
+		client.connectionDetails.meetingId = "meet-1";
+		client.connectionDetails.tokenExpiresAt = Date.now() - 1;
+
+		client.eventHandlers.get("reconnect_attempt")?.();
+
+		await vi.waitFor(() =>
+			expect(client.signalChannel.updateAuth).toHaveBeenCalledWith(
+				"reconnect-token",
+			),
+		);
 	});
 });
 

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -678,13 +678,13 @@ describe("SFUMeetingManager facade operations", () => {
 		expect(sample).not.toHaveProperty("consumers");
 	});
 
-	it("routes host control through the client", () => {
-		const sendEvent = vi.fn();
-		const manager = createManager({ sendEvent } as never);
+	it("routes host control through an acknowledged client request", async () => {
+		const sendRequest = vi.fn().mockResolvedValue({ success: true });
+		const manager = createManager({ sendRequest } as never);
 
-		manager.sendHostControl("mute_participant", "participant-1");
+		await manager.sendHostControl("mute_participant", "participant-1");
 
-		expect(sendEvent).toHaveBeenCalledWith("host_control", {
+		expect(sendRequest).toHaveBeenCalledWith("host_control", {
 			action: "mute_participant",
 			targetParticipantId: "participant-1",
 		});

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -131,7 +131,7 @@ export interface SFUEventHandlers {
 	onActiveSpeakerChanged?: (participantIds: string[]) => void;
 	onNetworkQualityUpdated?: (participantId: string, quality: string) => void;
 	onHostMutedYou?: () => void;
-	onHostKickedYou?: (data: { hostId?: string }) => void;
+	onHostKickedYou?: (data: { hostId?: string; banned?: boolean }) => void;
 	onParticipantConnectionReplaced?: (data: { reason: "takeover" }) => void | Promise<void>;
 	onRecoveryStateChange?: (
 		state:
@@ -203,6 +203,10 @@ export class ParticipantConnection {
 	isConnected = false;
 	initialSyncInProgress = false;
 	private bufferedReconciliationEvents: ReconciliationEvent[] = [];
+	private bufferedMediaStateUpdates = new Map<
+		string,
+		{ audioEnabled?: boolean; videoEnabled?: boolean }
+	>();
 	private reconciliation: MeetingReconciliationState<ReconciledParticipant> =
 		createMeetingReconciliationState();
 	private producerClaims = new Set<string>();
@@ -623,6 +627,7 @@ export class ParticipantConnection {
 			]);
 
 			this.initialSyncInProgress = false;
+			this.flushBufferedMediaStateUpdates();
 			await this.flushBufferedProducers(signal);
 		} catch (error) {
 			if (!signal.aborted) {
@@ -659,6 +664,7 @@ export class ParticipantConnection {
 				}
 			}
 			this.initialSyncInProgress = false;
+			this.flushBufferedMediaStateUpdates();
 
 			if (existingProducers.length) {
 				console.log(
@@ -697,6 +703,14 @@ export class ParticipantConnection {
 			} catch (error) {
 				if (signal.aborted) throw error;
 				console.warn("Failed to process buffered producer:", error);
+			}
+		}
+	}
+
+	private flushBufferedMediaStateUpdates(): void {
+		for (const [participantId, updates] of this.bufferedMediaStateUpdates) {
+			if (this.participantManager.updateMediaState(participantId, updates)) {
+				this.bufferedMediaStateUpdates.delete(participantId);
 			}
 		}
 	}
@@ -1378,6 +1392,7 @@ export class ParticipantConnection {
 				this.reconciliation = applyMeetingReconciliationEvent(previous, event);
 				if (!previous.participants.has(data.participantId)) {
 					this.participantManager.addParticipant(data);
+					this.flushBufferedMediaStateUpdates();
 				}
 			}
 		});
@@ -1531,7 +1546,16 @@ export class ParticipantConnection {
 			}
 
 			if (Object.keys(updates).length) {
-				this.participantManager.updateMediaState(d.participantId, updates);
+				if (this.initialSyncInProgress) {
+					this.bufferedMediaStateUpdates.set(d.participantId, {
+						...this.bufferedMediaStateUpdates.get(d.participantId),
+						...updates,
+					});
+					return;
+				}
+				if (!this.participantManager.updateMediaState(d.participantId, updates)) {
+					this.bufferedMediaStateUpdates.set(d.participantId, updates);
+				}
 			}
 		});
 
@@ -1577,8 +1601,12 @@ export class ParticipantConnection {
 					}
 					break;
 				case "kick_participant":
+				case "ban_participant":
 					if (isForMe) {
-						this.eventHandlers.onHostKickedYou?.({ hostId: d.hostId });
+						this.eventHandlers.onHostKickedYou?.({
+							hostId: d.hostId,
+							banned: d.action === "ban_participant",
+						});
 					}
 					break;
 				default:
@@ -1650,6 +1678,7 @@ export class ParticipantConnection {
 	async disconnect(): Promise<void> {
 		this.setState("stopping");
 		this.initialSyncInProgress = false;
+		this.bufferedMediaStateUpdates.clear();
 		this.lifecycleAbortController.abort(
 			new DOMException("Participant connection stopped", "AbortError"),
 		);
@@ -1696,6 +1725,7 @@ export class ParticipantConnection {
 		this.isConnected = false;
 		this.initialSyncInProgress = false;
 		this.bufferedReconciliationEvents = [];
+		this.bufferedMediaStateUpdates.clear();
 		this.reconciliation = createMeetingReconciliationState();
 		this.producerClaims.clear();
 		this.lastJoinUserData = null;

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -438,6 +438,45 @@ describe("ParticipantConnection", () => {
 		expect(mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
 	});
 
+	it("replays live camera state over the initial participant snapshot", async () => {
+		const { handlers, manager, participantManager, sfuClient } = createManager();
+		await manager.connect("token");
+		sfuClient.getRoomParticipants.mockImplementationOnce(async () => {
+			handlers.get("media_control_update")?.({
+				participantId: "remote-1",
+				action: "video_on",
+			});
+			return [
+				{
+					participantId: "remote-1",
+					user_id: "remote-1",
+					userData: { video_enabled: false },
+				},
+			];
+		});
+
+		await manager.setupExistingParticipants();
+
+		expect(participantManager.getParticipant("remote-1")?.video_enabled).toBe(true);
+	});
+
+	it("applies camera state received before a participant joins", async () => {
+		const { handlers, manager, participantManager } = createManager();
+		await manager.connect("token");
+
+		handlers.get("media_control_update")?.({
+			participantId: "remote-1",
+			action: "video_on",
+		});
+		handlers.get("participant_joined")?.({
+			participantId: "remote-1",
+			user_id: "remote-1",
+			userData: { video_enabled: false },
+		});
+
+		expect(participantManager.getParticipant("remote-1")?.video_enabled).toBe(true);
+	});
+
 	it("reattaches a surviving endpoint consumer when one producer closes", async () => {
 		const { handlers, manager, mediaManager } = createManager();
 		await manager.connect("token");

--- a/realtime/handlers.js
+++ b/realtime/handlers.js
@@ -4,36 +4,93 @@ const suite_handlers = (socket) => {
 	});
 
 	// guest specific rooms
-	socket.on("guest_subscribe", async (guest_id) => {
-		if (!guest_id || typeof guest_id !== "string") {
-			return;
+	socket.on("guest_subscribe", async (payload, untrustedAcknowledge) => {
+		const acknowledge = safe_acknowledge(untrustedAcknowledge);
+		try {
+			const validation = await validate_guest(socket, payload);
+			if (!validation.ok) {
+				acknowledge(validation);
+				return;
+			}
+			await socket.join(guest_room(payload.guest_id));
+			const currentValidation = await validate_guest(socket, payload);
+			if (!currentValidation.ok) {
+				await socket.leave(guest_room(payload.guest_id));
+				acknowledge(currentValidation);
+				return;
+			}
+			acknowledge(currentValidation);
+		} catch {
+			acknowledge({ ok: false, error: "validation_failed" });
 		}
+	});
 
-		if (!guest_id.startsWith("guest_") || guest_id.length < 10) {
-			return;
-		}
-
-		// session validation for guest
-		socket
-			.frappe_request("/api/method/suite.meet.api.meeting.validate_guest_session", {
-				guest_id: guest_id,
-			})
-			.then((res) => res.json())
-			.then(({ message }) => {
-				if (!message?.valid) {
-					return;
-				}
-				const room = guest_room(guest_id);
-				socket.join(room);
+	socket.on("guest_unsubscribe", async (payload, untrustedAcknowledge) => {
+		const acknowledge = safe_acknowledge(untrustedAcknowledge);
+		try {
+			const validation = await validate_guest(socket, payload);
+			if (!validation.ok && !validation.status) {
+				acknowledge(validation);
+				return;
+			}
+			await socket.leave(guest_room(payload.guest_id));
+			acknowledge({
+				ok: true,
+				...(validation.status && { status: validation.status }),
 			});
+		} catch {
+			acknowledge({ ok: false, error: "validation_failed" });
+		}
 	});
+};
 
-	socket.on("guest_unsubscribe", (guest_id) => {
-		if (!guest_id) return;
+const GUEST_STATUSES = new Set([
+	"pending",
+	"admitted",
+	"expired",
+	"rejected",
+	"banned",
+]);
 
-		const room = guest_room(guest_id);
-		socket.leave(room);
-	});
+const safe_acknowledge = (acknowledge) => (value) => {
+	if (typeof acknowledge !== "function") return;
+	try {
+		Promise.resolve(acknowledge(value)).catch(() => {});
+	} catch {}
+};
+
+const validate_guest = async (socket, payload) => {
+	if (
+		!payload ||
+		typeof payload !== "object" ||
+		typeof payload.guest_id !== "string" ||
+		!payload.guest_id.startsWith("guest_") ||
+		payload.guest_id.length < 10 ||
+		typeof payload.meeting_id !== "string" ||
+		!payload.meeting_id ||
+		typeof payload.guest_session_token !== "string" ||
+		!payload.guest_session_token
+	) {
+		return { ok: false, error: "invalid_request" };
+	}
+
+	try {
+		const body = new URLSearchParams(payload);
+		const response = await socket.frappe_request(
+			"/api/method/suite.meet.api.meeting.validate_guest_session",
+			{},
+			{ method: "POST", body },
+		);
+		const data = await response.json();
+		const status = GUEST_STATUSES.has(data?.message?.status)
+			? data.message.status
+			: undefined;
+		return data?.message?.valid === true
+			? { ok: true, ...(status && { status }) }
+			: { ok: false, error: "unauthorized", ...(status && { status }) };
+	} catch {
+		return { ok: false, error: "validation_failed" };
+	}
 };
 
 const guest_room = (guest_id) => `guest:${guest_id}`;

--- a/realtime/handlers.test.js
+++ b/realtime/handlers.test.js
@@ -3,41 +3,263 @@ const { test } = require("node:test");
 
 const registerHandlers = require("./handlers");
 
-function createSocket(validationResponse) {
+function createSocket(options = {}) {
 	const handlers = new Map();
 	const joinedRooms = [];
+	const leftRooms = [];
+	const requests = [];
+	let responseIndex = 0;
 	const socket = {
 		emit() {},
-		frappe_request: async () => ({
-			json: async () => validationResponse,
-		}),
+		frappe_request: async (url, params, requestOptions) => {
+			requests.push({ url, params, requestOptions });
+			if (options.requestError) throw options.requestError;
+			return {
+				json: async () => {
+					if (options.jsonError) throw options.jsonError;
+					return (
+						options.responses?.[responseIndex++] ??
+						options.response ?? { message: { valid: true, status: "pending" } }
+					);
+				},
+			};
+		},
 		join(room) {
+			if (options.joinError) throw options.joinError;
 			joinedRooms.push(room);
 		},
-		leave() {},
+		leave(room) {
+			if (options.leaveError) throw options.leaveError;
+			leftRooms.push(room);
+		},
 		on(event, handler) {
 			handlers.set(event, handler);
 		},
 	};
 
 	registerHandlers(socket);
-	return { handlers, joinedRooms };
+	return { handlers, joinedRooms, leftRooms, requests };
 }
 
-test("guest_subscribe ignores responses without validation data", async () => {
-	const { handlers, joinedRooms } = createSocket({});
+const subscription = {
+	guest_id: "guest_12345",
+	meeting_id: "room-1",
+	guest_session_token: "private-proof",
+};
 
-	await handlers.get("guest_subscribe")("guest_12345");
-	await new Promise(setImmediate);
+test("guest_subscribe validates structured proof before joining", async () => {
+	const fixture = createSocket();
+	let acknowledgement;
 
-	assert.deepEqual(joinedRooms, []);
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(fixture.joinedRooms, ["guest:guest_12345"]);
+	assert.equal(
+		fixture.requests[0].url,
+		"/api/method/suite.meet.api.meeting.validate_guest_session",
+	);
+	assert.equal(fixture.requests[0].url.includes("private-proof"), false);
+	assert.deepEqual(fixture.requests[0].params, {});
+	assert.equal(fixture.requests[0].requestOptions.method, "POST");
+	assert.equal(
+		fixture.requests[0].requestOptions.body.toString(),
+		new URLSearchParams(subscription).toString(),
+	);
+	assert.deepEqual(acknowledgement, { ok: true, status: "pending" });
 });
 
-test("guest_subscribe joins the validated guest room", async () => {
-	const { handlers, joinedRooms } = createSocket({ message: { valid: true } });
+test("guest_subscribe rejects missing proof", async () => {
+	const fixture = createSocket();
+	let acknowledgement;
 
-	await handlers.get("guest_subscribe")("guest_12345");
-	await new Promise(setImmediate);
+	await fixture.handlers.get("guest_subscribe")(
+		{ guest_id: "guest_12345", meeting_id: "room-1" },
+		(value) => {
+			acknowledgement = value;
+		},
+	);
 
-	assert.deepEqual(joinedRooms, ["guest:guest_12345"]);
+	assert.deepEqual(fixture.joinedRooms, []);
+	assert.deepEqual(fixture.requests, []);
+	assert.deepEqual(acknowledgement, { ok: false, error: "invalid_request" });
+});
+
+test("guest_subscribe rejects wrong-room or invalid proof response", async () => {
+	const fixture = createSocket({ response: { message: { valid: false } } });
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(fixture.joinedRooms, []);
+	assert.deepEqual(acknowledgement, { ok: false, error: "unauthorized" });
+});
+
+test("guest_subscribe propagates proof-bound terminal status without joining", async () => {
+	const fixture = createSocket({
+		response: { message: { valid: false, status: "rejected" } },
+	});
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(fixture.joinedRooms, []);
+	assert.deepEqual(acknowledgement, {
+		ok: false,
+		error: "unauthorized",
+		status: "rejected",
+	});
+});
+
+test("guest_subscribe acknowledges admission that races with room join", async () => {
+	const fixture = createSocket({
+		responses: [
+			{ message: { valid: true, status: "pending" } },
+			{ message: { valid: true, status: "admitted" } },
+		],
+	});
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.equal(fixture.requests.length, 2);
+	assert.deepEqual(fixture.joinedRooms, ["guest:guest_12345"]);
+	assert.deepEqual(fixture.leftRooms, []);
+	assert.deepEqual(acknowledgement, { ok: true, status: "admitted" });
+});
+
+test("guest_subscribe leaves and acknowledges rejection that races with room join", async () => {
+	const fixture = createSocket({
+		responses: [
+			{ message: { valid: true, status: "pending" } },
+			{ message: { valid: false, status: "rejected" } },
+		],
+	});
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.equal(fixture.requests.length, 2);
+	assert.deepEqual(fixture.joinedRooms, ["guest:guest_12345"]);
+	assert.deepEqual(fixture.leftRooms, ["guest:guest_12345"]);
+	assert.deepEqual(acknowledgement, {
+		ok: false,
+		error: "unauthorized",
+		status: "rejected",
+	});
+});
+
+test("guest_subscribe acknowledges malformed validation responses", async () => {
+	const fixture = createSocket({ response: {} });
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(fixture.joinedRooms, []);
+	assert.deepEqual(acknowledgement, { ok: false, error: "unauthorized" });
+});
+
+test("guest_subscribe catches request and JSON errors", async () => {
+	for (const options of [
+		{ requestError: new Error("offline") },
+		{ jsonError: new Error("bad json") },
+		{ joinError: new Error("join failed") },
+	]) {
+		const fixture = createSocket(options);
+		let acknowledgement;
+		await fixture.handlers.get("guest_subscribe")(subscription, (value) => {
+			acknowledgement = value;
+		});
+		assert.deepEqual(fixture.joinedRooms, []);
+		assert.deepEqual(acknowledgement, { ok: false, error: "validation_failed" });
+	}
+});
+
+test("guest handlers ignore non-function and throwing acknowledgements", async () => {
+	const fixture = createSocket();
+
+	await assert.doesNotReject(
+		fixture.handlers.get("guest_subscribe")(subscription, { untrusted: true }),
+	);
+	await assert.doesNotReject(
+		fixture.handlers.get("guest_unsubscribe")(subscription, () => {
+			throw new Error("untrusted callback");
+		}),
+	);
+	await assert.doesNotReject(
+		fixture.handlers.get("guest_subscribe")(subscription, async () => {
+			throw new Error("untrusted async callback");
+		}),
+	);
+});
+
+test("guest_unsubscribe validates proof before leaving", async () => {
+	const fixture = createSocket();
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_unsubscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(fixture.leftRooms, ["guest:guest_12345"]);
+	assert.deepEqual(acknowledgement, { ok: true, status: "pending" });
+});
+
+test("guest_unsubscribe permits every recognized proof-bound status", async () => {
+	for (const status of ["pending", "admitted", "expired", "rejected", "banned"]) {
+		const fixture = createSocket({
+			response: {
+				message: {
+					valid: ["pending", "admitted"].includes(status),
+					status,
+				},
+			},
+		});
+		let acknowledgement;
+
+		await fixture.handlers.get("guest_unsubscribe")(subscription, (value) => {
+			acknowledgement = value;
+		});
+
+		assert.deepEqual(fixture.leftRooms, ["guest:guest_12345"]);
+		assert.deepEqual(acknowledgement, { ok: true, status });
+	}
+});
+
+test("guest_unsubscribe rejects invalid proof without a status", async () => {
+	for (const response of [
+		{ message: { valid: false } },
+		{ message: { valid: false, status: "unrecognized" } },
+	]) {
+		const fixture = createSocket({ response });
+
+		await fixture.handlers.get("guest_unsubscribe")(subscription);
+
+		assert.deepEqual(fixture.leftRooms, []);
+	}
+});
+
+test("guest_unsubscribe catches leave errors", async () => {
+	const fixture = createSocket({ leaveError: new Error("leave failed") });
+	let acknowledgement;
+
+	await fixture.handlers.get("guest_unsubscribe")(subscription, (value) => {
+		acknowledgement = value;
+	});
+
+	assert.deepEqual(acknowledgement, {
+		ok: false,
+		error: "validation_failed",
+	});
 });

--- a/suite/meet/api/meeting.py
+++ b/suite/meet/api/meeting.py
@@ -11,15 +11,38 @@ import jwt
 from frappe import _
 from frappe.rate_limiter import rate_limit
 
+from suite.meet import guest_access
 from suite.meet.api.recording import get_active_recording_state
 from suite.meet.doctype.meet_room.meet_room import MeetRoom
 from suite.meet.utils.sfu_config import get_sfu_config
 from suite.meet.utils.user import (
-    get_guest_session,
     get_user_info,
-    set_guest_session,
     validate_guest_name,
 )
+
+_GUEST_PROOF_FIELD = "guest_session_token"
+_REDACTED_PROOF = "[REDACTED]"
+
+
+def _redact_guest_proof_from_request() -> None:
+    request = getattr(frappe.local, "request", None)
+    if not request:
+        return
+
+    if getattr(request, "is_json", False):
+        json_body = request.json
+        if isinstance(json_body, dict) and _GUEST_PROOF_FIELD in json_body:
+            json_body[_GUEST_PROOF_FIELD] = _REDACTED_PROOF
+
+    form = getattr(request, "form", None)
+    if form and _GUEST_PROOF_FIELD in form:
+        redacted_form = form.copy()
+        redacted_form[_GUEST_PROOF_FIELD] = _REDACTED_PROOF
+        request.form = redacted_form
+
+    form_dict = getattr(frappe.local, "form_dict", None)
+    if form_dict and _GUEST_PROOF_FIELD in form_dict:
+        form_dict[_GUEST_PROOF_FIELD] = _REDACTED_PROOF
 
 
 def _generate_sfu_token(
@@ -124,6 +147,60 @@ def _build_sfu_connection_details(meeting: MeetRoom, user: str) -> dict:
     }
 
 
+def _build_guest_connection_details(
+    meeting: MeetRoom,
+    lease: guest_access.GuestLease,
+    guest_session_token: str | None,
+) -> dict:
+    settings = frappe.get_cached_doc("Meet Settings")
+    if not settings.allow_guest or not meeting.allow_guest:
+        frappe.throw(_("Guests are not allowed in this meeting"), frappe.PermissionError)
+
+    expires_in = guest_access.remaining_authorization_ttl(lease)
+    if expires_in <= 0:
+        frappe.throw(_("Guest lease expired"), frappe.PermissionError)
+    sfu_config = get_sfu_config()
+    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
+    auth_token = _generate_sfu_token(
+        user_id=lease.guest_id,
+        meeting_id=meeting.name,
+        expires_in=expires_in,
+        user_name=lease.guest_name,
+        is_host=False,
+        is_cohost=False,
+        is_guest=True,
+        e2ee_required=e2ee_required,
+        guest_generation=lease.generation,
+    )
+    return {
+        "status": "joined",
+        "meeting_id": meeting.name,
+        "guest_id": lease.guest_id,
+        "guest_name": lease.guest_name,
+        "guest_session_token": guest_session_token,
+        "auth_token": auth_token,
+        "expires_in": expires_in,
+        "sfu_url": sfu_config["sfu_server_url"],
+        "sfu_port": sfu_config["sfu_server_port"],
+        "codec_strategy": _get_codec_strategy(),
+        "host_only_chat": bool(meeting.host_only_chat),
+        "e2ee_required": e2ee_required,
+        "recording": get_active_recording_state(meeting.name),
+        "message": "Successfully joined meeting",
+    }
+
+
+def _publish_waiting_room_updated(meeting: MeetRoom) -> None:
+    waiting_count = len(meeting.get_waiting_room()) + len(guest_access.list_pending(meeting.name))
+    frappe.publish_realtime(
+        "meeting_waiting_room_updated",
+        doctype=meeting.doctype,
+        docname=meeting.name,
+        message={"meeting": meeting.name, "waiting_count": waiting_count},
+        after_commit=True,
+    )
+
+
 @frappe.whitelist()
 @rate_limit(limit=10, seconds=60 * 60)
 def create(meeting_type: str = "open", allow_guest: bool = True, title: str | None = None) -> str:
@@ -148,8 +225,14 @@ def create(meeting_type: str = "open", allow_guest: bool = True, title: str | No
 @rate_limit(limit=10, seconds=60)
 def get_public_meeting_preview(meeting_id: str) -> dict:
     """Return title-only data for the meeting preview."""
-    title = frappe.db.get_value("Meet Room", meeting_id, "title")
-    return {"title": title or meeting_id}
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    settings = frappe.get_cached_doc("Meet Settings")
+    is_public = bool(settings.allow_guest and meeting.allow_guest)
+    user = frappe.session.user
+    is_participant = user != "Guest" and (meeting.is_host_or_cohost(user) or user in meeting.get_members())
+    if not is_public and not is_participant:
+        frappe.throw(_("Access denied"), frappe.PermissionError)
+    return {"title": meeting.title or meeting_id}
 
 
 @frappe.whitelist()
@@ -229,38 +312,62 @@ def join_meeting(meeting_id: str) -> dict:
         frappe.throw(_("Access denied"))
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def approve_join_request(meeting_id: str, user_id: str) -> dict:
     """Approve a user's join request from waiting room"""
     meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-    meeting.approve_user(user_id)
+    if not meeting.is_host_or_cohost(frappe.session.user):
+        frappe.throw(_("Only hosts and co-hosts can approve join requests"))
+    if user_id.startswith("guest_"):
+        lease = guest_access.admit(meeting_id, user_id)
+        frappe.publish_realtime(
+            "meet:guest_join_approved",
+            {
+                "meeting_id": meeting_id,
+                "guest_id": user_id,
+                "guest_name": lease.guest_name,
+                "message": "Your join request has been approved",
+            },
+            room=f"guest:{user_id}",
+            after_commit=True,
+        )
+        _publish_waiting_room_updated(meeting)
+    else:
+        meeting.approve_user(user_id)
 
     return {"meeting_id": meeting_id, "user_id": user_id, "message": "User approved successfully"}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def approve_all_join_requests(meeting_id: str) -> dict:
     """Approve all users' join requests from waiting room"""
     meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    if not meeting.is_host_or_cohost(frappe.session.user):
+        frappe.throw(_("Only hosts and co-hosts can approve join requests"))
     meeting.approve_all_users()
+    for lease in guest_access.list_pending(meeting_id):
+        approve_join_request(meeting_id, lease.guest_id)
 
     return {"meeting_id": meeting_id, "message": "All users approved successfully"}
 
 
-@frappe.whitelist()
+@frappe.whitelist(methods=["POST"])
 def reject_join_request(meeting_id: str, user_id: str) -> dict:
     """Reject a user's join request from waiting room"""
     meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id, for_update=True)
-    meeting.reject_user(user_id)
-
-    # For guests, publish realtime event in a guest-specific room
     if user_id.startswith("guest_"):
+        if not meeting.is_host_or_cohost(frappe.session.user):
+            frappe.throw(_("Only hosts and co-hosts can reject join requests"))
+        guest_access.reject(meeting_id, user_id)
         frappe.publish_realtime(
             "meet:guest_join_rejected",
             {"meeting_id": meeting_id, "guest_id": user_id},
             room=f"guest:{user_id}",
             after_commit=True,
         )
+        _publish_waiting_room_updated(meeting)
+    else:
+        meeting.reject_user(user_id)
 
     return {"meeting_id": meeting_id, "user_id": user_id, "message": "User rejected successfully"}
 
@@ -273,10 +380,8 @@ def get_waiting_room(meeting_id: str) -> dict:
     if not meeting.is_host_or_cohost(frappe.session.user):
         frappe.throw(_("Access denied"))
 
-    waiting_rows = meeting.waiting_room or []
-
     user_details = []
-    for row in waiting_rows:
+    for row in meeting.waiting_room or []:
         user = row.user
         user_info = get_user_info(user)
         user_name = row.user_name or (user_info.get("full_name") if user_info else None)
@@ -289,6 +394,17 @@ def get_waiting_room(meeting_id: str) -> dict:
                 "is_guest": user_info.get("is_guest", False) if user_info else user.startswith("guest_"),
             }
         )
+
+    user_details.extend(
+        {
+            "user_id": lease.guest_id,
+            "full_name": lease.guest_name,
+            "user_name": lease.guest_name,
+            "user_image": None,
+            "is_guest": True,
+        }
+        for lease in guest_access.list_pending(meeting_id)
+    )
 
     return {"meeting_id": meeting_id, "waiting_users": user_details}
 
@@ -379,252 +495,135 @@ def get_sfu_presence_preview_token(meeting_id: str) -> dict:
     }
 
 
-@frappe.whitelist(allow_guest=True)
-@rate_limit(limit=10, seconds=60 * 60)
-def join_meeting_as_guest(meeting_id: str, guest_name: str, guest_id: str | None = None) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def join_meeting_as_guest(
+    meeting_id: str,
+    guest_name: str,
+    guest_id: str | None = None,
+    guest_session_token: str | None = None,
+) -> dict:
     """
     Allow guest users to join a meeting without authentication.
     Generates a guest session and JWT token for SFU access.
     """
+    _redact_guest_proof_from_request()
     is_valid, error_message = validate_guest_name(guest_name)
     if not is_valid:
         frappe.throw(_(error_message))
 
+    rate_limited = not guest_id or not guest_session_token
+    if rate_limited:
+        guest_access.enforce_fresh_join_rate_limit(
+            str(getattr(frappe.local, "request_ip", None) or "unknown")
+        )
+
+    lease = guest_access.resume_for_join(meeting_id, guest_id, guest_session_token)
+    if lease is None and not rate_limited:
+        guest_access.enforce_fresh_join_rate_limit(
+            str(getattr(frappe.local, "request_ip", None) or "unknown")
+        )
+
     if not frappe.db.exists("Meet Room", meeting_id):
         frappe.throw(_("Meeting not found"))
 
-    meeting = frappe.get_doc("Meet Room", meeting_id, for_update=True)
+    meeting = frappe.get_doc("Meet Room", meeting_id)
 
     global_settings = frappe.get_cached_doc("Meet Settings")
     if not global_settings.allow_guest or not meeting.allow_guest:
         frappe.throw(_("Guests are not allowed in this meeting"))
-    # Check if reusing existing guest_id
-    if guest_id:
-        session_data = get_guest_session(guest_id)
-        if session_data and session_data.get("meeting_id") == meeting_id:
-            # Reuse existing guest_id
-            guest_name_clean = session_data.get("guest_name", guest_name.strip())
-        else:
-            # Invalid or expired, generate new
-            guest_id = None
+    created = lease is None
+    if created:
+        lease, guest_session_token = guest_access.create_lease(
+            meeting_id,
+            guest_name.strip(),
+            admitted=meeting.meeting_type != "restricted",
+        )
 
-    if not guest_id:
-        guest_id = f"guest_{secrets.token_urlsafe(16)}"
-        guest_name_clean = guest_name.strip()
-
-        session_data = {
-            "guest_id": guest_id,
-            "guest_name": guest_name_clean,
-            "meeting_id": meeting_id,
-            "ip_address": frappe.local.request_ip,
-            "joined_at": int(time.time()),
-        }
-        set_guest_session(guest_id, session_data, ttl=24 * 3600)
-
-    if meeting.is_user_banned(guest_id):
-        frappe.throw(_("You are banned from this meeting"))
-
-    sfu_config = get_sfu_config()
-    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
-
-    if meeting.meeting_type == "restricted":
-        if meeting.is_user_approved(guest_id):
-            auth_token = _generate_sfu_token(
-                user_id=guest_id,
-                meeting_id=meeting_id,
-                expires_in=24 * 3600,
-                user_name=guest_name_clean,
-                is_host=False,
-                is_guest=True,
-                e2ee_required=e2ee_required,
-            )
-            return {
-                "status": "joined",
-                "meeting_id": meeting_id,
-                "guest_id": guest_id,
-                "guest_name": guest_name_clean,
-                "auth_token": auth_token,
-                "sfu_url": sfu_config["sfu_server_url"],
-                "sfu_port": sfu_config["sfu_server_port"],
-                "codec_strategy": _get_codec_strategy(),
-                "host_only_chat": bool(meeting.host_only_chat),
-                "e2ee_required": e2ee_required,
-                "recording": get_active_recording_state(meeting_id),
-                "message": "Successfully joined meeting",
-            }
-        elif guest_id not in meeting.get_waiting_room():
-            meeting.add_guest_to_waiting_room(guest_id)
-
+    if lease.status == "pending":
+        if created:
+            waiting_count = len(meeting.get_waiting_room()) + len(guest_access.list_pending(meeting_id))
+            meeting.publish_waiting_room_request(lease.guest_id, waiting_count)
         return {
             "status": "waiting_for_approval",
             "meeting_id": meeting_id,
-            "guest_id": guest_id,
-            "guest_name": guest_name_clean,
+            "guest_id": lease.guest_id,
+            "guest_name": lease.guest_name,
+            "guest_session_token": guest_session_token,
             "message": "Waiting for host approval",
             "host_only_chat": bool(meeting.host_only_chat),
         }
 
-    # open meeting
-    auth_token = _generate_sfu_token(
-        user_id=guest_id,
-        meeting_id=meeting_id,
-        expires_in=24 * 3600,
-        user_name=guest_name_clean,
-        is_host=False,
-        is_guest=True,
-        e2ee_required=e2ee_required,
-    )
-
-    meeting.add_guest_to_members(guest_id)
-
-    return {
-        "status": "joined",
-        "meeting_id": meeting_id,
-        "guest_id": guest_id,
-        "guest_name": guest_name_clean,
-        "auth_token": auth_token,
-        "sfu_url": sfu_config["sfu_server_url"],
-        "sfu_port": sfu_config["sfu_server_port"],
-        "codec_strategy": _get_codec_strategy(),
-        "host_only_chat": bool(meeting.host_only_chat),
-        "e2ee_required": e2ee_required,
-        "recording": get_active_recording_state(meeting_id),
-        "message": "Successfully joined meeting",
-    }
+    return _build_guest_connection_details(meeting, lease, guest_session_token)
 
 
-@frappe.whitelist(allow_guest=True)
-@rate_limit(limit=10, seconds=60 * 60)
-def get_approved_guest_connection_details(meeting_id: str, guest_id: str) -> dict:
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def get_approved_guest_connection_details(
+    meeting_id: str,
+    guest_id: str,
+    guest_session_token: str | None = None,
+) -> dict:
     """
     Get SFU connection details for an approved guest.
     This is called after a guest receives approval notification.
     """
-    session_data = get_guest_session(guest_id)
-    if not session_data:
-        frappe.throw(_("Guest session not found or expired"))
-
-    if session_data.get("meeting_id") != meeting_id:
-        frappe.throw(_("Guest session does not belong to this meeting"), frappe.PermissionError)
-
+    _redact_guest_proof_from_request()
     if not frappe.db.exists("Meet Room", meeting_id):
         frappe.throw(_("Meeting not found"))
 
     meeting = frappe.get_doc("Meet Room", meeting_id)
+    lease = guest_access.authorize(
+        meeting_id,
+        guest_id,
+        guest_session_token,
+        statuses={"admitted"},
+    )
+    return _build_guest_connection_details(meeting, lease, guest_session_token)
 
-    settings = frappe.get_cached_doc("Meet Settings")
-    if not settings.allow_guest or not meeting.allow_guest:
-        frappe.throw(_("Guests are not allowed in this meeting"), frappe.PermissionError)
 
-    if not meeting.is_user_approved(guest_id):
-        frappe.throw(_("Guest not approved"))
-
-    if meeting.is_user_banned(guest_id):
-        frappe.throw(_("You are banned from this meeting"))
-
-    sfu_config = get_sfu_config()
-
-    guest_name = session_data.get("guest_name", f"Guest-{guest_id[:8]}")
-    e2ee_required = bool(getattr(meeting, "e2ee_enabled", False))
-
-    auth_token = _generate_sfu_token(
-        user_id=guest_id,
-        meeting_id=meeting_id,
-        expires_in=24 * 3600,
-        user_name=guest_name,
-        is_host=False,
-        is_guest=True,
-        e2ee_required=e2ee_required,
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def refresh_guest_sfu_token(
+    meeting_id: str,
+    guest_id: str,
+    guest_session_token: str | None = None,
+) -> dict:
+    _redact_guest_proof_from_request()
+    if not frappe.db.exists("Meet Room", meeting_id):
+        frappe.throw(_("Meeting not found"))
+    lease = guest_access.authorize(
+        meeting_id,
+        guest_id,
+        guest_session_token,
+        statuses={"admitted"},
+    )
+    return _build_guest_connection_details(
+        frappe.get_doc("Meet Room", meeting_id),
+        lease,
+        guest_session_token,
     )
 
-    return {
-        "status": "joined",
-        "meeting_id": meeting_id,
-        "guest_id": guest_id,
-        "guest_name": guest_name,
-        "auth_token": auth_token,
-        "sfu_url": sfu_config["sfu_server_url"],
-        "sfu_port": sfu_config["sfu_server_port"],
-        "codec_strategy": _get_codec_strategy(),
-        "host_only_chat": bool(meeting.host_only_chat),
-        "e2ee_required": e2ee_required,
-        "recording": get_active_recording_state(meeting_id),
-        "message": "Successfully joined meeting",
-    }
+
+@frappe.whitelist(methods=["POST"])
+def ban_guest(meeting_id: str, guest_id: str) -> dict:
+    meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
+    if not meeting.is_host_or_cohost(frappe.session.user):
+        frappe.throw(_("Only hosts and co-hosts can ban guests"), frappe.PermissionError)
+    guest_access.ban(meeting_id, guest_id)
+    return {"meeting_id": meeting_id, "guest_id": guest_id, "status": "banned"}
 
 
-@frappe.whitelist(allow_guest=True)
-def get_guest_sfu_connection_details(meeting_id: str, guest_token: str) -> dict:
-    """
-    Get SFU connection details for guest users.
-    Validates the guest token and returns SFU URL/port.
-    """
-    sfu_config = get_sfu_config()
-    secret = sfu_config.get("sfu_secret")
-    if not secret:
-        frappe.throw(_("SFU secret not configured"))
-
-    try:
-        decoded = jwt.decode(guest_token, secret, algorithms=["HS256"])
-    except jwt.ExpiredSignatureError:
-        frappe.throw(_("Guest token has expired"))
-    except jwt.InvalidTokenError:
-        frappe.throw(_("Invalid guest token"))
-
-    if not decoded.get("is_guest"):
-        frappe.throw(_("Not a guest token"))
-
-    if decoded.get("meeting_id") != meeting_id:
-        frappe.throw(_("Token meeting ID does not match"))
-
-    if not frappe.db.exists("Meet Room", meeting_id):
-        frappe.throw(_("Meeting not found"))
-
-    guest_id = decoded.get("user_id")
-    session_data = get_guest_session(guest_id) if isinstance(guest_id, str) else None
-    if not session_data or session_data.get("meeting_id") != meeting_id:
-        frappe.throw(_("Guest session not found or expired"), frappe.PermissionError)
-
-    meeting = frappe.get_doc("Meet Room", meeting_id)
-    settings = frappe.get_cached_doc("Meet Settings")
-    if (
-        not settings.allow_guest
-        or not meeting.allow_guest
-        or meeting.is_user_banned(guest_id)
-        or guest_id not in meeting.get_members()
-    ):
-        frappe.throw(_("Guest access denied"), frappe.PermissionError)
-
-    return {
-        "sfu_url": sfu_config["sfu_server_url"],
-        "sfu_port": sfu_config["sfu_server_port"],
-        "codec_strategy": _get_codec_strategy(),
-        "e2ee_required": _is_e2ee_enabled(meeting_id),
-    }
-
-
-@frappe.whitelist(allow_guest=True)
-@rate_limit(limit=10, seconds=60 * 60)
-def validate_guest_session(guest_id: str) -> dict:
-    """
-    Validate that a guest session exists and is active.
-
-    Args:
-            guest_id: The guest ID to validate
-
-    Returns:
-            dict: {"valid": bool}
-    """
-    if not guest_id or not guest_id.startswith("guest_"):
-        return {"valid": False, "error": "Invalid guest ID format"}
-
-    session_data = get_guest_session(guest_id)
-    if not session_data:
-        return {"valid": False, "error": "Guest session not found"}
-
-    return {
-        "valid": True,
-    }
+@frappe.whitelist(allow_guest=True, methods=["POST"])
+def validate_guest_session(
+    meeting_id: str,
+    guest_id: str,
+    guest_session_token: str | None = None,
+) -> dict:
+    """Return active validity and any proof-bound lease status."""
+    _redact_guest_proof_from_request()
+    status = guest_access.get_status(meeting_id, guest_id, guest_session_token)
+    result: dict[str, bool | str] = {"valid": status in guest_access.ACTIVE_STATUSES}
+    if status is not None:
+        result["status"] = status
+    return result
 
 
 @frappe.whitelist()
@@ -650,12 +649,14 @@ def check_meeting_access(meeting_id: str) -> dict:
     """
     try:
         meeting: MeetRoom = frappe.get_doc("Meet Room", meeting_id)
-        settings = frappe.get_cached_doc("Meet Settings")
-        allow_guest = settings.allow_guest and meeting.allow_guest
-
-        return {"allow_guest": allow_guest, "host_only_chat": bool(meeting.host_only_chat)}
     except frappe.DoesNotExistError:
-        frappe.throw(_("Meeting not found"))
+        return {"allow_guest": False}
+
+    settings = frappe.get_cached_doc("Meet Settings")
+    if not (settings.allow_guest and meeting.allow_guest):
+        return {"allow_guest": False}
+
+    return {"allow_guest": True, "host_only_chat": bool(meeting.host_only_chat)}
 
 
 @frappe.whitelist()

--- a/suite/meet/api/test/test_meeting.py
+++ b/suite/meet/api/test/test_meeting.py
@@ -8,12 +8,16 @@ import frappe
 import jwt
 from frappe.client import delete as delete_document
 from frappe.tests import IntegrationTestCase
+from werkzeug.test import EnvironBuilder
+from werkzeug.wrappers import Request
 
+from suite.meet import guest_access
 from suite.meet.api.meeting import (
     approve_all_join_requests,
     approve_join_request,
+    ban_guest,
+    check_meeting_access,
     get_approved_guest_connection_details,
-    get_guest_sfu_connection_details,
     get_public_meeting_preview,
     get_sfu_connection_details,
     get_sfu_presence_preview_token,
@@ -21,10 +25,11 @@ from suite.meet.api.meeting import (
     join_meeting,
     join_meeting_as_guest,
     promote_to_cohost,
+    refresh_guest_sfu_token,
     refresh_sfu_token,
     reject_join_request,
+    validate_guest_session,
 )
-from suite.meet.utils.user import set_guest_session
 
 
 class IntegrationTestMeetingApi(IntegrationTestCase):
@@ -32,6 +37,9 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         frappe.conf.sfu_secret = "test-sfu-secret"
         frappe.db.set_single_value("Meet Settings", "allow_guest", 1)
         frappe.clear_cache(doctype="Meet Settings")
+        frappe.cache.delete(
+            guest_access._fresh_join_rate_key(str(getattr(frappe.local, "request_ip", None) or "unknown"))
+        )
 
         self.host_email = "host-meet@example.com"
         self.member_email = "member-meet@example.com"
@@ -170,7 +178,7 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
             frappe.set_user(user)
             frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
 
-    def test_non_member_gets_public_preview_title_without_read_access(self):
+    def test_non_member_gets_guest_enabled_preview_title_without_read_access(self):
         self.meeting.title = "Quarterly planning"
         self.meeting.save(ignore_permissions=True)
 
@@ -179,6 +187,43 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
             frappe.get_doc("Meet Room", self.meeting.name).check_permission("read")
 
         self.assertEqual(get_public_meeting_preview(self.meeting.name)["title"], "Quarterly planning")
+
+    def test_private_preview_title_requires_participation(self):
+        self.meeting.title = "Confidential planning"
+        self.meeting.save(ignore_permissions=True)
+        self.meeting.db_set("allow_guest", 0)
+
+        for user in ("Guest", self.outsider_email):
+            with self.subTest(user=user):
+                frappe.set_user(user)
+                with self.assertRaises(frappe.PermissionError):
+                    get_public_meeting_preview(self.meeting.name)
+
+        self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
+        frappe.set_user(self.member_email)
+        self.assertEqual(
+            get_public_meeting_preview(self.meeting.name)["title"],
+            "Confidential planning",
+        )
+
+    def test_private_and_missing_meeting_access_are_indistinguishable(self):
+        self.meeting.db_set("allow_guest", 0)
+
+        frappe.set_user("Guest")
+        private_access = check_meeting_access(self.meeting.name)
+        missing_access = check_meeting_access("missing-meeting")
+
+        self.assertEqual(private_access, {"allow_guest": False})
+        self.assertEqual(missing_access, private_access)
+
+    def test_guest_enabled_meeting_access_returns_public_policy(self):
+        self.meeting.db_set("host_only_chat", 1)
+
+        frappe.set_user("Guest")
+        self.assertEqual(
+            check_meeting_access(self.meeting.name),
+            {"allow_guest": True, "host_only_chat": True},
+        )
 
     def test_meeting_list_only_contains_hosted_or_cohosted_meetings(self):
         self.meeting.add_user_to_table("co_hosts", self.member_email, save=True, ignore_permissions=True)
@@ -248,6 +293,10 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
 
         self.assertEqual(result["status"], "joined")
         self.assertEqual(result["recording"], recording)
+        self.assertEqual(result["expires_in"], 300)
+        self.assertTrue(result["guest_session_token"])
+        raw_lease = frappe.cache.get(f"meet:guest-lease:{frappe.local.site}:{result['guest_id']}")
+        self.assertNotIn(result["guest_session_token"], raw_lease.decode())
 
     def test_restricted_waiting_join_does_not_return_full_media_token(self):
         frappe.set_user(self.outsider_email)
@@ -273,17 +322,330 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
             refresh_sfu_token(self.meeting.name)
 
     def test_approved_guest_session_cannot_cross_meet_rooms(self):
-        guest_id = f"guest_{frappe.generate_hash(length=16)}"
-        set_guest_session(
-            guest_id,
-            {"guest_id": guest_id, "guest_name": "Room A Guest", "meeting_id": self.meeting.name},
-        )
+        lease, session_token = guest_access.create_lease(self.meeting.name, "Room A Guest", admitted=True)
         other_room = self._create_meeting(self.host_email, meeting_type="restricted")
-        other_room.add_user_to_table("members", guest_id, save=True, ignore_permissions=True)
         frappe.set_user("Guest")
 
         with self.assertRaises(frappe.PermissionError):
-            get_approved_guest_connection_details(other_room.name, guest_id)
+            get_approved_guest_connection_details(other_room.name, lease.guest_id, session_token)
+
+    def test_public_guest_id_cannot_resume_or_get_approved_connection_details(self):
+        frappe.set_user("Guest")
+        first = join_meeting_as_guest(self.meeting.name, "Private Guest")
+
+        public_id_join = join_meeting_as_guest(
+            self.meeting.name,
+            "Private Guest",
+            guest_id=first["guest_id"],
+        )
+
+        self.assertNotEqual(public_id_join["guest_id"], first["guest_id"])
+        with self.assertRaises(frappe.PermissionError):
+            get_approved_guest_connection_details(self.meeting.name, first["guest_id"])
+
+    def test_guest_proof_resumes_same_room_principal(self):
+        frappe.set_user("Guest")
+        first = join_meeting_as_guest(self.meeting.name, "Stable Guest")
+
+        resumed = join_meeting_as_guest(
+            self.meeting.name,
+            "Changed Name",
+            first["guest_id"],
+            first["guest_session_token"],
+        )
+
+        self.assertEqual(resumed["guest_id"], first["guest_id"])
+        self.assertEqual(resumed["guest_name"], "Stable Guest")
+
+    def test_approved_guest_connection_details_is_post_only(self):
+        self.assertEqual(
+            frappe.allowed_http_methods_for_whitelisted_func[get_approved_guest_connection_details],
+            ("POST",),
+        )
+
+    def test_wrong_guest_proof_cannot_get_admitted_token(self):
+        self.meeting.db_set("meeting_type", "open")
+        frappe.set_user("Guest")
+        joined = join_meeting_as_guest(self.meeting.name, "Proof Guest")
+
+        with self.assertRaises(frappe.PermissionError):
+            refresh_guest_sfu_token(
+                self.meeting.name,
+                joined["guest_id"],
+                "wrong-private-proof",
+            )
+
+    def test_pending_guest_expires_after_thirty_minutes_and_leaves_listing(self):
+        now = int(time.time())
+        frappe.set_user("Guest")
+        with patch("suite.meet.guest_access.time.time", return_value=now):
+            waiting = join_meeting_as_guest(self.meeting.name, "Pending Guest")
+
+        frappe.set_user(self.host_email)
+        with patch(
+            "suite.meet.guest_access.time.time",
+            return_value=now + guest_access.PENDING_TTL + 1,
+        ):
+            result = get_waiting_room(self.meeting.name)
+
+        self.assertNotIn(
+            waiting["guest_id"],
+            [user["user_id"] for user in result["waiting_users"]],
+        )
+
+    def test_expired_pending_guest_can_reconcile_status_with_proof(self):
+        now = int(time.time())
+        frappe.set_user("Guest")
+        with patch("suite.meet.guest_access.time.time", return_value=now):
+            waiting = join_meeting_as_guest(self.meeting.name, "Expired Pending Guest")
+
+        with patch(
+            "suite.meet.guest_access.time.time",
+            return_value=now + guest_access.PENDING_TTL + 1,
+        ):
+            result = validate_guest_session(
+                self.meeting.name,
+                waiting["guest_id"],
+                waiting["guest_session_token"],
+            )
+
+        self.assertEqual(result, {"valid": False, "status": "expired"})
+        self.assertGreater(frappe.cache.ttl(guest_access._guest_key(waiting["guest_id"])), 0)
+        self.assertLessEqual(
+            frappe.cache.ttl(guest_access._guest_key(waiting["guest_id"])),
+            guest_access.TERMINAL_TTL,
+        )
+
+    def test_expiry_cleanup_does_not_delete_concurrently_admitted_lease(self):
+        now = int(time.time())
+        with patch("suite.meet.guest_access.time.time", return_value=now):
+            pending, session_token = guest_access.create_lease(
+                self.meeting.name,
+                "Concurrent Guest",
+                admitted=False,
+            )
+            admitted = guest_access.admit(self.meeting.name, pending.guest_id)
+
+        with (
+            patch(
+                "suite.meet.guest_access.time.time",
+                return_value=now + guest_access.PENDING_TTL + 1,
+            ),
+            patch("suite.meet.guest_access._read", side_effect=[pending, admitted]),
+        ):
+            authorized = guest_access.authorize(
+                self.meeting.name,
+                pending.guest_id,
+                session_token,
+                statuses={"admitted"},
+            )
+
+        self.assertEqual(authorized, admitted)
+        self.assertIsNotNone(frappe.cache.get(guest_access._guest_key(pending.guest_id)))
+
+    def test_duplicate_guest_admission_preserves_authorization_generation(self):
+        pending, _session_token = guest_access.create_lease(
+            self.meeting.name,
+            "Idempotent Guest",
+            admitted=False,
+        )
+
+        admitted = guest_access.admit(self.meeting.name, pending.guest_id)
+        duplicate = guest_access.admit(self.meeting.name, pending.guest_id)
+
+        self.assertEqual(duplicate, admitted)
+        self.assertEqual(duplicate.generation, pending.generation + 1)
+
+    def test_duplicate_terminal_guest_transitions_preserve_generation(self):
+        for transition, status in (
+            (guest_access.reject, "rejected"),
+            (guest_access.ban, "banned"),
+        ):
+            with self.subTest(status=status):
+                pending, _session_token = guest_access.create_lease(
+                    self.meeting.name,
+                    f"Idempotent {status}",
+                    admitted=False,
+                )
+
+                terminal = transition(self.meeting.name, pending.guest_id)
+                duplicate = transition(self.meeting.name, pending.guest_id)
+
+                self.assertEqual(duplicate, terminal)
+                self.assertEqual(duplicate.generation, pending.generation + 1)
+
+    def test_guest_terminal_transitions_cannot_cross(self):
+        rejected, _session_token = guest_access.create_lease(
+            self.meeting.name,
+            "Rejected Guest",
+            admitted=False,
+        )
+        banned, _session_token = guest_access.create_lease(
+            self.meeting.name,
+            "Banned Guest",
+            admitted=False,
+        )
+        guest_access.reject(self.meeting.name, rejected.guest_id)
+        guest_access.ban(self.meeting.name, banned.guest_id)
+
+        with self.assertRaises(guest_access.GuestAccessDenied):
+            guest_access.ban(self.meeting.name, rejected.guest_id)
+        with self.assertRaises(guest_access.GuestAccessDenied):
+            guest_access.reject(self.meeting.name, banned.guest_id)
+
+    def test_guest_proof_is_redacted_before_downstream_endpoint_errors(self):
+        original_request = getattr(frappe.local, "request", None)
+        original_form_dict = frappe.local.form_dict
+        self.addCleanup(setattr, frappe.local, "request", original_request)
+        self.addCleanup(setattr, frappe.local, "form_dict", original_form_dict)
+        proof = "private-proof-that-must-not-reach-telemetry"
+        endpoints = (
+            (
+                join_meeting_as_guest,
+                (self.meeting.name, "Telemetry Guest", "guest_telemetry", proof),
+                "suite.meet.api.meeting.validate_guest_name",
+            ),
+            (
+                get_approved_guest_connection_details,
+                (self.meeting.name, "guest_telemetry", proof),
+                "suite.meet.api.meeting.frappe.db.exists",
+            ),
+            (
+                refresh_guest_sfu_token,
+                (self.meeting.name, "guest_telemetry", proof),
+                "suite.meet.api.meeting.frappe.db.exists",
+            ),
+            (
+                validate_guest_session,
+                (self.meeting.name, "guest_telemetry", proof),
+                "suite.meet.api.meeting.guest_access.get_status",
+            ),
+        )
+
+        for body_type in ("json", "form"):
+            for endpoint, args, downstream in endpoints:
+                with self.subTest(body_type=body_type, endpoint=endpoint.__name__):
+                    builder_args = {
+                        "json" if body_type == "json" else "data": {
+                            "meeting_id": self.meeting.name,
+                            "guest_session_token": proof,
+                        }
+                    }
+                    request = Request(EnvironBuilder(method="POST", **builder_args).get_environ())
+                    frappe.local.request = request
+                    frappe.local.form_dict = frappe._dict(guest_session_token=proof)
+
+                    def fail_after_redaction(*_args, **_kwargs):
+                        context = request.json if request.is_json else request.form
+                        self.assertEqual(
+                            context["guest_session_token"],
+                            "[REDACTED]",
+                        )
+                        self.assertNotIn(proof, str(context))
+                        self.assertEqual(
+                            frappe.form_dict.guest_session_token,
+                            "[REDACTED]",
+                        )
+                        raise RuntimeError("downstream infrastructure failed")
+
+                    with (
+                        patch(downstream, side_effect=fail_after_redaction),
+                        self.assertRaisesRegex(
+                            RuntimeError,
+                            "downstream infrastructure failed",
+                        ),
+                    ):
+                        endpoint(*args)
+
+    def test_guest_room_index_has_bounded_ttl_and_atomic_updates_reset_it(self):
+        pending, _session_token = guest_access.create_lease(
+            self.meeting.name,
+            "Indexed Guest",
+            admitted=False,
+        )
+        index_key = guest_access._room_key(self.meeting.name)
+
+        self.assertGreater(frappe.cache.ttl(index_key), guest_access.LEASE_TTL)
+        self.assertLessEqual(frappe.cache.ttl(index_key), guest_access.ROOM_INDEX_TTL)
+
+        frappe.cache.expire(index_key, 1)
+        guest_access.admit(self.meeting.name, pending.guest_id)
+
+        self.assertGreater(frappe.cache.ttl(index_key), guest_access.LEASE_TTL)
+        self.assertLessEqual(frappe.cache.ttl(index_key), guest_access.ROOM_INDEX_TTL)
+
+    def test_fresh_guest_join_rate_limit_rejects_before_room_lookup_and_expires(self):
+        previous_ip = getattr(frappe.local, "request_ip", None)
+        frappe.local.request_ip = f"guest-rate-{frappe.generate_hash(length=12)}"
+        rate_key = guest_access._fresh_join_rate_key(frappe.local.request_ip)
+        frappe.cache.delete(rate_key)
+        self.addCleanup(setattr, frappe.local, "request_ip", previous_ip)
+        self.addCleanup(frappe.cache.delete, rate_key)
+
+        lease, session_token = guest_access.create_lease(
+            self.meeting.name,
+            "Rate Limited Resume",
+            admitted=False,
+        )
+        for _ in range(guest_access.FRESH_JOIN_RATE_LIMIT):
+            guest_access.enforce_fresh_join_rate_limit(frappe.local.request_ip)
+
+        ttl = frappe.cache.ttl(rate_key)
+        self.assertGreater(ttl, 0)
+        self.assertLessEqual(ttl, guest_access.FRESH_JOIN_RATE_WINDOW)
+
+        frappe.set_user("Guest")
+        resumed = join_meeting_as_guest(
+            self.meeting.name,
+            lease.guest_name,
+            lease.guest_id,
+            session_token,
+        )
+        self.assertEqual(resumed["guest_id"], lease.guest_id)
+
+        with (
+            patch("suite.meet.api.meeting.frappe.db.exists") as room_exists,
+            self.assertRaises(frappe.RateLimitExceededError),
+        ):
+            join_meeting_as_guest(self.meeting.name, "Limited Guest")
+        room_exists.assert_not_called()
+
+        frappe.cache.expire(rate_key, 0)
+        self.assertEqual(frappe.cache.exists(rate_key, shared=True), 0)
+        guest_access.enforce_fresh_join_rate_limit(frappe.local.request_ip)
+        self.assertGreater(frappe.cache.ttl(rate_key), 0)
+
+    def test_guest_jwt_is_capped_by_five_minutes_and_remaining_lease(self):
+        now = int(time.time())
+        self.meeting.db_set("meeting_type", "open")
+        frappe.set_user("Guest")
+        with (
+            patch("suite.meet.guest_access.time.time", return_value=now),
+            patch("suite.meet.api.meeting.time.time", return_value=now),
+        ):
+            joined = join_meeting_as_guest(self.meeting.name, "Short Token Guest")
+        decoded = jwt.decode(joined["auth_token"], frappe.conf.sfu_secret, algorithms=["HS256"])
+        self.assertEqual(joined["expires_in"], 300)
+        self.assertEqual(decoded["exp"], now + 300)
+
+        near_expiry = now + guest_access.LEASE_TTL - 120
+        with (
+            patch("suite.meet.guest_access.time.time", return_value=near_expiry),
+            patch("suite.meet.api.meeting.time.time", return_value=near_expiry),
+        ):
+            refreshed = refresh_guest_sfu_token(
+                self.meeting.name,
+                joined["guest_id"],
+                joined["guest_session_token"],
+            )
+        decoded = jwt.decode(
+            refreshed["auth_token"],
+            frappe.conf.sfu_secret,
+            algorithms=["HS256"],
+            options={"verify_iat": False},
+        )
+        self.assertEqual(refreshed["expires_in"], 120)
+        self.assertEqual(decoded["exp"], now + guest_access.LEASE_TTL)
 
     def test_approved_guest_rechecks_current_guest_policy(self):
         frappe.set_user("Guest")
@@ -296,7 +658,7 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         frappe.clear_cache(doctype="Meet Settings")
         frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
-            get_approved_guest_connection_details(self.meeting.name, guest_id)
+            get_approved_guest_connection_details(self.meeting.name, guest_id, waiting["guest_session_token"])
 
     def test_approved_guest_rechecks_room_guest_policy(self):
         frappe.set_user("Guest")
@@ -308,7 +670,7 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
 
         frappe.set_user("Guest")
         with self.assertRaises(frappe.PermissionError):
-            get_approved_guest_connection_details(self.meeting.name, guest_id)
+            get_approved_guest_connection_details(self.meeting.name, guest_id, waiting["guest_session_token"])
 
     def test_expired_or_deleted_guest_session_cannot_reconnect(self):
         frappe.set_user("Guest")
@@ -316,11 +678,15 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         guest_id = waiting["guest_id"]
         frappe.set_user(self.host_email)
         approve_join_request(self.meeting.name, guest_id)
-        frappe.cache.delete_value(f"guest_session:{guest_id}")
-
         frappe.set_user("Guest")
-        with self.assertRaisesRegex(frappe.ValidationError, "not found or expired"):
-            get_approved_guest_connection_details(self.meeting.name, guest_id)
+        with (
+            patch(
+                "suite.meet.guest_access.time.time",
+                return_value=int(time.time()) + guest_access.LEASE_TTL + 1,
+            ),
+            self.assertRaises(frappe.PermissionError),
+        ):
+            get_approved_guest_connection_details(self.meeting.name, guest_id, waiting["guest_session_token"])
 
     def test_rejected_guest_session_cannot_reconnect(self):
         frappe.set_user("Guest")
@@ -330,8 +696,43 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         reject_join_request(self.meeting.name, guest_id)
 
         frappe.set_user("Guest")
-        with self.assertRaises(frappe.ValidationError):
-            get_approved_guest_connection_details(self.meeting.name, guest_id)
+        self.assertEqual(
+            validate_guest_session(
+                self.meeting.name,
+                guest_id,
+                waiting["guest_session_token"],
+            ),
+            {"valid": False, "status": "rejected"},
+        )
+        self.assertGreater(frappe.cache.ttl(guest_access._guest_key(guest_id)), 0)
+        self.assertLessEqual(
+            frappe.cache.ttl(guest_access._guest_key(guest_id)),
+            guest_access.TERMINAL_TTL,
+        )
+        with self.assertRaises(frappe.PermissionError):
+            get_approved_guest_connection_details(self.meeting.name, guest_id, waiting["guest_session_token"])
+
+    def test_guest_status_validation_fails_closed_without_valid_proof_or_redis(self):
+        frappe.set_user("Guest")
+        waiting = join_meeting_as_guest(self.meeting.name, "Status Proof Guest")
+
+        self.assertEqual(
+            validate_guest_session(
+                self.meeting.name,
+                waiting["guest_id"],
+                "wrong-private-proof",
+            ),
+            {"valid": False},
+        )
+        with (
+            patch("suite.meet.guest_access.frappe.cache.get", side_effect=ConnectionError),
+            self.assertRaises(ConnectionError),
+        ):
+            validate_guest_session(
+                self.meeting.name,
+                waiting["guest_id"],
+                waiting["guest_session_token"],
+            )
 
     def test_guest_connection_details_recheck_ban_and_session(self):
         self.meeting.db_set("meeting_type", "open")
@@ -339,12 +740,47 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
         joined = join_meeting_as_guest(self.meeting.name, "Banned Guest")
 
         frappe.set_user(self.host_email)
-        room = frappe.get_doc("Meet Room", self.meeting.name)
-        room.add_user_to_table("banned_users", joined["guest_id"], save=True, ignore_permissions=True)
+        ban_guest(self.meeting.name, joined["guest_id"])
         frappe.set_user("Guest")
 
+        self.assertEqual(
+            validate_guest_session(
+                self.meeting.name,
+                joined["guest_id"],
+                joined["guest_session_token"],
+            ),
+            {"valid": False, "status": "banned"},
+        )
         with self.assertRaises(frappe.PermissionError):
-            get_guest_sfu_connection_details(self.meeting.name, joined["auth_token"])
+            refresh_guest_sfu_token(
+                self.meeting.name,
+                joined["guest_id"],
+                joined["guest_session_token"],
+            )
+
+    def test_guest_admission_never_writes_participant_child_rows(self):
+        frappe.set_user("Guest")
+        waiting = join_meeting_as_guest(self.meeting.name, "Ephemeral Guest")
+        frappe.set_user(self.host_email)
+
+        approve_join_request(self.meeting.name, waiting["guest_id"])
+
+        self.meeting.reload()
+        self.assertNotIn(waiting["guest_id"], self.meeting.get_members())
+        self.assertNotIn(waiting["guest_id"], self.meeting.get_waiting_room())
+        self.assertNotIn(waiting["guest_id"], self.meeting.get_table_users("banned_users"))
+
+    def test_redis_failure_creates_no_guest_or_room_mutation(self):
+        frappe.set_user("Guest")
+        with (
+            patch("suite.meet.guest_access.frappe.cache.pipeline", side_effect=ConnectionError),
+            self.assertRaises(ConnectionError),
+        ):
+            join_meeting_as_guest(self.meeting.name, "Unavailable Redis")
+
+        self.meeting.reload()
+        self.assertFalse(any(user.startswith("guest_") for user in self.meeting.get_members()))
+        self.assertFalse(any(user.startswith("guest_") for user in self.meeting.get_waiting_room()))
 
     def test_waiting_room_apis_reject_member_and_outsider(self):
         self._join_waiting(self.member_email)

--- a/suite/meet/api/test_helpers.py
+++ b/suite/meet/api/test_helpers.py
@@ -37,9 +37,10 @@ def provision_host() -> dict[str, str]:
 @whitelist_for_tests()
 def clear_create_rate_limit() -> None:
     """Clear rate-limit buckets shared by meeting E2E browser contexts."""
-    keys = frappe.cache.get_keys("rl:suite.meet.api.meeting.join_meeting_as_guest:*")
-    keys += frappe.cache.get_keys("rl:suite.meet.api.meeting.create:*")
-    keys += frappe.cache.get_keys("rl:suite.meet.api.meeting.get_public_meeting_preview:*")
-    keys += frappe.cache.get_keys("rl:suite.meet.api.meeting.check_meeting_access:*")
-    for key in keys:
-        frappe.cache.set(key, 0)  # nosemgrep
+    for pattern in (
+        "rl:suite.meet.api.meeting.join_meeting_as_guest:*",
+        "rl:suite.meet.api.meeting.create:*",
+        "rl:suite.meet.api.meeting.get_public_meeting_preview:*",
+        "rl:suite.meet.api.meeting.check_meeting_access:*",
+    ):
+        frappe.cache.delete_keys(pattern)

--- a/suite/meet/doctype/meet_room/meet_room.py
+++ b/suite/meet/doctype/meet_room/meet_room.py
@@ -9,8 +9,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from suite.meet import guest_access
 from suite.meet.utils.user import (
-    get_guest_session,
     get_user_info,
     unique_users,
 )
@@ -119,11 +119,6 @@ class MeetRoom(Document):
         user_info = get_user_info(user)
         if user_info and user_info.get("full_name"):
             return user_info.get("full_name")
-
-        if user.startswith("guest_"):
-            guest_session = get_guest_session(user)
-            if guest_session and guest_session.get("guest_name"):
-                return guest_session.get("guest_name")
 
         return user
 
@@ -246,10 +241,6 @@ class MeetRoom(Document):
             if user:
                 self.append("members", self.build_user_row(user))
 
-    def add_guest_to_members(self, guest_id: str):
-        self.validate_guest_id(guest_id)
-        self.add_user_to_table("members", guest_id, save=True, ignore_permissions=True)
-
     def get_waiting_room(self):
         """Get list of users waiting for approval"""
         return self.get_table_users("waiting_room")
@@ -257,10 +248,6 @@ class MeetRoom(Document):
     def add_to_waiting_room(self, user):
         """Add user to waiting room"""
         self.add_waiting_room_user(user)
-
-    def add_guest_to_waiting_room(self, guest_id: str):
-        self.validate_guest_id(guest_id)
-        self.add_waiting_room_user(guest_id, save=True, ignore_permissions=True)
 
     def remove_from_waiting_room(self, user):
         """Remove user from waiting room"""
@@ -293,23 +280,6 @@ class MeetRoom(Document):
             message={"meeting": self.name, "user": user, "approved_by": frappe.session.user},
             after_commit=True,
         )
-
-        # for guests
-        if user.startswith("guest_"):
-            session_data = get_guest_session(user)
-            if session_data:
-                guest_name = session_data.get("guest_name")
-                frappe.publish_realtime(
-                    "meet:guest_join_approved",
-                    {
-                        "meeting_id": self.name,
-                        "guest_id": user,
-                        "guest_name": guest_name,
-                        "message": "Your join request has been approved",
-                    },
-                    room=f"guest:{user}",
-                    after_commit=True,
-                )
 
         updated_waiting_users = self.get_waiting_room()
 
@@ -484,20 +454,20 @@ class MeetRoom(Document):
             if not user or user in users_notified:
                 continue
             users_notified.add(user)
-            if user.startswith("guest_"):
-                frappe.publish_realtime(
-                    "meeting:e2ee_enabled",
-                    payload,
-                    room=f"guest:{user}",
-                    after_commit=True,
-                )
-            else:
-                frappe.publish_realtime(
-                    "meeting:e2ee_enabled",
-                    payload,
-                    user=user,
-                    after_commit=True,
-                )
+            frappe.publish_realtime(
+                "meeting:e2ee_enabled",
+                payload,
+                user=user,
+                after_commit=True,
+            )
+
+        for lease in guest_access.list_admitted(self.name):
+            frappe.publish_realtime(
+                "meeting:e2ee_enabled",
+                payload,
+                room=f"guest:{lease.guest_id}",
+                after_commit=True,
+            )
 
         return True
 

--- a/suite/meet/guest_access.py
+++ b/suite/meet/guest_access.py
@@ -1,0 +1,367 @@
+import hashlib
+import json
+import secrets
+import time
+from dataclasses import asdict, dataclass
+
+import frappe
+
+PENDING_TTL = 30 * 60
+LEASE_TTL = 24 * 60 * 60
+GUEST_TOKEN_TTL = 5 * 60
+TERMINAL_TTL = 5 * 60
+ROOM_INDEX_TTL = LEASE_TTL + TERMINAL_TTL
+FRESH_JOIN_RATE_LIMIT = 10
+FRESH_JOIN_RATE_WINDOW = 60 * 60
+
+ACTIVE_STATUSES = {"pending", "admitted"}
+TERMINAL_STATUSES = {"expired", "rejected", "banned"}
+
+_COMPARE_AND_REPLACE = """
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+if ARGV[4] == '1' then
+    redis.call('ZADD', KEYS[2], ARGV[5], ARGV[6])
+else
+    redis.call('ZREM', KEYS[2], ARGV[6])
+end
+if redis.call('EXISTS', KEYS[2]) == 1 then
+    redis.call('EXPIRE', KEYS[2], ARGV[7])
+end
+return 1
+"""
+
+_COMPARE_AND_DELETE = """
+if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+    return 0
+end
+redis.call('DEL', KEYS[1])
+redis.call('ZREM', KEYS[2], ARGV[2])
+return 1
+"""
+
+_INCREMENT_WITH_EXPIRY = """
+local count = redis.call('INCR', KEYS[1])
+if count == 1 or redis.call('TTL', KEYS[1]) < 0 then
+    redis.call('EXPIRE', KEYS[1], ARGV[1])
+end
+return count
+"""
+
+
+class GuestAccessDenied(frappe.PermissionError):
+    pass
+
+
+class GuestLeaseExpired(GuestAccessDenied):
+    pass
+
+
+@dataclass(frozen=True)
+class GuestLease:
+    guest_id: str
+    proof_digest: str
+    room_id: str
+    guest_name: str
+    status: str
+    created_at: int
+    expires_at: int
+    absolute_expires_at: int
+    generation: int
+
+
+def create_lease(room_id: str, guest_name: str, *, admitted: bool) -> tuple[GuestLease, str]:
+    now = int(time.time())
+    guest_id = f"guest_{secrets.token_urlsafe(24)}"
+    session_token = secrets.token_urlsafe(24)
+    absolute_expires_at = now + LEASE_TTL
+    lease = GuestLease(
+        guest_id=guest_id,
+        proof_digest=_digest(session_token),
+        room_id=room_id,
+        guest_name=guest_name,
+        status="admitted" if admitted else "pending",
+        created_at=now,
+        expires_at=absolute_expires_at if admitted else now + PENDING_TTL,
+        absolute_expires_at=absolute_expires_at,
+        generation=1,
+    )
+    _write_new(lease)
+    return lease, session_token
+
+
+def enforce_fresh_join_rate_limit(ip_address: str) -> None:
+    count = frappe.cache.eval(
+        _INCREMENT_WITH_EXPIRY,
+        1,
+        _fresh_join_rate_key(ip_address),
+        FRESH_JOIN_RATE_WINDOW,
+    )
+    if count > FRESH_JOIN_RATE_LIMIT:
+        frappe.throw(
+            "Too many guest join attempts. Please try again later.",
+            frappe.RateLimitExceededError,
+        )
+
+
+def resume_for_join(
+    room_id: str,
+    guest_id: str | None,
+    session_token: str | None,
+) -> GuestLease | None:
+    if not guest_id or not session_token:
+        return None
+    lease = _read(guest_id)
+    if not lease:
+        return None
+    if not secrets.compare_digest(lease.proof_digest, _digest(session_token)):
+        return None
+    if lease.room_id != room_id:
+        raise GuestAccessDenied("Guest lease belongs to another room")
+    lease = _require_live(lease)
+    if lease.status in TERMINAL_STATUSES:
+        raise GuestAccessDenied(f"Guest lease is {lease.status}")
+    if lease.status not in ACTIVE_STATUSES:
+        return None
+    return lease
+
+
+def authorize(
+    room_id: str,
+    guest_id: str,
+    session_token: str | None,
+    *,
+    statuses: set[str] | None = None,
+) -> GuestLease:
+    if not session_token:
+        raise GuestAccessDenied("Guest session proof required")
+    lease = _read(guest_id)
+    if not lease or not secrets.compare_digest(lease.proof_digest, _digest(session_token)):
+        raise GuestAccessDenied("Invalid guest session")
+    if lease.room_id != room_id:
+        raise GuestAccessDenied("Guest lease belongs to another room")
+    lease = _require_live(lease)
+    if statuses is not None and lease.status not in statuses:
+        raise GuestAccessDenied("Guest access denied")
+    return lease
+
+
+def validate(room_id: str, guest_id: str, session_token: str | None) -> bool:
+    return get_status(room_id, guest_id, session_token) in ACTIVE_STATUSES
+
+
+def get_status(room_id: str, guest_id: str, session_token: str | None) -> str | None:
+    try:
+        lease = authorize(room_id, guest_id, session_token)
+    except GuestAccessDenied:
+        return None
+    return lease.status
+
+
+def get_guest(guest_id: str) -> GuestLease | None:
+    lease = _read(guest_id)
+    if not lease:
+        return None
+    try:
+        lease = _require_live(lease)
+    except GuestLeaseExpired:
+        return None
+    return lease if lease.status in ACTIVE_STATUSES else None
+
+
+def list_pending(room_id: str) -> list[GuestLease]:
+    return _list_room(room_id, "pending")
+
+
+def list_admitted(room_id: str) -> list[GuestLease]:
+    return _list_room(room_id, "admitted")
+
+
+def _list_room(room_id: str, status: str) -> list[GuestLease]:
+    now = int(time.time())
+    index_key = _room_key(room_id)
+    guest_ids = frappe.cache.zrangebyscore(index_key, now + 1, "+inf")
+    matches = []
+    for raw_guest_id in guest_ids:
+        guest_id = _text(raw_guest_id)
+        lease = _read(guest_id)
+        if not lease or lease.room_id != room_id:
+            frappe.cache.zrem(index_key, guest_id)
+            continue
+        if lease.expires_at <= now:
+            continue
+        if lease.status == status:
+            matches.append(lease)
+    frappe.cache.zremrangebyscore(index_key, "-inf", now)
+    return matches
+
+
+def admit(room_id: str, guest_id: str) -> GuestLease:
+    return _transition(room_id, guest_id, {"pending", "admitted"}, "admitted")
+
+
+def reject(room_id: str, guest_id: str) -> GuestLease:
+    return _transition(room_id, guest_id, {"pending"}, "rejected")
+
+
+def ban(room_id: str, guest_id: str) -> GuestLease:
+    return _transition(room_id, guest_id, {"pending", "admitted"}, "banned")
+
+
+def remaining_authorization_ttl(lease: GuestLease) -> int:
+    return min(GUEST_TOKEN_TTL, max(0, lease.expires_at - int(time.time())))
+
+
+def _transition(
+    room_id: str,
+    guest_id: str,
+    allowed_statuses: set[str],
+    status: str,
+) -> GuestLease:
+    lock = frappe.cache.lock(_lock_key(room_id), timeout=15)
+    if not lock.acquire(blocking=True, blocking_timeout=5):
+        raise RuntimeError("Guest access is busy")
+    try:
+        lease = _read(guest_id)
+        if not lease or lease.room_id != room_id:
+            raise GuestAccessDenied("Guest lease not found")
+        lease = _require_live(lease)
+        if lease.status == status:
+            return lease
+        if lease.status not in allowed_statuses:
+            raise GuestAccessDenied("Guest transition denied")
+        expires_at = lease.absolute_expires_at if status == "admitted" else int(time.time()) + TERMINAL_TTL
+        updated = GuestLease(
+            **{
+                **asdict(lease),
+                "status": status,
+                "expires_at": expires_at,
+                "generation": lease.generation + 1,
+            }
+        )
+        if not _write(updated, expected=lease):
+            raise GuestAccessDenied("Guest lease changed during transition")
+        return updated
+    finally:
+        lock.release()
+
+
+def _require_live(lease: GuestLease) -> GuestLease:
+    now = int(time.time())
+    if lease.expires_at > now:
+        return lease
+
+    if lease.status in ACTIVE_STATUSES:
+        expired = GuestLease(
+            **{
+                **asdict(lease),
+                "status": "expired",
+                "expires_at": now + TERMINAL_TTL,
+                "generation": lease.generation + 1,
+            }
+        )
+        if _write(expired, expected=lease, indexed=False):
+            return expired
+    else:
+        _delete(lease)
+
+    current = _read(lease.guest_id)
+    if current and current != lease:
+        return _require_live(current)
+    raise GuestLeaseExpired("Guest lease expired")
+
+
+def _read(guest_id: str) -> GuestLease | None:
+    raw = frappe.cache.get(_guest_key(guest_id))
+    if raw is None:
+        return None
+    try:
+        value = json.loads(_text(raw))
+        return GuestLease(**value)
+    except (TypeError, ValueError, KeyError):
+        return None
+
+
+def _write_new(lease: GuestLease) -> None:
+    ttl = _retention_ttl(lease)
+    pipeline = frappe.cache.pipeline(transaction=True)
+    pipeline.set(_guest_key(lease.guest_id), _serialize(lease), ex=ttl, nx=True)
+    pipeline.zadd(_room_key(lease.room_id), {lease.guest_id: lease.expires_at})
+    pipeline.expire(_room_key(lease.room_id), ROOM_INDEX_TTL)
+    result = pipeline.execute()
+    if len(result) != 3 or result[0] is not True or result[2] is not True:
+        raise RuntimeError("Failed to create guest lease")
+
+
+def _write(lease: GuestLease, *, expected: GuestLease, indexed: bool = True) -> bool:
+    return bool(
+        frappe.cache.eval(
+            _COMPARE_AND_REPLACE,
+            2,
+            _guest_key(lease.guest_id),
+            _room_key(lease.room_id),
+            _serialize(expected),
+            _serialize(lease),
+            _retention_ttl(lease),
+            int(indexed),
+            lease.expires_at,
+            lease.guest_id,
+            ROOM_INDEX_TTL,
+        )
+    )
+
+
+def _delete(lease: GuestLease) -> bool:
+    return bool(
+        frappe.cache.eval(
+            _COMPARE_AND_DELETE,
+            2,
+            _guest_key(lease.guest_id),
+            _room_key(lease.room_id),
+            _serialize(lease),
+            lease.guest_id,
+        )
+    )
+
+
+def _retention_ttl(lease: GuestLease) -> int:
+    ttl = lease.expires_at - int(time.time())
+    if lease.status in ACTIVE_STATUSES:
+        ttl += TERMINAL_TTL
+    return max(1, ttl)
+
+
+def _serialize(lease: GuestLease) -> str:
+    return json.dumps(asdict(lease))
+
+
+def _digest(session_token: str) -> str:
+    return hashlib.sha256(session_token.encode()).hexdigest()
+
+
+def _site() -> str:
+    return str(frappe.local.site)
+
+
+def _guest_key(guest_id: str) -> str:
+    return f"meet:guest-lease:{_site()}:{guest_id}"
+
+
+def _room_key(room_id: str) -> str:
+    return f"meet:guest-room:{_site()}:{room_id}"
+
+
+def _lock_key(room_id: str) -> str:
+    return f"meet:guest-lock:{_site()}:{room_id}"
+
+
+def _fresh_join_rate_key(ip_address: str) -> bytes:
+    return frappe.cache.make_key(
+        f"rl:suite.meet.api.meeting.join_meeting_as_guest:fresh:{_digest(ip_address)}"
+    )
+
+
+def _text(value: str | bytes) -> str:
+    return value.decode() if isinstance(value, bytes) else value

--- a/suite/meet/sfu-server/src/server/AuthManager.ts
+++ b/suite/meet/sfu-server/src/server/AuthManager.ts
@@ -4,6 +4,8 @@ import type { JWTPayload } from '../types';
 import { loggers } from '../utils/logger';
 import type { RecordingGrantManager } from './RecordingGrantManager';
 
+const TOKEN_EXPIRY_GRACE_MS = 5000;
+
 export class AuthManager {
 	private jwtSecret: string;
 
@@ -36,6 +38,7 @@ export class AuthManager {
 				socket.isHost = false;
 				socket.isCohost = false;
 				socket.isGuest = false;
+				socket.guestGeneration = undefined;
 				socket.scope = 'recording';
 				socket.e2eeRequired = false;
 				socket.e2eeReady = false;
@@ -61,6 +64,7 @@ export class AuthManager {
 			socket.currentToken = token;
 			socket.tokenExpiresAt = decoded.exp ? decoded.exp * 1000 : undefined;
 			socket.isGuest = decoded.is_guest || false;
+			socket.guestGeneration = decoded.guest_generation;
 
 			loggers.authManager.info(
 				'Authenticated user: %s for meeting: %s (site: %s)',
@@ -98,10 +102,23 @@ export class AuthManager {
 			throw new Error('Token site mismatch');
 		}
 
+		if (
+			(decoded.scope ?? 'presence-preview') !== socket.scope ||
+			Boolean(decoded.is_guest) !== Boolean(socket.isGuest) ||
+			(socket.isGuest && decoded.guest_generation !== socket.guestGeneration)
+		) {
+			throw new Error('Token identity mismatch');
+		}
+
+		this.clearTokenExpiryTimer(socket);
 		socket.currentToken = token;
 		socket.tokenExpiresAt = decoded.exp ? decoded.exp * 1000 : undefined;
 		socket.isHost = decoded.is_host || false;
 		socket.isCohost = decoded.is_cohost || false;
+		socket.userName = decoded.user_name;
+		socket.scope = decoded.scope ?? 'presence-preview';
+		socket.isGuest = decoded.is_guest || false;
+		socket.guestGeneration = decoded.guest_generation;
 		socket.e2eeRequired = Boolean(decoded.e2ee_required);
 		socket.e2eeReady = socket.e2eeRequired
 			? wasE2EERequired && wasE2EEReady
@@ -127,14 +144,14 @@ export class AuthManager {
 	}
 
 	triggerTokenExpiry(socket: Socket, reason: string): void {
-		if (socket.disconnected) {
+		if (socket.disconnected || socket.tokenExpiryTimer) {
 			return;
 		}
 
 		const timestamp = new Date().toISOString();
 
 		loggers.authManager.warn(
-			'Disconnecting socket %s (user %s) due to expired token (%s)',
+			'Token expired for socket %s (user %s); awaiting refresh (%s)',
 			socket.id,
 			socket.userId,
 			reason,
@@ -157,18 +174,22 @@ export class AuthManager {
 			);
 		}
 
-		setImmediate(() => {
-			if (!socket.disconnected) {
+		socket.tokenExpiryTimer = setTimeout(() => {
+			socket.tokenExpiryTimer = undefined;
+			if (!socket.disconnected && this.isTokenExpired(socket)) {
 				socket.disconnect(true);
 			}
-		});
+		}, TOKEN_EXPIRY_GRACE_MS);
+		socket.tokenExpiryTimer.unref();
 	}
 
 	cleanupSocket(socket: Socket): void {
+		this.clearTokenExpiryTimer(socket);
 		socket.currentToken = undefined;
 		socket.tokenExpiresAt = undefined;
 		socket.e2eeReady = undefined;
 		socket.e2eeRequired = undefined;
+		socket.guestGeneration = undefined;
 	}
 
 	ensurePresenceAccess(socket: Socket): void {
@@ -230,6 +251,11 @@ export class AuthManager {
 			throw new Error('Guests are not permitted to perform this action.');
 		}
 	}
+
+	private clearTokenExpiryTimer(socket: Socket): void {
+		if (socket.tokenExpiryTimer) clearTimeout(socket.tokenExpiryTimer);
+		socket.tokenExpiryTimer = undefined;
+	}
 }
 
 function parseParticipantClaims(value: unknown): JWTPayload {
@@ -251,6 +277,12 @@ function parseParticipantClaims(value: unknown): JWTPayload {
 	const sessionId = optionalString(value, 'session_id');
 	const isCohost = optionalBoolean(value, 'is_cohost');
 	const isGuest = optionalBoolean(value, 'is_guest');
+	const guestGeneration = isGuest
+		? optionalInteger(value, 'guest_generation')
+		: undefined;
+	if (isGuest && (guestGeneration === undefined || guestGeneration < 1)) {
+		throw new Error('Invalid participant claims');
+	}
 	const e2eeRequired = optionalBoolean(value, 'e2ee_required');
 	const exp = optionalInteger(value, 'exp');
 	const iat = optionalInteger(value, 'iat');
@@ -263,6 +295,9 @@ function parseParticipantClaims(value: unknown): JWTPayload {
 		...(userAvatar !== undefined ? { user_avatar: userAvatar } : {}),
 		...(isCohost !== undefined ? { is_cohost: isCohost } : {}),
 		...(isGuest !== undefined ? { is_guest: isGuest } : {}),
+		...(guestGeneration !== undefined
+			? { guest_generation: guestGeneration }
+			: {}),
 		...(scope !== undefined ? { scope } : {}),
 		...(e2eeRequired !== undefined ? { e2ee_required: e2eeRequired } : {}),
 		...(sessionId !== undefined ? { session_id: sessionId } : {}),

--- a/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
+++ b/suite/meet/sfu-server/src/server/E2EEEpochRelay.ts
@@ -15,7 +15,7 @@ import {
 	type PersistedE2eePendingCommitRequest,
 } from './E2eeCoordinatorPersistence';
 import type { E2eeRosterStore } from './E2eeRosterStore';
-import { checkSocketRateLimits } from './handlers/utils';
+import { checkSocketRateLimits, getRoomId } from './handlers/utils';
 
 type TypedSocket = Socket<
 	ClientToServerEvents,
@@ -134,6 +134,7 @@ export class E2EEEpochRelay {
 		const allowed = checkSocketRateLimits(
 			socket,
 			this.rateLimiter,
+			`e2ee-epoch:${getRoomId(socket)}`,
 			E2EE_EPOCH_USER_LIMIT,
 			E2EE_EPOCH_IP_LIMIT,
 			E2EE_EPOCH_RATE_WINDOW_MS,

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -59,6 +59,7 @@ export class RoomRegistry {
 	>();
 	private nextSenderIdByRoom: Map<string, number> = new Map();
 	private participantToSender: Map<string, Map<string, number>> = new Map();
+	private revokedParticipants = new Map<string, Set<string>>();
 
 	constructor(io: Server<ClientToServerEvents, ServerToClientEvents>) {
 		this.io = io;
@@ -261,6 +262,19 @@ export class RoomRegistry {
 		return (this.participantConnections.get(roomId)?.size ?? 0) > 0;
 	}
 
+	revokeParticipant(roomId: string, participantId: string): void {
+		let revoked = this.revokedParticipants.get(roomId);
+		if (!revoked) {
+			revoked = new Set();
+			this.revokedParticipants.set(roomId, revoked);
+		}
+		revoked.add(participantId);
+	}
+
+	isParticipantRevoked(roomId: string, participantId: string): boolean {
+		return this.revokedParticipants.get(roomId)?.has(participantId) ?? false;
+	}
+
 	getRecorderSockets(roomId: string): Socket[] {
 		return [...(this.recorderSockets.get(roomId) ?? [])]
 			.map((socketId) => this.io.sockets.sockets.get(socketId))
@@ -360,6 +374,7 @@ export class RoomRegistry {
 		this.recorderPeerSockets.delete(roomId);
 		this.nextSenderIdByRoom.delete(roomId);
 		this.participantToSender.delete(roomId);
+		this.revokedParticipants.delete(roomId);
 	}
 
 	emitToScope<Event extends ServerEventName>(

--- a/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
+++ b/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
@@ -212,7 +212,7 @@ export class SocketHandlerManager {
 						outcome: 'failure',
 					});
 					this.authManager.triggerTokenExpiry(socket, 'middleware_guard');
-					return;
+					if (packet[0] !== 'auth:update_token') return;
 				}
 				next();
 			});

--- a/suite/meet/sfu-server/src/server/__tests__/AuthManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/AuthManager.test.ts
@@ -1,13 +1,20 @@
 import * as jwt from 'jsonwebtoken';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { JWTPayload } from '../../types';
 import { AuthManager } from '../AuthManager';
 import { createMockSocket } from './test-helpers';
 
 const SECRET = 'test-secret';
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 function token(
-	overrides: Partial<JWTPayload> & { user_avatar?: string | null } = {},
+	overrides: Partial<JWTPayload> & {
+		user_avatar?: string | null;
+		guest_generation?: number;
+	} = {},
 ): string {
 	return jwt.sign(
 		{
@@ -55,6 +62,123 @@ describe('AuthManager', () => {
 		expect(manager.authenticateSocket(socket)).toBe(true);
 	});
 
+	it('rejects legacy guest tokens without an authorization generation', () => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			handshake: {
+				auth: {
+					token: token({ user_id: 'guest_1', is_guest: true }),
+				},
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(manager.authenticateSocket(socket)).toBe(false);
+	});
+
+	it('rejects guest tokens with a non-positive authorization generation', () => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			handshake: {
+				auth: {
+					token: token({
+						user_id: 'guest_1',
+						is_guest: true,
+						guest_generation: 0,
+					}),
+				},
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(manager.authenticateSocket(socket)).toBe(false);
+	});
+
+	it('binds guest authorization generation and preserves it on refresh', () => {
+		const manager = new AuthManager(SECRET);
+		const authToken = token({
+			user_id: 'guest_1',
+			is_guest: true,
+			guest_generation: 3,
+		});
+		const socket = createMockSocket({
+			handshake: {
+				auth: { token: authToken },
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(manager.authenticateSocket(socket)).toBe(true);
+		expect(socket.guestGeneration).toBe(3);
+		expect(() =>
+			manager.updateSocketToken(
+				socket,
+				token({
+					user_id: 'guest_1',
+					is_guest: true,
+					guest_generation: 3,
+				}),
+			),
+		).not.toThrow();
+	});
+
+	it.each([
+		['missing', {}],
+		['changed', { guest_generation: 4 }],
+	] as const)('rejects guest token refresh with %s generation', (_case, claims) => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			userId: 'guest_1',
+			meetingId: 'room-1',
+			site: 'site-a',
+			scope: 'full',
+			isGuest: true,
+			guestGeneration: 3,
+			handshake: {
+				auth: {},
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(() =>
+			manager.updateSocketToken(
+				socket,
+				token({ user_id: 'guest_1', is_guest: true, ...claims }),
+			),
+		).toThrow();
+	});
+
+	it('rejects guest token refresh with a different guest identity', () => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			userId: 'guest_1',
+			meetingId: 'room-1',
+			site: 'site-a',
+			scope: 'full',
+			isGuest: true,
+			guestGeneration: 3,
+		});
+
+		expect(() =>
+			manager.updateSocketToken(
+				socket,
+				token({
+					user_id: 'guest_2',
+					is_guest: true,
+					guest_generation: 3,
+				}),
+			),
+		).toThrow('Token user mismatch');
+	});
+
 	it('rejects token refreshes that change site', () => {
 		const manager = new AuthManager(SECRET);
 		const socket = createMockSocket({
@@ -94,6 +218,107 @@ describe('AuthManager', () => {
 
 		expect(socket.isHost).toBe(false);
 		expect(socket.isCohost).toBe(true);
+	});
+
+	it.each([
+		['scope', { scope: 'presence-preview' }],
+		['guest status', { is_guest: true, guest_generation: 1 }],
+	] as const)('rejects token refreshes that change %s', (_field, override) => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			userId: 'user-1',
+			meetingId: 'room-1',
+			site: 'site-a',
+			scope: 'full',
+			isGuest: false,
+			handshake: {
+				auth: {},
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		expect(() => manager.updateSocketToken(socket, token(override))).toThrow(
+			'Token identity mismatch',
+		);
+	});
+
+	it('updates the validated display identity from a replacement token', () => {
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			userId: 'user-1',
+			userName: 'Old Name',
+			meetingId: 'room-1',
+			site: 'site-a',
+			scope: 'full',
+			isGuest: false,
+			handshake: {
+				auth: {},
+				query: {},
+				headers: {},
+				address: '127.0.0.1',
+			} as never,
+		});
+
+		manager.updateSocketToken(socket, token({ user_name: 'Current Name' }));
+
+		expect(socket.userName).toBe('Current Name');
+	});
+
+	it('allows a valid refresh during the expired-token grace period', async () => {
+		vi.useFakeTimers();
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({
+			userId: 'user-1',
+			meetingId: 'room-1',
+			site: 'site-a',
+			scope: 'full',
+			isGuest: false,
+			tokenExpiresAt: Date.now() - 1,
+		});
+		const disconnect = vi.spyOn(socket, 'disconnect');
+
+		manager.triggerTokenExpiry(socket, 'middleware_guard');
+		manager.updateSocketToken(
+			socket,
+			token({ exp: Math.floor(Date.now() / 1000) + 60 }),
+		);
+		await vi.advanceTimersByTimeAsync(5000);
+
+		expect(disconnect).not.toHaveBeenCalled();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it('disconnects after the expired-token grace period without refresh', async () => {
+		vi.useFakeTimers();
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({ tokenExpiresAt: Date.now() - 1 });
+		const disconnect = vi.spyOn(socket, 'disconnect');
+
+		manager.triggerTokenExpiry(socket, 'middleware_guard');
+		await vi.advanceTimersByTimeAsync(4999);
+		expect(disconnect).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(1);
+		expect(disconnect).toHaveBeenCalledWith(true);
+	});
+
+	it('deduplicates and cleans the expired-token grace timer', () => {
+		vi.useFakeTimers();
+		const manager = new AuthManager(SECRET);
+		const socket = createMockSocket({ tokenExpiresAt: Date.now() - 1 });
+
+		manager.triggerTokenExpiry(socket, 'middleware_guard');
+		manager.triggerTokenExpiry(socket, 'idle_sweep');
+
+		expect(vi.getTimerCount()).toBe(1);
+		expect(
+			socket.emitCalls.filter(({ event }) => event === 'auth:expired'),
+		).toHaveLength(1);
+
+		manager.cleanupSocket(socket);
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it('rejects recording scope on the participant JWT path', () => {

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -265,6 +265,25 @@ describe('RoomRegistry', () => {
 		expect(registry.hasHumanParticipants('r1')).toBe(false);
 	});
 
+	it('blocks a room-scoped banned participant until room cleanup', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+
+		registry.revokeParticipant('r1', 'guest_1');
+		expect(registry.isParticipantRevoked('r1', 'guest_1')).toBe(true);
+		expect(registry.isParticipantRevoked('r2', 'guest_1')).toBe(false);
+
+		registry.cleanupRoom('r1');
+		expect(registry.isParticipantRevoked('r1', 'guest_1')).toBe(false);
+	});
+
+	it('does not revoke a removed participant', () => {
+		const { io } = makeIo();
+		const registry = new RoomRegistry(io);
+
+		expect(registry.isParticipantRevoked('r1', 'guest_1')).toBe(false);
+	});
+
 	it('assigns independent E2EE sender IDs to participant connections', () => {
 		const { io } = makeIo();
 		const registry = new RoomRegistry(io);

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	createManager,
 	createMockSocket,
@@ -51,6 +51,10 @@ function emitJoin(
 		callback,
 	);
 }
+
+afterEach(() => {
+	vi.useRealTimers();
+});
 
 describe('SocketHandlerManager characterization', () => {
 	it('middleware rejects sockets when authentication fails', () => {
@@ -483,6 +487,24 @@ describe('SocketHandlerManager characterization', () => {
 				participantId: 'user-1',
 				userData: expect.objectContaining({ userId: 'user-1', name: 'Alice' }),
 			}),
+		);
+	});
+
+	it('derives guest participant metadata from the signed socket identity', async () => {
+		const harness = createManager();
+		const socket = connectFullSocket(harness, {
+			id: 'malicious-guest',
+			userId: 'guest_1',
+			isGuest: true,
+		});
+
+		emitJoin(socket, { userId: 'guest_1', isGuest: false });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.addPeer).toHaveBeenCalledWith(
+			'room-1',
+			'malicious-guest',
+			expect.objectContaining({ is_guest: true }),
 		);
 	});
 
@@ -1056,11 +1078,16 @@ describe('SocketHandlerManager characterization', () => {
 
 		target.emitCalls.length = 0;
 		host.emitCalls.length = 0;
+		const hostCallback = vi.fn();
 
-		host.fire('host_control', {
-			action: 'mute_participant',
-			targetParticipantId: 'target-1',
-		});
+		host.fire(
+			'host_control',
+			{
+				action: 'mute_participant',
+				targetParticipantId: 'target-1',
+			},
+			hostCallback,
+		);
 		expect(harness.mediasoup.participantExistsInRoom).toHaveBeenCalledWith(
 			'room-1',
 			'target-1',
@@ -1078,6 +1105,7 @@ describe('SocketHandlerManager characterization', () => {
 			}),
 		);
 		expect(host.emitCalls.some((c) => c.event === 'sfu_error')).toBe(false);
+		expect(hostCallback).toHaveBeenCalledWith({ success: true });
 
 		const nonHost = connectFullSocket(harness, {
 			id: 'sock-nonhost',
@@ -1101,11 +1129,16 @@ describe('SocketHandlerManager characterization', () => {
 
 		nonHost.emitCalls.length = 0;
 		anotherTarget.emitCalls.length = 0;
+		const nonHostCallback = vi.fn();
 
-		nonHost.fire('host_control', {
-			action: 'mute_participant',
-			targetParticipantId: 'target-2',
-		});
+		nonHost.fire(
+			'host_control',
+			{
+				action: 'mute_participant',
+				targetParticipantId: 'target-2',
+			},
+			nonHostCallback,
+		);
 
 		const nonHostErr = nonHost.emitCalls.find((c) => c.event === 'sfu_error');
 		expect(nonHostErr).toBeDefined();
@@ -1117,6 +1150,233 @@ describe('SocketHandlerManager characterization', () => {
 		expect(
 			anotherTarget.emitCalls.some((c) => c.event === 'host_control_update'),
 		).toBe(false);
+		expect(nonHostCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Only host or co-host can control participants',
+		});
+	});
+
+	it('ban disconnects a guest and rejects rejoin while remove permits rejoin', async () => {
+		vi.useFakeTimers();
+		const harness = createManager();
+		const host = connectFullSocket(harness, {
+			id: 'ban-host',
+			userId: 'host-1',
+			isHost: true,
+		});
+		emitJoin(host, { userId: 'host-1' });
+		await vi.advanceTimersByTimeAsync(0);
+
+		const banned = connectFullSocket(harness, {
+			id: 'banned-socket',
+			userId: 'guest_banned',
+			isGuest: true,
+		});
+		emitJoin(banned, { userId: 'guest_banned', isGuest: true });
+		await vi.advanceTimersByTimeAsync(0);
+		const banAcknowledgement = vi.fn();
+		host.fire(
+			'host_control',
+			{
+				action: 'ban_participant',
+				targetParticipantId: 'guest_banned',
+			},
+			banAcknowledgement,
+		);
+		expect(banAcknowledgement).toHaveBeenCalledWith({ success: true });
+		expect(banned.emitCalls).toContainEqual({
+			event: 'host_control_update',
+			data: expect.objectContaining({ action: 'ban_participant' }),
+		});
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(harness.io.socketsMap.has(banned.id)).toBe(false);
+
+		const bannedRejoin = connectFullSocket(harness, {
+			id: 'banned-rejoin',
+			userId: 'guest_banned',
+			isGuest: true,
+		});
+		const bannedCallback = vi.fn();
+		emitJoin(
+			bannedRejoin,
+			{ userId: 'guest_banned', isGuest: true },
+			bannedCallback,
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(bannedCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Guest is banned from this room',
+		});
+
+		const removed = connectFullSocket(harness, {
+			id: 'removed-socket',
+			userId: 'guest_removed',
+			isGuest: true,
+		});
+		emitJoin(removed, { userId: 'guest_removed', isGuest: true });
+		await vi.advanceTimersByTimeAsync(0);
+		const removeAcknowledgement = vi.fn();
+		host.fire(
+			'host_control',
+			{
+				action: 'kick_participant',
+				targetParticipantId: 'guest_removed',
+			},
+			removeAcknowledgement,
+		);
+		expect(removeAcknowledgement).toHaveBeenCalledWith({ success: true });
+		await vi.advanceTimersByTimeAsync(1000);
+
+		const removedRejoin = connectFullSocket(harness, {
+			id: 'removed-rejoin',
+			userId: 'guest_removed',
+			isGuest: true,
+		});
+		const removedCallback = vi.fn();
+		emitJoin(
+			removedRejoin,
+			{ userId: 'guest_removed', isGuest: true },
+			removedCallback,
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(removedCallback).toHaveBeenCalledWith(
+			expect.objectContaining({ success: true }),
+		);
+
+		harness.manager.stop();
+	});
+
+	it.each([
+		'rejects',
+		'hangs',
+	] as const)('disconnects a banned guest when E2EE removal signaling %s', async (failure) => {
+		vi.useFakeTimers();
+		const harness = createManager();
+		const relay = (
+			harness.manager as unknown as {
+				e2eeEpochRelay: {
+					requestCommitForRemoval: () => Promise<boolean>;
+				};
+			}
+		).e2eeEpochRelay;
+		vi.spyOn(relay, 'requestCommitForRemoval').mockImplementation(() =>
+			failure === 'rejects'
+				? Promise.reject(new Error('signaling failed'))
+				: new Promise<boolean>(() => {}),
+		);
+		const host = connectFullSocket(harness, {
+			id: `host-${failure}`,
+			userId: 'host-1',
+			isHost: true,
+		});
+		emitJoin(host, { userId: 'host-1' });
+		await vi.advanceTimersByTimeAsync(0);
+
+		const guest = connectFullSocket(harness, {
+			id: `guest-${failure}`,
+			userId: 'guest_1',
+			isGuest: true,
+		});
+		emitJoin(guest, { userId: 'guest_1', isGuest: true });
+		await vi.advanceTimersByTimeAsync(0);
+		guest.e2eeRequired = true;
+
+		const acknowledgement = vi.fn();
+		host.fire(
+			'host_control',
+			{
+				action: 'ban_participant',
+				targetParticipantId: 'guest_1',
+			},
+			acknowledgement,
+		);
+		await vi.advanceTimersByTimeAsync(0);
+		expect(acknowledgement).toHaveBeenCalledWith({ success: true });
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(harness.io.socketsMap.has(guest.id)).toBe(false);
+		harness.manager.stop();
+	});
+
+	it('rejects attempts to ban authenticated participants', async () => {
+		const harness = createManager();
+		const host = connectFullSocket(harness, {
+			id: 'authenticated-ban-host',
+			userId: 'host-1',
+			isHost: true,
+		});
+		emitJoin(host, { userId: 'host-1' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const target = connectFullSocket(harness, {
+			id: 'authenticated-ban-target',
+			userId: 'user-2',
+			isGuest: false,
+		});
+		emitJoin(target, { userId: 'user-2' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const acknowledgement = vi.fn();
+		host.fire(
+			'host_control',
+			{
+				action: 'ban_participant',
+				targetParticipantId: 'user-2',
+			},
+			acknowledgement,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(host.emitCalls).toContainEqual({
+			event: 'sfu_error',
+			data: expect.objectContaining({ error: 'Only guests can be banned' }),
+		});
+		expect(harness.io.socketsMap.has(target.id)).toBe(true);
+		expect(target.emitCalls).not.toContainEqual({
+			event: 'host_control_update',
+			data: expect.anything(),
+		});
+		expect(acknowledgement).toHaveBeenCalledWith({
+			success: false,
+			error: 'Only guests can be banned',
+		});
+		harness.manager.stop();
+	});
+
+	it('acknowledges and records an absent guest ban', async () => {
+		const harness = createManager();
+		const host = connectFullSocket(harness, {
+			id: 'absent-ban-host',
+			userId: 'host-1',
+			isHost: true,
+		});
+		emitJoin(host, { userId: 'host-1' });
+		await new Promise((resolve) => setImmediate(resolve));
+		const acknowledgement = vi.fn();
+
+		host.fire(
+			'host_control',
+			{
+				action: 'ban_participant',
+				targetParticipantId: 'guest_absent',
+			},
+			acknowledgement,
+		);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(acknowledgement).toHaveBeenCalledWith({ success: true });
+		const guest = connectFullSocket(harness, {
+			id: 'absent-banned-rejoin',
+			userId: 'guest_absent',
+			isGuest: true,
+		});
+		const joinCallback = vi.fn();
+		emitJoin(guest, { userId: 'guest_absent', isGuest: true }, joinCallback);
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(joinCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Guest is banned from this room',
+		});
+		harness.manager.stop();
 	});
 
 	it('create_producer broadcasts screen producers to existing full-access participants', async () => {
@@ -1873,6 +2133,28 @@ describe('SocketHandlerManager characterization', () => {
 	});
 
 	describe('idle expiry sweep', () => {
+		it('permits only token refresh packets while the token is expired', () => {
+			const harness = createManager();
+			const socket = connectFullSocket(harness, { id: 'expired-middleware' });
+			harness.authManager.isTokenExpired.mockReturnValue(true);
+			const refreshNext = vi.fn();
+			const joinNext = vi.fn();
+
+			socket.packetMiddleware?.(
+				['auth:update_token', { token: 'fresh' }],
+				refreshNext,
+			);
+			socket.packetMiddleware?.(['join_room', {}], joinNext);
+
+			expect(refreshNext).toHaveBeenCalledOnce();
+			expect(joinNext).not.toHaveBeenCalled();
+			expect(harness.authManager.triggerTokenExpiry).toHaveBeenCalledWith(
+				socket,
+				'middleware_guard',
+			);
+			harness.manager.stop();
+		});
+
 		it('disconnects sockets whose token has expired, leaves non-expired ones alone', () => {
 			const harness = createManager();
 			const expired = connectFullSocket(harness, { id: 'sock-exp' });

--- a/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
@@ -5,25 +5,29 @@ import { findSocketsByParticipantId } from './utils';
 
 export function registerHostControlHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
-		socket.on('host_control', async (data) => {
+		socket.on('host_control', async (data, callback) => {
+			const acknowledge =
+				typeof callback === 'function' ? callback : () => undefined;
+			const fail = (error: string) => {
+				socket.emit('sfu_error', {
+					error,
+					timestamp: new Date().toISOString(),
+				});
+				acknowledge({ success: false, error });
+			};
+
 			try {
 				deps.authManager.ensureFullAccess(socket);
 				const { action, targetParticipantId } = data;
 				const roomId = socket.roomId;
 
 				if (!roomId || !socket.participantId) {
-					socket.emit('sfu_error', {
-						error: 'Not in a room',
-						timestamp: new Date().toISOString(),
-					});
+					fail('Not in a room');
 					return;
 				}
 
 				if (!socket.isHost && !socket.isCohost) {
-					socket.emit('sfu_error', {
-						error: 'Only host or co-host can control participants',
-						timestamp: new Date().toISOString(),
-					});
+					fail('Only host or co-host can control participants');
 					loggers.socketHandler.warn(
 						'Non-host/co-host %s attempted host control in room %s',
 						socket.participantId,
@@ -32,28 +36,45 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 					return;
 				}
 
-				if (
-					!deps.mediasoup.participantExistsInRoom(roomId, targetParticipantId)
-				) {
-					socket.emit('sfu_error', {
-						error: 'Target participant not found',
-						timestamp: new Date().toISOString(),
-					});
-					return;
-				}
+				let targetSockets: Socket[];
+				if (action === 'ban_participant') {
+					if (
+						typeof targetParticipantId !== 'string' ||
+						!targetParticipantId.startsWith('guest_') ||
+						targetParticipantId.length === 'guest_'.length
+					) {
+						throw new Error('Only guests can be banned');
+					}
+					targetSockets = findSocketsByParticipantId(
+						deps.io,
+						roomId,
+						targetParticipantId,
+					);
+					if (targetSockets.some((targetSocket) => !targetSocket.isGuest)) {
+						throw new Error('Only guests can be banned');
+					}
+					deps.registry.revokeParticipant(roomId, targetParticipantId);
+					if (targetSockets.length === 0) {
+						acknowledge({ success: true });
+						return;
+					}
+				} else {
+					if (
+						!deps.mediasoup.participantExistsInRoom(roomId, targetParticipantId)
+					) {
+						fail('Target participant not found');
+						return;
+					}
 
-				const targetSockets = findSocketsByParticipantId(
-					deps.io,
-					roomId,
-					targetParticipantId,
-				);
-
-				if (targetSockets.length === 0) {
-					socket.emit('sfu_error', {
-						error: 'Target participant socket not found',
-						timestamp: new Date().toISOString(),
-					});
-					return;
+					targetSockets = findSocketsByParticipantId(
+						deps.io,
+						roomId,
+						targetParticipantId,
+					);
+					if (targetSockets.length === 0) {
+						fail('Target participant socket not found');
+						return;
+					}
 				}
 
 				switch (action) {
@@ -73,10 +94,36 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 							roomId,
 						);
 						break;
-					case 'kick_participant': {
+					case 'kick_participant':
+					case 'ban_participant': {
 						const targetSenderIds = targetSockets
 							.map((targetSocket) => targetSocket.senderId)
 							.filter((senderId): senderId is number => senderId !== undefined);
+						let participantDeparted = false;
+						for (const targetSocket of targetSockets) {
+							participantDeparted =
+								deps.registry.releaseParticipant(
+									targetSocket,
+									roomId,
+									targetParticipantId,
+								) || participantDeparted;
+						}
+						if (participantDeparted) {
+							deps.registry.emitParticipantEvent(
+								roomId,
+								'participant_left',
+								targetParticipantId,
+							);
+							if (deps.registry.hasRaisedHand(roomId, targetParticipantId)) {
+								deps.registry.clearRaisedHand(roomId, targetParticipantId);
+								deps.registry.emitRaisedHand(roomId, {
+									participantId: targetParticipantId,
+									raised: false,
+									timestamp: new Date().toISOString(),
+								});
+							}
+							deps.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId);
+						}
 						for (const targetSocket of targetSockets) {
 							targetSocket.emit('host_control_update', {
 								action,
@@ -87,75 +134,77 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 						}
 
 						loggers.socketHandler.info(
-							'Host %s kicked participant %s (senderIds=%s) from room %s',
+							'Host %s removed participant %s (senderIds=%s) from room %s',
 							socket.participantId,
 							targetParticipantId,
 							targetSenderIds.join(','),
 							roomId,
 						);
-						if (
-							targetSockets.some((targetSocket) => targetSocket.e2eeRequired) &&
-							targetSenderIds.length > 0
-						) {
-							await deps.e2eeEpochRelay.requestCommitForRemoval(
-								roomId,
-								targetSenderIds,
-								deps.e2eeEpochRelay.getCurrentEpochNumber(roomId),
-							);
-						}
-
 						setTimeout(() => {
 							for (const targetSocket of targetSockets) {
 								if (targetSocket.connected) targetSocket.disconnect(true);
 							}
 							loggers.socketHandler.info(
-								'Forcefully disconnected kicked participant %s',
+								'Forcefully disconnected removed participant %s',
 								targetParticipantId,
 							);
 						}, 1000);
+
+						if (
+							targetSockets.some((targetSocket) => targetSocket.e2eeRequired) &&
+							targetSenderIds.length > 0
+						) {
+							try {
+								void deps.e2eeEpochRelay
+									.requestCommitForRemoval(
+										roomId,
+										targetSenderIds,
+										deps.e2eeEpochRelay.getCurrentEpochNumber(roomId),
+									)
+									.catch((error: unknown) => {
+										logE2EERemovalFailure(targetParticipantId, error);
+									});
+							} catch (error) {
+								logE2EERemovalFailure(targetParticipantId, error);
+							}
+						}
 						break;
 					}
 					case 'lower_hand':
-						if (deps.registry.hasRaisedHand(roomId, targetParticipantId)) {
-							deps.registry.clearRaisedHand(roomId, targetParticipantId);
-							deps.registry.emitToFullAccessParticipants(
-								roomId,
-								'hand_raised',
-								{
-									participantId: targetParticipantId,
-									raised: false,
-									timestamp: new Date().toISOString(),
-								},
-							);
-							loggers.socketHandler.info(
-								'Host %s lowered hand of participant %s',
-								socket.participantId,
-								targetParticipantId,
-							);
-						} else {
-							socket.emit('sfu_error', {
-								error: 'Participant does not have a raised hand',
-								timestamp: new Date().toISOString(),
-							});
+						if (!deps.registry.hasRaisedHand(roomId, targetParticipantId)) {
+							fail('Participant does not have a raised hand');
+							return;
 						}
-						break;
-					default:
-						socket.emit('sfu_error', {
-							error: 'Invalid host control action',
+						deps.registry.clearRaisedHand(roomId, targetParticipantId);
+						deps.registry.emitToFullAccessParticipants(roomId, 'hand_raised', {
+							participantId: targetParticipantId,
+							raised: false,
 							timestamp: new Date().toISOString(),
 						});
+						loggers.socketHandler.info(
+							'Host %s lowered hand of participant %s',
+							socket.participantId,
+							targetParticipantId,
+						);
 						break;
+					default:
+						fail('Invalid host control action');
+						return;
 				}
+				acknowledge({ success: true });
 			} catch (error) {
-				loggers.socketHandler.warn(
-					'host_control handling failed: %s',
-					(error as Error).message,
-				);
-				socket.emit('sfu_error', {
-					error: (error as Error).message,
-					timestamp: new Date().toISOString(),
-				});
+				const message = (error as Error).message;
+				loggers.socketHandler.warn('host_control handling failed: %s', message);
+				fail(message);
 			}
 		});
 	};
+}
+
+function logE2EERemovalFailure(participantId: string, error: unknown): void {
+	loggers.socketHandler.warn(
+		'E2EE removal signaling failed for participant %s: %s',
+		participantId,
+		(error as Error).message,
+	);
 }

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -37,6 +37,12 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 
 			const scopedRoomId = getRoomId(socket);
 			if (socket.scope === 'full') {
+				if (
+					socket.isGuest &&
+					deps.registry.isParticipantRevoked(scopedRoomId, participantId)
+				) {
+					throw new Error('Guest is banned from this room');
+				}
 				enforceE2EEJoinPolicy(socket, e2ee);
 				await deps.roomLifecycle.humanJoined(scopedRoomId);
 				const acquisition = deps.registry.acquireParticipant(
@@ -286,7 +292,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 						avatar: userData.avatar,
 						audio_enabled: mediaState.audio_enabled,
 						video_enabled: mediaState.video_enabled,
-						is_guest: userData.is_guest,
+						is_guest: Boolean(socket.isGuest),
 					},
 					e2ee,
 				});

--- a/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
@@ -79,12 +79,14 @@ export function registerRoomQueryHandlers(deps: HandlerDeps) {
 					deps.authManager.ensureRecorderAccess(socket);
 				else deps.authManager.ensurePresenceAccess(socket);
 
+				const roomId = getRoomId(socket);
 				if (
 					!checkSocketRateLimits(
 						socket,
 						deps.rateLimiter,
-						10,
-						10,
+						`room-participants:${roomId}`,
+						60,
+						300,
 						60 * 1000,
 						deps.runtime.bypassRateLimits,
 					)
@@ -96,7 +98,6 @@ export function registerRoomQueryHandlers(deps: HandlerDeps) {
 					return;
 				}
 
-				const roomId = getRoomId(socket);
 				loggers.socketHandler.debug(
 					'Getting room participants for room %s, user %s, scope %s',
 					roomId,

--- a/suite/meet/sfu-server/src/server/handlers/utils.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/utils.test.ts
@@ -1,0 +1,54 @@
+import type { Socket } from 'socket.io';
+import { describe, expect, it } from 'vitest';
+import { RateLimiter } from '../../utils/rateLimiter';
+import { checkSocketRateLimits } from './utils';
+
+function socket(userId: string, address = '127.0.0.1'): Socket {
+	return {
+		userId,
+		handshake: { address, headers: {} },
+	} as unknown as Socket;
+}
+
+describe('checkSocketRateLimits', () => {
+	it('isolates limits by operation and room namespace', () => {
+		const limiter = new RateLimiter();
+		const participant = socket('user-1');
+
+		expect(
+			checkSocketRateLimits(
+				participant,
+				limiter,
+				'room-query:room-1',
+				1,
+				1,
+				60_000,
+			),
+		).toBe(true);
+		expect(
+			checkSocketRateLimits(
+				participant,
+				limiter,
+				'room-query:room-1',
+				1,
+				1,
+				60_000,
+			),
+		).toBe(false);
+		expect(
+			checkSocketRateLimits(
+				participant,
+				limiter,
+				'room-query:room-2',
+				1,
+				1,
+				60_000,
+			),
+		).toBe(true);
+		expect(
+			checkSocketRateLimits(participant, limiter, 'e2ee:room-1', 1, 1, 60_000),
+		).toBe(true);
+
+		limiter.destroy();
+	});
+});

--- a/suite/meet/sfu-server/src/server/handlers/utils.ts
+++ b/suite/meet/sfu-server/src/server/handlers/utils.ts
@@ -23,6 +23,7 @@ export function getPeerId(socket: Socket): string {
 export function checkSocketRateLimits(
 	socket: Socket,
 	rateLimiter: RateLimiter,
+	namespace: string,
 	userLimit: number,
 	ipLimit: number,
 	windowMs: number,
@@ -42,8 +43,8 @@ export function checkSocketRateLimits(
 		getFirstIp(forwarded) ||
 		socket.handshake.address;
 
-	const userKey = `user:${socket.userId}`;
-	const ipKey = `ip:${clientIp}`;
+	const userKey = `${namespace}:user:${socket.userId}`;
+	const ipKey = `${namespace}:ip:${clientIp}`;
 
 	const userAllowed = rateLimiter.checkRateLimit(userKey, userLimit, windowMs);
 	const ipAllowed = rateLimiter.checkRateLimit(ipKey, ipLimit, windowMs);

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -236,7 +236,10 @@ export interface ClientToServerEvents {
 		callback: (response: RoomParticipantsResponse) => void,
 	) => void;
 	media_control: (data: MediaControlRequest) => void;
-	host_control: (data: HostControlRequest) => void;
+	host_control: (
+		data: HostControlRequest,
+		callback: (response: SFUResponse) => void,
+	) => void;
 	screen_share: (
 		data: ScreenShareRequest,
 		callback?: (response: SFUResponse) => void,
@@ -342,6 +345,7 @@ export interface SocketData {
 	meetingId: string;
 	isHost: boolean;
 	isGuest?: boolean;
+	guestGeneration?: number;
 	roomId?: string;
 	participantId?: string;
 	participantConnectionId?: string;
@@ -546,6 +550,7 @@ export interface JWTPayload {
 	is_host: boolean;
 	is_cohost?: boolean;
 	is_guest?: boolean;
+	guest_generation?: number;
 	scope?: SFUScope;
 	e2ee_required?: boolean;
 	session_id?: string;
@@ -687,6 +692,7 @@ declare module 'socket.io' {
 		isHost: boolean;
 		isCohost: boolean;
 		isGuest?: boolean;
+		guestGeneration?: number;
 		roomId?: string;
 		participantId?: string;
 		participantConnectionId?: string;
@@ -694,6 +700,7 @@ declare module 'socket.io' {
 		senderId?: number;
 		currentToken?: string;
 		tokenExpiresAt?: number;
+		tokenExpiryTimer?: NodeJS.Timeout;
 		scope?: SFUScope;
 		e2eeRequired?: boolean;
 		e2eeReady?: boolean;

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -46,6 +46,7 @@ export type MediaControlAction = 'mute' | 'unmute' | 'video_off' | 'video_on';
 export type HostControlAction =
 	| 'mute_participant'
 	| 'kick_participant'
+	| 'ban_participant'
 	| 'lower_hand';
 
 export type ProducerCloseReason =

--- a/suite/meet/utils/user.py
+++ b/suite/meet/utils/user.py
@@ -7,6 +7,8 @@ import re
 import frappe
 from frappe.utils.caching import redis_cache
 
+from suite.meet import guest_access
+
 
 def unique_users(user_list: list) -> list[dict]:
     """Return unique child table rows, preserving order and metadata."""
@@ -49,12 +51,12 @@ def get_user_info(user_id: str) -> dict | None:
         return None
 
     if is_guest_user(user_id):
-        guest_session = get_guest_session(user_id)
-        if not guest_session:
+        guest_lease = guest_access.get_guest(user_id)
+        if not guest_lease:
             return None
 
         return {
-            "full_name": guest_session.get("guest_name"),
+            "full_name": guest_lease.guest_name,
             "is_guest": True,
         }
 
@@ -68,26 +70,6 @@ def get_user_info(user_id: str) -> dict | None:
         "user_image": user_info.get("user_image"),
         "is_guest": False,
     }
-
-
-def get_guest_session(guest_id: str) -> dict | None:
-    """Retrieve guest session data from cache."""
-    cache_key = f"guest_session:{guest_id}"
-    session_data = frappe.cache.get_value(cache_key)
-
-    if not session_data:
-        return None
-
-    if isinstance(session_data, dict):
-        return session_data
-
-    return None
-
-
-def set_guest_session(guest_id: str, session_data: dict, ttl: int = 86400) -> None:
-    """Store guest session data (default 24 hours)."""
-    cache_key = f"guest_session:{guest_id}"
-    frappe.cache.set_value(cache_key, session_data, expires_in_sec=ttl)
 
 
 def validate_guest_name(guest_name: str) -> tuple[bool, str | None]:


### PR DESCRIPTION
## Summary

- replace persisted guest participants with proof-bound ephemeral access leases
- validate guest realtime and SFU operations against current lease state
- restore guest preview, admission, retry, and reconnect flows across browser sessions
- reconcile missed or no-longer-present guest status through the proof-bound endpoint
- automatically reset rejected and expired guest attempts while keeping bans blocking