### PR TITLE
feat(slides): ability to embed YouTube and Drive videos to slides

### DIFF
--- a/frontend/src/apps/slides/components/InsertDriveVideoButton.vue
+++ b/frontend/src/apps/slides/components/InsertDriveVideoButton.vue
@@ -1,0 +1,79 @@
+<template>
+	<Tooltip text="Insert from Drive" :hover-delay="0.7">
+		<div class="cursor-pointer rounded-4 p-2 hover:bg-surface-gray-3" @click="openPicker">
+			<HardDrive class="size-4 stroke-[1.5] text-ink-gray-7" />
+		</div>
+	</Tooltip>
+
+	<Dialog v-model:open="showDialog" title="Insert video from Drive">
+		<div>
+			<SearchInput v-model="search" placeholder="Search your Drive" />
+			<div class="no-scrollbar mt-3 flex max-h-80 flex-col gap-0.5 overflow-y-auto">
+				<button
+					v-for="file in videos"
+					:key="file.name"
+					type="button"
+					class="flex w-full items-center gap-2 rounded-4 px-2 py-2 text-start hover:bg-surface-gray-2"
+					@click="insert(file)"
+				>
+					<FileVideo class="size-4 shrink-0 text-ink-gray-5" />
+					<div class="min-w-0 flex-1">
+						<div class="truncate text-sm text-ink-gray-8">{{ file.file_name }}</div>
+						<div class="truncate text-xs text-ink-gray-5">Edited {{ dayjs(file.modified).fromNow() }}</div>
+					</div>
+				</button>
+
+				<LoadingIndicator v-if="loading" class="m-auto w-3 py-4" />
+				<div v-else-if="!videos.length" class="py-6 text-center text-sm text-ink-gray-5">
+					{{ search ? `No videos found for "${search}"` : 'No videos in your Drive yet' }}
+				</div>
+			</div>
+		</div>
+	</Dialog>
+</template>
+
+<script setup>
+import { ref, watch } from 'vue'
+
+import { HardDrive, FileVideo } from 'lucide-vue-next'
+import { Dialog, Tooltip, LoadingIndicator } from 'frappe-ui'
+
+import SearchInput from '@/apps/slides/components/controls/SearchInput.vue'
+import dayjs from '@/apps/slides/utils/dayjs'
+import { listDriveVideos } from '@/apps/slides/utils/driveVideo'
+import { addDriveVideoElement } from '@/apps/slides/stores/element'
+
+const showDialog = ref(false)
+const search = ref('')
+const videos = ref([])
+const loading = ref(false)
+
+const openPicker = () => {
+	showDialog.value = true
+	search.value = ''
+	fetchVideos()
+}
+
+const fetchVideos = async () => {
+	loading.value = true
+	try {
+		videos.value = await listDriveVideos(search.value)
+	} catch {
+		videos.value = []
+	} finally {
+		loading.value = false
+	}
+}
+
+// debounced so a search doesn't fire a request per keystroke
+let searchTimeout = null
+watch(search, () => {
+	clearTimeout(searchTimeout)
+	searchTimeout = setTimeout(fetchVideos, 300)
+})
+
+const insert = (file) => {
+	addDriveVideoElement(file.name)
+	showDialog.value = false
+}
+</script>

--- a/frontend/src/apps/slides/components/PropertiesPanel.vue
+++ b/frontend/src/apps/slides/components/PropertiesPanel.vue
@@ -47,11 +47,11 @@
 					<hr class="border-t" />
 					<PlaybackSection />
 				</template>
-				<template v-if="['image', 'video'].includes(activeElement?.type)">
+				<template v-if="['image', 'video', 'youtube'].includes(activeElement?.type)">
 					<hr class="border-t" />
 					<BorderSection :key="activeElement?.id" />
 				</template>
-				<template v-if="['image', 'video', 'shape'].includes(activeElement?.type)">
+				<template v-if="['image', 'video', 'youtube', 'shape'].includes(activeElement?.type)">
 					<hr class="border-t" />
 					<ShadowSection :key="activeElement?.id" />
 				</template>
@@ -109,6 +109,7 @@ const selectionLabel = computed(() => {
 	const count = activeElementIds.value.length
 	if (count > 1) return `${count} elements`
 	const type = activeElement.value?.type
+	if (type === 'youtube') return 'YouTube'
 	return type ? type[0].toUpperCase() + type.slice(1) : ''
 })
 

--- a/frontend/src/apps/slides/components/SelectionControls.vue
+++ b/frontend/src/apps/slides/components/SelectionControls.vue
@@ -52,7 +52,7 @@ const { currentResizer, startResize } = inject('resizer', {})
 const { isHovered, isRounding } = inject('cornerRadius', {})
 
 const showRotateHandle = computed(() => {
-	return !['line', 'text', 'table', 'video'].includes(props.elementType)
+	return !['line', 'text', 'table', 'video', 'youtube'].includes(props.elementType)
 })
 
 const isResizeHandleVisible = (resizer) => {
@@ -73,7 +73,7 @@ const resizeHandles = computed(() => {
 			'bottom-left',
 			'bottom-right',
 		]
-	} else if (['image', 'video'].includes(props.elementType)) {
+	} else if (['image', 'video', 'youtube'].includes(props.elementType)) {
 		directions = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
 	} else if (props.elementType === 'line') {
 		directions = ['line-left', 'line-right']
@@ -122,7 +122,7 @@ const isEndBound = (direction) => {
 
 const CORNERS = ['top-left', 'top-right', 'bottom-left', 'bottom-right']
 
-const ROUNDABLE = ['rectangle', 'image', 'video']
+const ROUNDABLE = ['rectangle', 'image', 'video', 'youtube']
 
 const cornerHandles = computed(() => {
 	if (!ROUNDABLE.includes(props.elementType) || currentResizer.value) return []

--- a/frontend/src/apps/slides/components/SlideElement.vue
+++ b/frontend/src/apps/slides/components/SlideElement.vue
@@ -16,6 +16,7 @@ import { computed } from 'vue'
 import TextElement from '@/apps/slides/components/TextElement.vue'
 import ImageElement from '@/apps/slides/components/ImageElement.vue'
 import VideoElement from '@/apps/slides/components/VideoElement.vue'
+import YoutubeElement from '@/apps/slides/components/YoutubeElement.vue'
 import ShapeElement from '@/apps/slides/components/ShapeElement.vue'
 import TableElement from '@/apps/slides/components/TableElement.vue'
 
@@ -141,6 +142,8 @@ const getDynamicComponent = (type) => {
 			return ImageElement
 		case 'video':
 			return VideoElement
+		case 'youtube':
+			return YoutubeElement
 		case 'shape':
 			return ShapeElement
 		case 'table':

--- a/frontend/src/apps/slides/components/Toolbar.vue
+++ b/frontend/src/apps/slides/components/Toolbar.vue
@@ -17,6 +17,8 @@
 
 		<YoutubeDropdown />
 
+		<InsertDriveVideoButton />
+
 		<ToolDropdown tooltip="Shapes" :icon="Shapes" :options="shapeTools" />
 
 		<ToolDropdown tooltip="Lines" :icon="Polyline" :options="lineTools" />
@@ -46,6 +48,7 @@ import ToolDropdown from '@/apps/slides/components/ToolDropdown.vue'
 import Polyline from '@/apps/slides/icons/Polyline.vue'
 import TableDropdown from '@/apps/slides/components/TableDropdown.vue'
 import YoutubeDropdown from '@/apps/slides/components/YoutubeDropdown.vue'
+import InsertDriveVideoButton from '@/apps/slides/components/InsertDriveVideoButton.vue'
 
 import { handleScrollBarWheelEvent } from '@/apps/slides/utils/helpers'
 import { shapeTools, lineTools } from '@/apps/slides/utils/toolbarTools'

--- a/frontend/src/apps/slides/components/Toolbar.vue
+++ b/frontend/src/apps/slides/components/Toolbar.vue
@@ -15,6 +15,8 @@
 			</div>
 		</Tooltip>
 
+		<YoutubeDropdown />
+
 		<ToolDropdown tooltip="Shapes" :icon="Shapes" :options="shapeTools" />
 
 		<ToolDropdown tooltip="Lines" :icon="Polyline" :options="lineTools" />
@@ -43,6 +45,7 @@ import { allowedImageFileTypes } from '@/apps/slides/utils/constants'
 import ToolDropdown from '@/apps/slides/components/ToolDropdown.vue'
 import Polyline from '@/apps/slides/icons/Polyline.vue'
 import TableDropdown from '@/apps/slides/components/TableDropdown.vue'
+import YoutubeDropdown from '@/apps/slides/components/YoutubeDropdown.vue'
 
 import { handleScrollBarWheelEvent } from '@/apps/slides/utils/helpers'
 import { shapeTools, lineTools } from '@/apps/slides/utils/toolbarTools'

--- a/frontend/src/apps/slides/components/YoutubeDropdown.vue
+++ b/frontend/src/apps/slides/components/YoutubeDropdown.vue
@@ -1,0 +1,53 @@
+<template>
+	<Popover side="top" align="center" :offset="12" @close="reset">
+		<template #trigger="{ open }">
+			<div>
+				<Tooltip text="YouTube" :hover-delay="0.7">
+					<div :class="triggerClass(open)">
+						<Youtube class="size-4 stroke-[1.5] text-ink-gray-7" />
+					</div>
+				</Tooltip>
+			</div>
+		</template>
+		<template #default="{ close }">
+			<form class="flex w-72 flex-col gap-2 p-3" @submit.prevent="submit(close)">
+				<span class="text-sm text-ink-gray-6">Paste a YouTube video link</span>
+				<TextInput v-model="url" type="text" placeholder="https://www.youtube.com/watch?v=…" />
+				<span v-if="hasError" class="text-sm text-ink-red-4">
+					Couldn't find a video at that link
+				</span>
+				<Button variant="solid" label="Insert" :disabled="!url" @click="submit(close)" />
+			</form>
+		</template>
+	</Popover>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+
+import { Youtube } from 'lucide-vue-next'
+import { Popover, Tooltip, TextInput, Button } from 'frappe-ui'
+
+import { addYoutubeElement } from '@/apps/slides/stores/element'
+
+const url = ref('')
+const hasError = ref(false)
+
+const triggerClass = (isOpen) => [
+	'flex cursor-pointer items-center rounded-4 p-2 hover:bg-surface-gray-3',
+	{ 'bg-surface-gray-3': isOpen },
+]
+
+const reset = () => {
+	url.value = ''
+	hasError.value = false
+}
+
+const submit = (close) => {
+	if (!addYoutubeElement(url.value)) {
+		hasError.value = true
+		return
+	}
+	close()
+}
+</script>

--- a/frontend/src/apps/slides/components/YoutubeElement.vue
+++ b/frontend/src/apps/slides/components/YoutubeElement.vue
@@ -1,0 +1,66 @@
+<template>
+	<div class="relative h-full">
+		<img
+			v-if="mode == 'thumbnail'"
+			class="size-full object-cover"
+			:style="frameStyle"
+			:src="thumbnailSrc"
+		/>
+		<iframe
+			v-else
+			class="size-full"
+			:style="frameStyle"
+			:src="embedSrc"
+			title="YouTube video"
+			frameborder="0"
+			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+			allowfullscreen
+		/>
+		<!-- the iframe swallows every pointer event, so while editing this blocks
+		clicks from reaching the YouTube player and moves/selects the element instead -->
+		<div v-if="mode != 'thumbnail' && !inViewerMode" class="absolute left-0 top-0 size-full"></div>
+	</div>
+</template>
+
+<script setup>
+import { computed, inject, ref } from 'vue'
+
+import { useBoxShadow } from '@/apps/slides/composables/useShadow'
+import { defaultBorderColor } from '@/apps/slides/utils/constants'
+import { getYoutubeEmbedSrc, getYoutubeThumbnailSrc } from '@/apps/slides/utils/youtube'
+
+const props = defineProps({
+	mode: {
+		type: String,
+		default: 'editor',
+	},
+	transitionStyles: {
+		type: Object,
+		default: () => ({}),
+	},
+})
+
+const element = defineModel('element', {
+	type: Object,
+	default: null,
+})
+
+const inReadonlyMode = inject('inReadonlyMode', ref(false))
+const inSlideShowMode = inject('inSlideShowMode', ref(false))
+const inViewerMode = computed(() => inReadonlyMode.value || inSlideShowMode.value)
+
+const boxShadow = useBoxShadow(element)
+
+const embedSrc = computed(() => getYoutubeEmbedSrc(element.value.videoId))
+const thumbnailSrc = computed(() => getYoutubeThumbnailSrc(element.value.videoId))
+
+const frameStyle = computed(() => ({
+	opacity: (element.value.opacity ?? 100) / 100,
+	borderRadius: `${element.value.borderRadius}px`,
+	borderStyle: element.value.borderStyle || 'none',
+	borderColor: element.value.borderColor || defaultBorderColor,
+	borderWidth: `${element.value.borderWidth}px`,
+	boxShadow: boxShadow.value,
+	...props.transitionStyles,
+}))
+</script>

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -19,6 +19,8 @@ import { getMinSizeForElement } from '../utils/resize'
 import { getBoundTargetIds, getLineBox, remapElementIds } from '../utils/connectors'
 import { getAttachmentUrl } from '../utils/mediaUploads'
 import { guessTextColorFromBackground, guessShapeColorsFromBackground } from '../utils/color'
+import { defaultBorderColor, defaultShadowColor } from '../utils/constants'
+import { getYoutubeVideoId } from '../utils/youtube'
 import { presentationId } from './presentation'
 import { getCommandsToInitElementRefId, getCommandsToUpdateElementRefId } from './transition'
 import { commandHistory } from './historyMeta'
@@ -459,6 +461,57 @@ const addTableElement = async (rows = 3, cols = 3) => {
 			commands,
 		}),
 	)
+}
+
+// returns false for an unrecognised URL so the caller can show an inline error
+const addYoutubeElement = (url) => {
+	const videoId = getYoutubeVideoId(url)
+	if (!videoId) return false
+
+	const width = 480
+	const height = width * (9 / 16)
+	const position = getLeftTopForCenteredElement(width, height)
+
+	const element = {
+		id: generateUniqueId(),
+		zIndex: currentSlide.value.elements.length + 1,
+		left: position.left,
+		top: position.top,
+		width,
+		height,
+		opacity: 100,
+		type: 'youtube',
+		videoId,
+		borderStyle: 'none',
+		borderWidth: 0,
+		borderRadius: 0,
+		borderColor: defaultBorderColor,
+		shadowColor: defaultShadowColor,
+		shadowOpacity: 100,
+		shadowBlur: 0,
+		shadowOffset: 0,
+		shadowAngle: 45,
+	}
+
+	const refCommands = getCommandsToUpdateElementRefId(element) || []
+
+	const commands = [
+		addElementCommand({
+			slideId: currentSlide.value.clientId,
+			element: element,
+		}),
+		...refCommands,
+	]
+
+	commandHistory.execute(
+		batchCommand({
+			slideId: currentSlide.value.clientId,
+			elementIds: [element.id],
+			commands,
+		}),
+	)
+
+	return true
 }
 
 // createResource hands back the last poster it saved when a request fails, which
@@ -1442,6 +1495,7 @@ export {
 	addMediaElement,
 	addShapeElement,
 	addTableElement,
+	addYoutubeElement,
 	duplicateElements,
 	deleteElements,
 	hasBoundConnector,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -21,6 +21,7 @@ import { getAttachmentUrl } from '../utils/mediaUploads'
 import { guessTextColorFromBackground, guessShapeColorsFromBackground } from '../utils/color'
 import { defaultBorderColor, defaultShadowColor } from '../utils/constants'
 import { getYoutubeVideoId } from '../utils/youtube'
+import { getDriveVideoStreamUrl } from '../utils/driveVideo'
 import { presentationId } from './presentation'
 import { getCommandsToInitElementRefId, getCommandsToUpdateElementRefId } from './transition'
 import { commandHistory } from './historyMeta'
@@ -761,6 +762,18 @@ const addMediaElement = async (file, type, targetSlide, localFile) => {
 	)
 }
 
+// a Drive file streams through Drive's own permission-checked endpoint rather
+// than a Presentation attachment, so playback follows whatever access the
+// viewer actually has there
+const addDriveVideoElement = (entityName) => {
+	return addMediaElement(
+		{ file_url: getDriveVideoStreamUrl(entityName), name: entityName },
+		'video',
+		currentSlide.value,
+		null,
+	)
+}
+
 const probeReplacementMedia = async (element, fileDoc, localFile) => {
 	const newUrl = getAttachmentUrl(fileDoc.file_url)
 
@@ -1496,6 +1509,7 @@ export {
 	addShapeElement,
 	addTableElement,
 	addYoutubeElement,
+	addDriveVideoElement,
 	duplicateElements,
 	deleteElements,
 	hasBoundConnector,

--- a/frontend/src/apps/slides/utils/driveVideo.js
+++ b/frontend/src/apps/slides/utils/driveVideo.js
@@ -1,0 +1,16 @@
+import { call } from 'frappe-ui'
+
+const VIDEO_FILE_KIND = JSON.stringify(['Video'])
+
+// Drive's own permission model, not core File perms — this is the same
+// endpoint Drive's own <video> preview streams from, so playback stays
+// gated by whatever access the viewer actually has in Drive.
+export const getDriveVideoStreamUrl = (entityName) =>
+	`/api/method/suite.drive.api.files.stream_file_content?entity_name=${entityName}`
+
+// no search: recently touched videos. with search: whole-tree search, per
+// suite.drive.api.list's own contract.
+export const listDriveVideos = (search) => {
+	const method = search ? 'suite.drive.api.list.files' : 'suite.drive.api.list.recents'
+	return call(method, { search: search || undefined, file_kinds: VIDEO_FILE_KIND })
+}

--- a/frontend/src/apps/slides/utils/resize.js
+++ b/frontend/src/apps/slides/utils/resize.js
@@ -5,12 +5,13 @@ const MIN_SIZE = {
 	shape: { width: 10, height: 16 },
 	image: { width: 20, height: 20 },
 	video: { width: 20, height: 20 },
+	youtube: { width: 20, height: 20 },
 	default: { width: 10, height: 16 },
 }
 
 export const getMinSizeForElement = (type) => MIN_SIZE[type] ?? MIN_SIZE.default
 
-export const isAspectLocked = (type) => type === 'image' || type === 'video'
+export const isAspectLocked = (type) => ['image', 'video', 'youtube'].includes(type)
 
 // 2d vector helpers, all working on { x, y } points
 const addVectors = (a, b) => ({ x: a.x + b.x, y: a.y + b.y })

--- a/frontend/src/apps/slides/utils/youtube.js
+++ b/frontend/src/apps/slides/utils/youtube.js
@@ -1,0 +1,33 @@
+// dot-boundary host check, e.g. "youtube.com" matches "www.youtube.com" but not "notyoutube.com"
+const YOUTUBE_HOSTS = ['youtube.com', 'youtu.be', 'youtube-nocookie.com']
+
+const matchesYoutubeHost = (hostname) =>
+	YOUTUBE_HOSTS.some((host) => hostname === host || hostname.endsWith(`.${host}`))
+
+// pulls a video id out of any shape of YouTube URL (watch, share, shorts, live, embed)
+export const getYoutubeVideoId = (url) => {
+	let parsed
+	try {
+		parsed = new URL(String(url).trim())
+	} catch {
+		return null
+	}
+
+	if (!matchesYoutubeHost(parsed.hostname)) return null
+
+	if (parsed.hostname === 'youtu.be' || parsed.hostname === 'www.youtu.be') {
+		return parsed.pathname.slice(1).split('/')[0] || null
+	}
+
+	const segments = parsed.pathname.split('/').filter(Boolean)
+	if (['shorts', 'live', 'embed'].includes(segments[0])) {
+		return segments[1] || null
+	}
+
+	return parsed.searchParams.get('v') || null
+}
+
+export const getYoutubeEmbedSrc = (videoId) => `https://www.youtube.com/embed/${videoId}?rel=0`
+
+export const getYoutubeThumbnailSrc = (videoId) =>
+	`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`


### PR DESCRIPTION
Fixes #748

## Problem

Slides has no way to put anything but locally-uploaded images/videos on a slide. This adds two ways to embed external media:

1. **YouTube** — paste a URL, get an embedded player. Writer already has this via `frappe-ui`'s iframe extension.
2. **Drive** — insert a video that already lives in the user's Drive storage, without re-uploading it.

## Solution

### YouTube embeds

Writer's iframe extension lives inside a `frappe-ui` git dependency and is wired into tiptap; it isn't part of the package's public `exports` map and Slides' canvas isn't a tiptap document, so it can't be imported directly. Ported just the URL-parsing piece, scoped to YouTube:

- `utils/youtube.js` — `getYoutubeVideoId(url)` parses watch/share/shorts/live/embed URLs.
- `stores/element.js` — `addYoutubeElement(url)` creates a new `youtube`-type element (stores only `videoId`, not an arbitrary iframe `src`).
- `components/YoutubeElement.vue` — renders the iframe (thumbnail mode uses YouTube's public `img.youtube.com` thumbnail instead of mounting an iframe in every slide-list thumbnail).
- `components/YoutubeDropdown.vue` — toolbar popover (mirrors the existing `TableDropdown` popover shape) with a URL field and inline validation error.
- `youtube` was added everywhere `image`/`video` are already grouped for border/shadow/corner-radius/aspect-lock behaviour (`resize.js`, `PropertiesPanel.vue`, `SelectionControls.vue`, `SlideElement.vue`), so it resizes and styles exactly like existing media.

**Fixed after initial implementation:** an iframe swallows every pointer event, so dragging the embed actually clicked into the YouTube player and started playback instead of moving the element. `YoutubeElement.vue` now overlays a plain div above the iframe while editing (blocking clicks from reaching the player) and only lets the iframe receive pointer events in slideshow/read-only view — the same problem `VideoElement.vue` solves for native `<video>`, just handled with an overlay instead of custom controls since iframe content can't be intercepted at the click level.

### Drive video embeds

Drive stores files as plain Frappe `File` docs and already exposes whitelisted, permission-checked endpoints that Writer calls directly today (`suite.drive.api.list.*`, `suite.drive.api.files.stream_file_content`). That meant no backend work was needed:

- `utils/driveVideo.js` — `listDriveVideos(search)` (recents when empty, tree-wide search otherwise, filtered to `file_kinds: ["Video"]`) and `getDriveVideoStreamUrl(entityName)`, which points straight at Drive's own `stream_file_content` endpoint — the same one Drive's own video preview streams from.
- `stores/element.js` — `addDriveVideoElement(entityName)`, a thin wrapper around the existing `addMediaElement`. A Drive video becomes an ordinary `video` element whose `src` is the stream URL, so it gets poster capture, aspect-lock, border/shadow controls, and undo history for free — no new element type or renderer.
- `components/InsertDriveVideoButton.vue` — toolbar button opening a `Dialog` with a search box and a row list (name + "Edited X ago"), styled after Writer's own Drive-document picker (`DocumentList.vue`) for visual consistency.

Confirmed the reuse is safe on the backend side: `presentation.py`'s attachment-reconciliation logic only touches elements whose `src` starts with `/private`, so a Drive stream URL (`/api/method/...`) is never mistaken for a Presentation-owned attachment and never at risk of being cleaned up/deleted by Slides' own save logic.

## Tests

No automated frontend tests were added (the codebase has no existing test coverage for the toolbar/element-insertion flow this touches). Verified with:

- `vite build` after each change — clean build, no new errors/warnings.
- Manual walkthrough: insert a YouTube URL, drag/resize/style the embed, confirm it doesn't autoplay while editing; browse and insert a Drive video, confirm search debounces and the picker's empty/loading states render.

## Behaviour notes

- A YouTube embed only autoplays/responds to clicks in slideshow or read-only view — while editing, clicks/drags always hit the canvas, matching how the existing `video` element behaves.
- A Drive video's playback is gated by Drive's own permission model, live, on every request — not by Slides' sharing. If a presentation is shared with someone who doesn't have Drive access to the specific embedded video, they'll see the slide but the video won't play for them. This matches how Drive-backed embeds already work elsewhere in the suite (e.g. Writer) and needs no extra plumbing for v1.
- Drive integration intentionally stops at video files for now; picking is a flat recents/search list, not a full folder browser.
