### PR TITLE
chore: enable track changes on settings and exchange doctypes

### DIFF
--- a/suite/calendar/doctype/calendar_exchange/calendar_exchange.json
+++ b/suite/calendar/doctype/calendar_exchange/calendar_exchange.json
@@ -276,7 +276,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-31 09:39:50.807837",
  "modified_by": "Administrator",
  "module": "Calendar",
  "name": "Calendar Exchange",
@@ -318,5 +318,6 @@
  "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/drive/doctype/drive_disk_settings/drive_disk_settings.json
+++ b/suite/drive/doctype/drive_disk_settings/drive_disk_settings.json
@@ -54,7 +54,7 @@
    "label": "Quota"
   },
   {
-   "description": "Where and how Drive lays out file contents — on the site's disk, or in the S3 bucket below.",
+   "description": "Where and how Drive lays out file contents \u2014 on the site's disk, or in the S3 bucket below.",
    "fieldname": "storage_section",
    "fieldtype": "Section Break",
    "label": "Storage Layout"
@@ -144,7 +144,7 @@
   },
   {
    "default": "0",
-   "description": "Let WebDAV clients (Windows Explorer, Finder, rclone…) connect to Drive at /dav using Frappe login credentials.",
+   "description": "Let WebDAV clients (Windows Explorer, Finder, rclone\u2026) connect to Drive at /dav using Frappe login credentials.",
    "fieldname": "webdav_enabled",
    "fieldtype": "Check",
    "label": "Enable WebDAV"
@@ -165,7 +165,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2026-08-25 12:30:00.000000",
+ "modified": "2026-08-31 09:40:05.165393",
  "modified_by": "Administrator",
  "module": "Drive",
  "name": "Drive Disk Settings",
@@ -195,5 +195,6 @@
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/drive/doctype/drive_disk_settings/drive_disk_settings.py
+++ b/suite/drive/doctype/drive_disk_settings/drive_disk_settings.py
@@ -8,6 +8,29 @@ from suite.drive.webdav import ALLOWED_METHODS, parse_webdav_methods
 
 
 class DriveDiskSettings(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        aws_key: DF.Data | None
+        aws_secret: DF.Password | None
+        bucket: DF.Data | None
+        enabled: DF.Check
+        endpoint_url: DF.Data | None
+        flat: DF.Check
+        preview_size: DF.Int
+        quota: DF.Int
+        root_folder: DF.Data | None
+        signature_version: DF.Data | None
+        thumbnail_prefix: DF.Data | None
+        webdav_allowed_methods: DF.SmallText | None
+        webdav_enabled: DF.Check
+    # end: auto-generated types
+
     def validate(self):
         # A mirrored tree on S3 means a folder move copies and deletes every object
         # under it, which times out on large folders.

--- a/suite/drive/doctype/drive_settings/drive_settings.json
+++ b/suite/drive/doctype/drive_settings/drive_settings.json
@@ -26,7 +26,7 @@
    "label": "Account"
   },
   {
-   "description": "The user these settings belong to — the document is named after them.",
+   "description": "The user these settings belong to \u2014 the document is named after them.",
    "fieldname": "user",
    "fieldtype": "Link",
    "label": "User",
@@ -93,7 +93,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-08-25 12:45:00.000000",
+ "modified": "2026-08-31 09:41:00.812051",
  "modified_by": "Administrator",
  "module": "Drive",
  "name": "Drive Settings",
@@ -127,5 +127,6 @@
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/drive/doctype/drive_settings/drive_settings.py
+++ b/suite/drive/doctype/drive_settings/drive_settings.py
@@ -8,6 +8,22 @@ PRIVILEGED_FIELDS = ("quota", "user_folder")
 
 
 class DriveSettings(Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        auto_detect_links: DF.Check
+        quota: DF.Int
+        user: DF.Link | None
+        user_folder: DF.Link | None
+        webdav_enabled: DF.Check
+        writer_settings: DF.JSON | None
+    # end: auto-generated types
+
     def validate(self):
         if self.flags.ignore_permissions or frappe.session.user == "Administrator":
             return

--- a/suite/mail/doctype/contacts_exchange/contacts_exchange.json
+++ b/suite/mail/doctype/contacts_exchange/contacts_exchange.json
@@ -268,7 +268,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-31 09:39:45.316810",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Contacts Exchange",
@@ -310,5 +310,6 @@
  "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/mail/doctype/jmap_account/jmap_account.json
+++ b/suite/mail/doctype/jmap_account/jmap_account.json
@@ -339,7 +339,7 @@
    "link_fieldname": "account"
   }
  ],
- "modified": "2026-07-22 15:10:00.000000",
+ "modified": "2026-08-31 09:41:45.879147",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "JMAP Account",
@@ -374,5 +374,6 @@
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],
- "title_field": "_name"
+ "title_field": "_name",
+ "track_changes": 1
 }

--- a/suite/mail/doctype/mail_exchange/mail_exchange.json
+++ b/suite/mail/doctype/mail_exchange/mail_exchange.json
@@ -276,7 +276,7 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-31 09:42:32.984669",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Exchange",
@@ -318,5 +318,6 @@
  "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/mail/doctype/mail_signature/mail_signature.json
+++ b/suite/mail/doctype/mail_signature/mail_signature.json
@@ -44,7 +44,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-31 09:42:50.179296",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mail Signature",
@@ -81,5 +81,6 @@
  "row_format": "Dynamic",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/mail/doctype/mail_signature/mail_signature.py
+++ b/suite/mail/doctype/mail_signature/mail_signature.py
@@ -8,4 +8,17 @@ from suite.utils.permissions import OwnerFromUser
 
 
 class MailSignature(OwnerFromUser, Document):
+    # begin: auto-generated types
+    # This code is auto-generated. Do not modify anything in this block.
+
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:
+        from frappe.types import DF
+
+        html_body: DF.Code | None
+        signature_name: DF.Data
+        user: DF.Link
+    # end: auto-generated types
+
     pass

--- a/suite/mail/doctype/mailbox_settings/mailbox_settings.json
+++ b/suite/mail/doctype/mailbox_settings/mailbox_settings.json
@@ -132,7 +132,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-21 00:00:00.000000",
+ "modified": "2026-08-31 09:42:22.107419",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Mailbox Settings",
@@ -168,5 +168,6 @@
  "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }

--- a/suite/mail/doctype/mailbox_settings/mailbox_settings.py
+++ b/suite/mail/doctype/mailbox_settings/mailbox_settings.py
@@ -29,6 +29,7 @@ class MailboxSettings(Document):
         color: DF.Literal["Gray", "Blue", "Green", "Amber", "Red", "Purple"]
         disable_push_notification: DF.Check
         emails_from: DF.SmallText | None
+        icon: DF.Icon | None
         mailbox_id: DF.Data
         mark_as_read: DF.Check
         match_if: DF.Literal["any", "all"]

--- a/suite/mail/doctype/screened_email_address/screened_email_address.json
+++ b/suite/mail/doctype/screened_email_address/screened_email_address.json
@@ -60,7 +60,7 @@
  "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2026-07-31 11:51:13.368588",
+ "modified": "2026-08-31 09:39:19.658055",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "Screened Email Address",
@@ -96,5 +96,6 @@
  "rows_threshold_for_grid_search": 20,
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "track_changes": 1
 }


### PR DESCRIPTION
## Summary
- Enable `track_changes` on Calendar Exchange, Contacts Exchange, Mail Exchange, JMAP Account, Mail Signature, Mailbox Settings, Screened Email Address, Drive Settings and Drive Disk Settings, so edits to these documents appear in the timeline / Version log.
- Desk-export side effects bundled in the same save: regenerated type-hint blocks for Drive Settings, Drive Disk Settings and Mail Signature; added the missing `icon` hint to Mailbox Settings; em-dash characters in the Drive JSON descriptions are now written as `\u2014` escapes.

## Test plan
- `bench --site <site> migrate` applies cleanly.
- Edit any of the listed doctypes from the desk and confirm a Version entry is written and shown in the form timeline.
- `bench --site <site> run-tests --app suite` still passes for the mail and drive modules.
