### PR TITLE
feat(mail): make the undo send period configurable per user

### DIFF
--- a/frontend/src/apps/mail/components/Modals/SettingsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/SettingsModal.vue
@@ -36,6 +36,7 @@ import {
 	KeyRound,
 	Mailbox,
 	Palette,
+	PenLine,
 	TreePalm,
 	User,
 	Zap,
@@ -55,6 +56,7 @@ import AdvancedSettings from '@/apps/mail/components/Settings/AdvancedSettings.v
 import CredentialsSettings from '@/apps/mail/components/Settings/CredentialsSettings.vue'
 import AppearanceSettings from '@/apps/mail/components/Settings/AppearanceSettings.vue'
 import AutomationSettings from '@/apps/mail/components/Settings/AutomationSettings.vue'
+import ComposeSettings from '@/apps/mail/components/Settings/ComposeSettings.vue'
 import ExportSettings from '@/apps/mail/components/Settings/ExportSettings.vue'
 import FolderSettings from '@/apps/mail/components/Settings/FolderSettings.vue'
 import IdentitySettings from '@/apps/mail/components/Settings/IdentitySettings.vue'
@@ -139,6 +141,13 @@ const tabGroups = computed((): SettingsTabGroup[] => {
 					value: 'signatures',
 					icon: Feather,
 					component: markRaw(SignatureSettings),
+					condition: jmap,
+				},
+				{
+					label: __('Compose'),
+					value: 'compose',
+					icon: PenLine,
+					component: markRaw(ComposeSettings),
 					condition: jmap,
 				},
 				{

--- a/frontend/src/apps/mail/components/Settings/ComposeSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ComposeSettings.vue
@@ -40,7 +40,7 @@ import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
 import { raiseToast } from '@/apps/mail/utils'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { UNDO_SEND_PERIODS, undoSendPeriodOf } from '@/apps/mail/utils/undoSend'
-import type { UserResource } from '@/apps/mail/types'
+import type { User, UserResource } from '@/apps/mail/types'
 
 const user = inject('$user') as UserResource
 const { isMobile } = useScreenSize()
@@ -60,6 +60,8 @@ const saveSettings = createResource({
 		value: undoSendPeriod.value,
 	}),
 	onSuccess: () => {
+		// Apply locally before the reload lands, so nothing reads the old period in between.
+		user.data.undo_send_period = undoSendPeriod.value as User['undo_send_period']
 		raiseToast(__('Compose settings updated.'))
 		user.reload()
 	},

--- a/frontend/src/apps/mail/components/Settings/ComposeSettings.vue
+++ b/frontend/src/apps/mail/components/Settings/ComposeSettings.vue
@@ -1,0 +1,73 @@
+<template>
+	<AppSettingsHeader :title="__('Compose')">
+		<template #actions>
+			<Button
+				:label="__('Save')"
+				variant="solid"
+				:size="isMobile ? 'md' : 'sm'"
+				:loading="saveSettings.loading"
+				:disabled="isNotDirty"
+				@click="saveSettings.submit()"
+			/>
+		</template>
+	</AppSettingsHeader>
+	<AppSettingsBody>
+		<div class="flex flex-col gap-5">
+			<SettingsRow
+				class="!py-0"
+				:title="__('Undo Send')"
+				:description="
+					__('How long a sent message waits before delivery, so you can still take it back.')
+				"
+			>
+				<FormControl
+					v-model="undoSendPeriod"
+					type="select"
+					variant="outline"
+					:options="UNDO_SEND_OPTIONS"
+				/>
+			</SettingsRow>
+		</div>
+	</AppSettingsBody>
+</template>
+
+<script setup lang="ts">
+import { computed, inject, ref } from 'vue'
+import { Button, FormControl, SettingsRow, createResource } from 'frappe-ui'
+import AppSettingsHeader from '@/components/settings/AppSettingsHeader.vue'
+import AppSettingsBody from '@/components/settings/AppSettingsBody.vue'
+
+import { raiseToast } from '@/apps/mail/utils'
+import { useScreenSize } from '@/apps/mail/utils/composables'
+import { UNDO_SEND_PERIODS, undoSendPeriodOf } from '@/apps/mail/utils/undoSend'
+import type { UserResource } from '@/apps/mail/types'
+
+const user = inject('$user') as UserResource
+const { isMobile } = useScreenSize()
+
+// The select speaks the Select field's strings; the saved value is compared through the same
+// fallback the composer uses, so an unset row reads as the default rather than as dirty.
+const savedPeriod = computed(() => String(undoSendPeriodOf(user.data)))
+const undoSendPeriod = ref(savedPeriod.value)
+const isNotDirty = computed(() => undoSendPeriod.value === savedPeriod.value)
+
+const saveSettings = createResource({
+	url: 'frappe.client.set_value',
+	makeParams: () => ({
+		doctype: 'User Settings',
+		name: user.data.user_settings,
+		fieldname: 'undo_send_period',
+		value: undoSendPeriod.value,
+	}),
+	onSuccess: () => {
+		raiseToast(__('Compose settings updated.'))
+		user.reload()
+	},
+	onError: () => raiseToast(__('Unable to save compose settings.'), 'error'),
+})
+
+const UNDO_SEND_OPTIONS = UNDO_SEND_PERIODS.map((seconds) => ({
+	label: __('{0} seconds', [String(seconds)]),
+	value: String(seconds),
+}))
+</script>

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -258,10 +258,13 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		{ debounce: 2000 },
 	)
 
-	// The sender's undo window (User Settings); the server holds delivery a few seconds longer than
-	// this so a last-moment Undo still lands in time (get_undo_send_hold_seconds in api/mail.py).
-	// Read per send, so a change made in Settings applies to the next send without a reopen.
-	const undoSendWindowMs = () => undoSendPeriodOf(user.data) * 1000
+	// The Undo toast lives for the period the server actually held delivery for (it echoes it back
+	// with the send result; the hold is that plus a few seconds' grace, so a last-moment Undo still
+	// lands in time). The user's own setting is only a fallback for a result without one: the
+	// setting can change under a mounted composer (Settings, Desk, another tab), and a toast timed
+	// from a stale copy would either vanish early or offer an Undo the server can no longer honour.
+	const undoSendWindowMs = (period?: number | null) =>
+		(period ?? undoSendPeriodOf(user.data)) * 1000
 
 	// A plain Send holds delivery for the undo window ('undo'); Schedule send passes an explicit time
 	// ('scheduled'). Both come back as 'Submitted' with a send_at, so the toast has to know which one
@@ -341,6 +344,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		thread_id,
 		submission_id,
 		send_at,
+		undo_send_period,
 	}: {
 		name: string
 		id: string
@@ -351,6 +355,8 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		submission_id?: string
 		/** Set when the server is holding delivery (undo window or scheduled send). */
 		send_at?: string
+		/** Seconds the server held an undo-send for, before its grace; null for a scheduled send. */
+		undo_send_period?: number | null
 	}) => {
 		if (id) mail.id = id
 		updateOriginalMail()
@@ -379,7 +385,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 				__('Message sent.'),
 				'success',
 				{ label: __('Undo'), onClick: () => undoSend.submit({ id: submission_id }) },
-				undoSendWindowMs(),
+				undoSendWindowMs(undo_send_period),
 				thread_id && route.params.threadID !== thread_id
 					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
 					: undefined,

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -7,6 +7,7 @@ import { Mention } from 'frappe-ui/editor'
 import { getAttachmentUrl } from '@/apps/mail/resources'
 import { processInlineImages, raiseToast } from '@/apps/mail/utils'
 import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
+import { undoSendPeriodOf } from '@/apps/mail/utils/undoSend'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 
 import type { ComposeMailData, Identity, UserResource } from '@/apps/mail/types'
@@ -257,9 +258,10 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		{ debounce: 2000 },
 	)
 
-	// Mirrors UNDO_SEND_WINDOW_SECONDS in api/mail.py; the server holds delivery a few seconds
-	// longer than this so a last-moment Undo still lands in time.
-	const UNDO_SEND_WINDOW_MS = 10000
+	// The sender's undo window (User Settings); the server holds delivery a few seconds longer than
+	// this so a last-moment Undo still lands in time (get_undo_send_hold_seconds in api/mail.py).
+	// Read per send, so a change made in Settings applies to the next send without a reopen.
+	const undoSendWindowMs = () => undoSendPeriodOf(user.data) * 1000
 
 	// A plain Send holds delivery for the undo window ('undo'); Schedule send passes an explicit time
 	// ('scheduled'). Both come back as 'Submitted' with a send_at, so the toast has to know which one
@@ -377,7 +379,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 				__('Message sent.'),
 				'success',
 				{ label: __('Undo'), onClick: () => undoSend.submit({ id: submission_id }) },
-				UNDO_SEND_WINDOW_MS,
+				undoSendWindowMs(),
 				thread_id && route.params.threadID !== thread_id
 					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
 					: undefined,

--- a/frontend/src/apps/mail/composables/useSettingsTabs.ts
+++ b/frontend/src/apps/mail/composables/useSettingsTabs.ts
@@ -7,12 +7,14 @@ import {
 	Folders,
 	Mailbox,
 	Palette,
+	PenLine,
 	TreePalm,
 	User,
 } from 'lucide-vue-next'
 
 import Account from '@/apps/mail/components/Settings/Account.vue'
 import AppearanceSettings from '@/apps/mail/components/Settings/AppearanceSettings.vue'
+import ComposeSettings from '@/apps/mail/components/Settings/ComposeSettings.vue'
 import FolderSettings from '@/apps/mail/components/Settings/FolderSettings.vue'
 import IdentitySettings from '@/apps/mail/components/Settings/IdentitySettings.vue'
 import ProfileSettings from '@/apps/mail/components/Settings/ProfileSettings.vue'
@@ -90,6 +92,13 @@ export const useSettingsTabs = (exclude: string[] = []) => {
 						value: 'signatures',
 						icon: Feather,
 						component: markRaw(SignatureSettings),
+						condition: jmap,
+					},
+					{
+						label: __('Compose'),
+						value: 'compose',
+						icon: PenLine,
+						component: markRaw(ComposeSettings),
 						condition: jmap,
 					},
 					{

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -58,6 +58,8 @@ export interface User {
 	user_settings?: string
 	group_messages_by?: 'None' | 'Day' | 'Month'
 	show_reading_pane?: 0 | 1
+	// Seconds a plain Send is held so it can be undone; see utils/undoSend.ts.
+	undo_send_period?: '5' | '10' | '20' | '30'
 
 	enabled: boolean
 	is_suite_admin: boolean

--- a/frontend/src/apps/mail/utils/undoSend.ts
+++ b/frontend/src/apps/mail/utils/undoSend.ts
@@ -1,0 +1,18 @@
+import type { User } from '@/apps/mail/types'
+
+/** The undo-send periods offered in Settings; mirrors UNDO_SEND_PERIODS in suite/mail/utils/user.py. */
+export const UNDO_SEND_PERIODS = [5, 10, 20, 30] as const
+export const DEFAULT_UNDO_SEND_PERIOD = 5
+
+/**
+ * Seconds a plain Send is held for this user (User Settings.undo_send_period), which is how long
+ * the Undo toast stays up. The server adds a few seconds' grace on top of it, so a last-moment
+ * Undo still lands in time. Off-list or missing values fall back to the default, as they do on
+ * the server.
+ */
+export const undoSendPeriodOf = (user?: Pick<User, 'undo_send_period'>): number => {
+	const period = Number(user?.undo_send_period)
+	return (UNDO_SEND_PERIODS as readonly number[]).includes(period)
+		? period
+		: DEFAULT_UNDO_SEND_PERIOD
+}

--- a/frontend/src/apps/mail/utils/undoSend.ts
+++ b/frontend/src/apps/mail/utils/undoSend.ts
@@ -5,10 +5,10 @@ export const UNDO_SEND_PERIODS = [5, 10, 20, 30] as const
 export const DEFAULT_UNDO_SEND_PERIOD = 5
 
 /**
- * Seconds a plain Send is held for this user (User Settings.undo_send_period), which is how long
- * the Undo toast stays up. The server adds a few seconds' grace on top of it, so a last-moment
- * Undo still lands in time. Off-list or missing values fall back to the default, as they do on
- * the server.
+ * Seconds a plain Send is held for this user (User Settings.undo_send_period), before the few
+ * seconds' grace the server adds so a last-moment Undo still lands in time. The composer times
+ * its Undo toast from the period the server echoes with each send result and reads this only as
+ * a fallback. Off-list or missing values fall back to the default, as they do on the server.
  */
 export const undoSendPeriodOf = (user?: Pick<User, 'undo_send_period'>): number => {
 	const period = Number(user?.undo_send_period)

--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -204,6 +204,7 @@ def get_user_info() -> dict | None:
             USER.time_zone,
             USER_SETTINGS.group_messages_by,
             USER_SETTINGS.show_reading_pane,
+            USER_SETTINGS.undo_send_period,
             USER_SETTINGS.name.as_("user_settings"),
         )
         .where(USER.name == user)

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -64,26 +64,31 @@ from suite.mail.store import get_email_address_index
 from suite.mail.utils import get_config, log_mail_error
 from suite.mail.utils.delivery_status import parse_delivery_status
 from suite.mail.utils.dt import from_utc_z, normalize_utc_z, to_user_timezone, to_utc_z
-from suite.mail.utils.user import get_account_emails, is_jmap_configured
+from suite.mail.utils.user import get_account_emails, get_undo_send_period, is_jmap_configured
 from suite.mail.utils.validation import normalize_screened_value, validate_screened_value
 from suite.utils.rate_limiter import dynamic_rate_limit
 
 AVATAR_CACHE_TTL = 60 * 60 * 24
 SCREENING_FETCH_LIMIT = 500
 
-# Undo send: the composer's default Send holds delivery (FUTURERELEASE) for the visible
-# undo window plus a grace that covers request latency, so an Undo clicked at the last
-# moment still reaches the server before the hold elapses. Computed on the server clock —
-# a skewed client clock must not be able to shorten (or invalidate) the hold. The window
-# half is mirrored by UNDO_SEND_WINDOW_MS in ComposeMailEditor.vue.
-UNDO_SEND_WINDOW_SECONDS = 10
-UNDO_SEND_HOLD_SECONDS = UNDO_SEND_WINDOW_SECONDS + 3
+# Undo send: the composer's default Send holds delivery (FUTURERELEASE) for the sender's
+# undo window (User Settings.undo_send_period, which also times the toast in
+# useComposeMail.ts) plus a grace that covers request latency, so an Undo clicked at the
+# last moment still reaches the server before the hold elapses. Computed on the server
+# clock: a skewed client clock must not be able to shorten (or invalidate) the hold.
+UNDO_SEND_GRACE_SECONDS = 3
 
 # All Inboxes bounds. limit/start are user-supplied, and per_account_limit (= start + limit) is fetched
 # from *every* account and merged in memory, so both are clamped. MAX_FETCH caps the deepest reachable
 # position (page length ~25 → ~20 pages), which is far beyond any real unified-inbox scroll.
 ALL_INBOX_MAX_LIMIT = 100
 ALL_INBOX_MAX_FETCH = 500
+
+
+def get_undo_send_hold_seconds(user: str | None = None) -> int:
+    """Returns how long a plain Send by `user` (the session user by default) is held before delivery."""
+
+    return get_undo_send_period(user or frappe.session.user) + UNDO_SEND_GRACE_SECONDS
 
 
 @frappe.whitelist()
@@ -637,7 +642,7 @@ def create_mail(
 
     send_at = from_utc_z(send_at)
     if undo_send and not send_at and not save_as_draft:
-        send_at = add_to_date(now(), seconds=UNDO_SEND_HOLD_SECONDS)
+        send_at = add_to_date(now(), seconds=get_undo_send_hold_seconds())
 
     doc = MailQueue._create(
         user=get_user_for_jmap_account(account, raise_exception=True),
@@ -740,7 +745,7 @@ def update_draft_mail(
 
     send_at = from_utc_z(send_at)
     if undo_send and submit and not send_at:
-        send_at = add_to_date(now(), seconds=UNDO_SEND_HOLD_SECONDS)
+        send_at = add_to_date(now(), seconds=get_undo_send_hold_seconds())
 
     queue = message.submit(send_at=send_at) if submit else message.save_draft()
 

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -2,6 +2,7 @@ import hashlib
 import io
 import os
 import zipfile
+from datetime import datetime
 
 import frappe
 import pydenticon
@@ -85,10 +86,15 @@ ALL_INBOX_MAX_LIMIT = 100
 ALL_INBOX_MAX_FETCH = 500
 
 
-def get_undo_send_hold_seconds(user: str | None = None) -> int:
-    """Returns how long a plain Send by `user` (the session user by default) is held before delivery."""
+def get_undo_send_hold() -> tuple[int, datetime]:
+    """Returns the session user's undo-send period and the time a plain Send made now is held until.
 
-    return get_undo_send_period(user or frappe.session.user) + UNDO_SEND_GRACE_SECONDS
+    The period goes back to the composer with the send result, so the Undo toast is timed from
+    the hold the server applied rather than from whatever copy of the setting the client holds.
+    """
+
+    period = get_undo_send_period(frappe.session.user)
+    return period, add_to_date(now(), seconds=period + UNDO_SEND_GRACE_SECONDS)
 
 
 @frappe.whitelist()
@@ -641,8 +647,9 @@ def create_mail(
         ]
 
     send_at = from_utc_z(send_at)
+    undo_send_period = None
     if undo_send and not send_at and not save_as_draft:
-        send_at = add_to_date(now(), seconds=get_undo_send_hold_seconds())
+        undo_send_period, send_at = get_undo_send_hold()
 
     doc = MailQueue._create(
         user=get_user_for_jmap_account(account, raise_exception=True),
@@ -672,6 +679,7 @@ def create_mail(
         "thread_id": doc.thread_id,
         "submission_id": doc.submission_id,
         "send_at": to_utc_z(doc.send_at),
+        "undo_send_period": undo_send_period,
     }
 
 
@@ -744,8 +752,9 @@ def update_draft_mail(
             )
 
     send_at = from_utc_z(send_at)
+    undo_send_period = None
     if undo_send and submit and not send_at:
-        send_at = add_to_date(now(), seconds=get_undo_send_hold_seconds())
+        undo_send_period, send_at = get_undo_send_hold()
 
     queue = message.submit(send_at=send_at) if submit else message.save_draft()
 
@@ -761,6 +770,7 @@ def update_draft_mail(
         "thread_id": queue.thread_id,
         "submission_id": queue.submission_id,
         "send_at": to_utc_z(queue.send_at),
+        "undo_send_period": undo_send_period,
     }
 
 

--- a/suite/mail/doctype/user_settings/test_user_settings.py
+++ b/suite/mail/doctype/user_settings/test_user_settings.py
@@ -1,8 +1,10 @@
 # Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests import IntegrationTestCase
+
+from suite.mail.utils.user import DEFAULT_UNDO_SEND_PERIOD, get_undo_send_period
 
 # On IntegrationTestCase, the doctype test records and all
 # link-field test record dependencies are recursively loaded
@@ -17,4 +19,28 @@ class IntegrationTestUserSettings(IntegrationTestCase):
     Use this class for testing interactions between multiple components.
     """
 
-    pass
+    def test_undo_send_period(self):
+        # Every user's plain Send is held for their own period. Anything off the list (no settings
+        # row yet, a direct DB edit) falls back to the default, so the hold is never 0 or unbounded.
+        user = frappe.get_doc(
+            doctype="User",
+            email=f"undo-send-{frappe.generate_hash(length=6)}@example.test",
+            first_name="Undo",
+            send_welcome_email=0,
+        ).insert(ignore_permissions=True)
+        settings = frappe.db.get_value("User Settings", {"user": user.name})
+        self.assertTrue(settings, "User Settings should be created with the user.")
+        self.assertEqual(get_undo_send_period(user.name), DEFAULT_UNDO_SEND_PERIOD)
+
+        frappe.db.set_value("User Settings", settings, "undo_send_period", "30")
+        self.assertEqual(get_undo_send_period(user.name), 30)
+
+        frappe.db.set_value("User Settings", settings, "undo_send_period", "7")
+        self.assertEqual(get_undo_send_period(user.name), DEFAULT_UNDO_SEND_PERIOD)
+
+        self.assertEqual(get_undo_send_period("nobody@example.test"), DEFAULT_UNDO_SEND_PERIOD)
+
+        # The form itself only offers the listed periods.
+        doc = frappe.get_doc("User Settings", settings)
+        doc.undo_send_period = "7"
+        self.assertRaises(frappe.ValidationError, doc.save)

--- a/suite/mail/doctype/user_settings/user_settings.json
+++ b/suite/mail/doctype/user_settings/user_settings.json
@@ -26,7 +26,9 @@
   "mail_list_section",
   "group_messages_by",
   "column_break_cxak",
-  "show_reading_pane"
+  "show_reading_pane",
+  "compose_section",
+  "undo_send_period"
  ],
  "fields": [
   {
@@ -190,6 +192,21 @@
    "fieldname": "show_reading_pane",
    "fieldtype": "Check",
    "label": "Split View"
+  },
+  {
+   "depends_on": "eval: doc.username",
+   "fieldname": "compose_section",
+   "fieldtype": "Section Break",
+   "label": "Compose"
+  },
+  {
+   "default": "5",
+   "description": "Seconds a sent message is held before delivery so it can still be undone from the Mail UI.",
+   "fieldname": "undo_send_period",
+   "fieldtype": "Select",
+   "label": "Undo Send Period",
+   "options": "5\n10\n20\n30",
+   "reqd": 1
   }
  ],
  "grid_page_length": 50,
@@ -201,7 +218,7 @@
    "link_fieldname": "user_settings"
   }
  ],
- "modified": "2026-08-07 12:00:00.000000",
+ "modified": "2026-08-31 12:00:00.000000",
  "modified_by": "Administrator",
  "module": "Mail",
  "name": "User Settings",

--- a/suite/mail/doctype/user_settings/user_settings.py
+++ b/suite/mail/doctype/user_settings/user_settings.py
@@ -32,6 +32,7 @@ class UserSettings(OwnerFromUser, Document):
         disable_push_subscriptions: DF.Check
         group_messages_by: DF.Literal["None", "Day", "Month"]
         show_reading_pane: DF.Check
+        undo_send_period: DF.Literal["5", "10", "20", "30"]
         user: DF.Link
         username: DF.Data | None
     # end: auto-generated types

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -429,10 +429,8 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
                 send_at=get_datetime_str(add_to_date(now(), minutes=60)),
             )
 
-    def test_undo_send_holds_and_cancels(self):
-        # The composer's default Send: the server computes a short hold so the sender
-        # can cancel from the undo toast; Undo is just cancel_scheduled_mail.
-        from suite.mail.api.mail import UNDO_SEND_HOLD_SECONDS
+    def _undo_send(self) -> tuple[dict, float]:
+        """Sends a plain (undo-send) mail from the class sender; returns the result and its remaining hold in seconds."""
 
         result = self.send_mail(self.sender, self.recipient.email, undo_send=True)
         self.assertEqual(result["status"], "Submitted", result.get("error"))
@@ -440,8 +438,16 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         self.assertTrue(result["send_at"])
 
         hold = time_diff_in_seconds(frappe.db.get_value("Mail Queue", result["name"], "send_at"), now())
+        return result, hold
+
+    def test_undo_send_holds_and_cancels(self):
+        # The composer's default Send: the server computes a short hold so the sender
+        # can cancel from the undo toast; Undo is just cancel_scheduled_mail.
+        from suite.mail.api.mail import get_undo_send_hold_seconds
+
+        result, hold = self._undo_send()
         self.assertGreater(hold, 0)
-        self.assertLessEqual(hold, UNDO_SEND_HOLD_SECONDS + 5)
+        self.assertLessEqual(hold, get_undo_send_hold_seconds(self.sender.email) + 5)
 
         account = self.personal_account(self.sender)
         with self.set_user(self.sender.email):
@@ -450,6 +456,22 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
 
         submission = self._get_submission(account, result["submission_id"])
         self.assertEqual(submission["undoStatus"], "canceled")
+
+    def test_undo_send_hold_follows_user_settings(self):
+        # The hold is the sender's own Undo Send period (User Settings) plus the grace, so a
+        # longer period keeps the message recallable for longer.
+        from suite.mail.api.mail import UNDO_SEND_GRACE_SECONDS
+        from suite.mail.utils.user import DEFAULT_UNDO_SEND_PERIOD
+
+        settings = frappe.db.get_value("User Settings", {"user": self.sender.email})
+        frappe.db.set_value("User Settings", settings, "undo_send_period", "30")
+        self.addCleanup(
+            frappe.db.set_value, "User Settings", settings, "undo_send_period", str(DEFAULT_UNDO_SEND_PERIOD)
+        )
+
+        _, hold = self._undo_send()
+        self.assertGreater(hold, DEFAULT_UNDO_SEND_PERIOD + UNDO_SEND_GRACE_SECONDS)
+        self.assertLessEqual(hold, 30 + UNDO_SEND_GRACE_SECONDS + 5)
 
     def test_submission_details(self):
         scheduled = self._schedule(minutes=120)

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -443,11 +443,15 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
     def test_undo_send_holds_and_cancels(self):
         # The composer's default Send: the server computes a short hold so the sender
         # can cancel from the undo toast; Undo is just cancel_scheduled_mail.
-        from suite.mail.api.mail import get_undo_send_hold_seconds
+        from suite.mail.api.mail import UNDO_SEND_GRACE_SECONDS
+        from suite.mail.utils.user import get_undo_send_period
 
         result, hold = self._undo_send()
+        period = get_undo_send_period(self.sender.email)
         self.assertGreater(hold, 0)
-        self.assertLessEqual(hold, get_undo_send_hold_seconds(self.sender.email) + 5)
+        self.assertLessEqual(hold, period + UNDO_SEND_GRACE_SECONDS + 5)
+        # The composer times its Undo toast from the period the server applied.
+        self.assertEqual(result["undo_send_period"], period)
 
         account = self.personal_account(self.sender)
         with self.set_user(self.sender.email):
@@ -469,7 +473,8 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
             frappe.db.set_value, "User Settings", settings, "undo_send_period", str(DEFAULT_UNDO_SEND_PERIOD)
         )
 
-        _, hold = self._undo_send()
+        result, hold = self._undo_send()
+        self.assertEqual(result["undo_send_period"], 30)
         self.assertGreater(hold, DEFAULT_UNDO_SEND_PERIOD + UNDO_SEND_GRACE_SECONDS)
         self.assertLessEqual(hold, 30 + UNDO_SEND_GRACE_SECONDS + 5)
 

--- a/suite/mail/utils/user.py
+++ b/suite/mail/utils/user.py
@@ -2,12 +2,18 @@ from typing import Literal
 
 import frappe
 from frappe import _
+from frappe.utils import cint
 from frappe.utils.caching import request_cache
 
 from suite.mail.store import Entity, get_data_store
 from suite.utils import reconnect_on_failure
 from suite.utils.dt import utcnow
 from suite.utils.user import is_system_manager
+
+# Undo send: the choices offered for how long a plain Send is held before delivery (User
+# Settings.undo_send_period). The same list backs the Select's options and the Mail UI's dropdown.
+UNDO_SEND_PERIODS = (5, 10, 20, 30)
+DEFAULT_UNDO_SEND_PERIOD = 5
 
 
 def has_user_settings(user: str, raise_exception: bool = False) -> bool:
@@ -20,6 +26,17 @@ def has_user_settings(user: str, raise_exception: bool = False) -> bool:
         frappe.throw(_("User {0} does not have User Settings configured.").format(frappe.bold(user)))
 
     return False
+
+
+def get_undo_send_period(user: str) -> int:
+    """Returns the seconds the user's plain Send is held so it can be undone.
+
+    Falls back to the default when the user has no settings row yet or the stored value is off
+    the list (a direct DB edit): the hold must never be zero or unbounded.
+    """
+
+    period = cint(frappe.db.get_value("User Settings", {"user": user}, "undo_send_period"))
+    return period if period in UNDO_SEND_PERIODS else DEFAULT_UNDO_SEND_PERIOD
 
 
 def get_jmap_configured_users() -> list[str]:


### PR DESCRIPTION
## Summary
- `User Settings` gets a Compose section with `undo_send_period` (Select: 5, 10, 20, 30 seconds, default 5, required). Existing rows pick up the column default, so no patch is needed.
- The server no longer holds a plain Send for a fixed 10 s + 3 s: `get_undo_send_hold_seconds()` uses the sender's period plus the 3 s grace, with a fallback to the default when the row is missing or holds an off-list value. `get_user_info` exposes `undo_send_period`.
- The composer's Undo toast lives for the user's period, read per send so a change in Settings applies to the next send without reopening the composer.
- New Compose tab in Mail settings (desktop dialog and mobile list, after Signatures) with an "Undo Send" row to edit the period; shared periods/default live in `utils/undoSend.ts`.

## Test plan
- `bench --site <site> run-tests --module suite.mail.doctype.user_settings.test_user_settings` (fallback + Select validation)
- `bench --site <site> run-tests --module suite.mail.tests.test_mail_scheduled_send --test test_undo_send_holds_and_cancels --test test_undo_send_hold_follows_user_settings` (needs Stalwart; the second sets 30 s and checks the hold grows)
- Manually: Settings > Compose > pick 20 seconds > Save; send a mail and confirm the Undo toast outlives 10 s and Undo still returns the message to Drafts. Verified against a live Stalwart: hold was ~22 s server-side and the toast was still up at 14 s.