### PR TITLE
feat(mail): add shortcuts for undo send, schedule send and the outbox

### DIFF
--- a/frontend/src/apps/mail/components/ComposeMailEditor.vue
+++ b/frontend/src/apps/mail/components/ComposeMailEditor.vue
@@ -474,11 +474,12 @@ const handleKeydown = (e: KeyboardEvent) => {
 	handleDiscardShortcut(e)
 }
 
+// ⌘Enter sends; with Shift it asks when to, as the split button's menu does.
 const handleSendShortcut = (e: KeyboardEvent) => {
-	if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-		e.preventDefault()
-		sendMail()
-	}
+	if (!(e.metaKey || e.ctrlKey) || e.key !== 'Enter') return
+	e.preventDefault()
+	if (e.shiftKey) openScheduleModal()
+	else sendMail()
 }
 
 const handleDiscardShortcut = (e: KeyboardEvent) => {

--- a/frontend/src/apps/mail/components/ComposeMailToolbar.vue
+++ b/frontend/src/apps/mail/components/ComposeMailToolbar.vue
@@ -73,7 +73,7 @@
 					<Dropdown :options="sendOptions">
 						<Button
 							variant="solid"
-							:tooltip="__('Schedule send')"
+							:tooltip="__('Schedule send ({0}+Shift+Enter)', [modifier])"
 							:disabled="isRecipientsEmpty || isUploading"
 							class="!rounded-l-none"
 						>

--- a/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
+++ b/frontend/src/apps/mail/components/Modals/ShortcutsModal.vue
@@ -55,6 +55,8 @@ const shortcutGroups = computed(() => [
 			shortcuts: [
 				[['C'], __('Compose New Mail')],
 				[[modifier.value, 'Enter'], __('Send Mail')],
+				[[modifier.value, 'Shift', 'Enter'], __('Schedule Send')],
+				[[modifier.value, 'Z'], __('Undo Send')],
 				[[modifier.value, 'D'], __('Discard Draft')],
 				[['R'], __('Reply to Mail')],
 				[['Shift', 'R'], __('Reply All to Mail')],
@@ -106,6 +108,7 @@ const shortcutGroups = computed(() => [
 				[['G', __('then'), 'F'], __('Go to Starred')],
 				[['G', __('then'), 'S'], __('Go to {0}', [mailboxName('sent')])],
 				[['G', __('then'), 'D'], __('Go to {0}', [mailboxName('drafts')])],
+				[['G', __('then'), 'O'], __('Go to Outbox')],
 				[['G', __('then'), 'J'], __('Go to {0}', [mailboxName('junk')])],
 				[['G', __('then'), 'E'], __('Go to {0}', [mailboxName('archive')])],
 				[['G', __('then'), 'T'], __('Go to {0}', [mailboxName('trash')])],

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -269,8 +269,11 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 
 	// A plain Send holds delivery for the undo window ('undo'); Schedule send passes an explicit time
 	// ('scheduled'). Both come back as 'Submitted' with a send_at, so the toast has to know which one
-	// it confirms.
+	// it confirms — and which account it went out as. The scope follows the active account, and the
+	// hold is long enough to switch accounts in, so an undo names the account pinned at send time
+	// rather than whichever the scope has moved on to.
 	const sendMode = ref<'undo' | 'scheduled'>('undo')
+	let sentAs = scopeAccountId.value
 
 	const sendMail = async (sendAt?: string) => {
 		if (deleteMail.loading) return
@@ -287,6 +290,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		if (createMail.loading) await createMail.promise
 		if (updateDraft.loading) await updateDraft.promise
 
+		sentAs = scopeAccountId.value
 		if (mail.id) updateDraft.submit({ submit: true, send_at: sendAt, undo_send: !sendAt })
 		else createMail.submit({ save_as_draft: false, send_at: sendAt, undo_send: !sendAt })
 	}
@@ -330,7 +334,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	// is just cancelling that submission — the message lands back in Drafts.
 	const undoSend = createResource({
 		url: 'suite.mail.api.scheduled.cancel_scheduled_mail',
-		makeParams: ({ id }: { id: string }) => ({ account: scopeAccountId.value, id }),
+		makeParams: ({ account, id }: { account: string; id: string }) => ({ account, id }),
 		onSuccess: () => {
 			reloadMails()
 			raiseToast(__('Sending undone. The message is back in your drafts.'))
@@ -345,13 +349,22 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 	// The two are one action: whichever fires takes the toast and the slot with it, so the other
 	// cannot cancel twice. When the window closes the slot is only vacated if it is still this
 	// send's — a list action taken since has its own undo in there, and the toasts are its.
-	const offerUndoSend = (submissionId: string, windowMs: number, threadId?: string) => {
+	//
+	// It outlives the view it was sent from: cancelling a hold is a server call, as good from the
+	// Outbox or the Screener as from the inbox, and looking at Sent right after sending is exactly
+	// when a typo gets noticed.
+	const offerUndoSend = (
+		account: string,
+		submissionId: string,
+		windowMs: number,
+		threadId?: string,
+	) => {
 		const undoSendNow = () => {
 			toast.dismiss(sentToast)
 			retireUndoAction(undoSendNow)
-			undoSend.submit({ id: submissionId })
+			undoSend.submit({ account, id: submissionId })
 		}
-		setUndoAction(undoSendNow)
+		setUndoAction(undoSendNow, { outlivesView: true })
 		setTimeout(() => retireUndoAction(undoSendNow), windowMs)
 
 		// Two buttons, and they are not equals: Undo expires with the toast, so it takes the urgent
@@ -409,7 +422,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 
 		if (status === 'Drafted' && isSavingDraft.value) raiseToast(__('Draft saved.'))
 		else if (status === 'Submitted' && send_at && submission_id && sendMode.value === 'undo')
-			offerUndoSend(submission_id, undoSendWindowMs(undo_send_period), thread_id)
+			offerUndoSend(sentAs, submission_id, undoSendWindowMs(undo_send_period), thread_id)
 		else if (status === 'Submitted' && send_at && sendMode.value === 'scheduled')
 			raiseToast(__('Send scheduled.'), 'success', {
 				label: __('View'),

--- a/frontend/src/apps/mail/composables/useComposeMail.ts
+++ b/frontend/src/apps/mail/composables/useComposeMail.ts
@@ -1,11 +1,12 @@
 import { computed, inject, onScopeDispose, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { watchDebounced } from '@vueuse/core'
-import { createResource } from 'frappe-ui'
+import { createResource, toast } from 'frappe-ui'
 import { Mention } from 'frappe-ui/editor'
 
 import { getAttachmentUrl } from '@/apps/mail/resources'
 import { processInlineImages, raiseToast } from '@/apps/mail/utils'
+import { useUndo } from '@/apps/mail/utils/composables'
 import { createMentionSuggestion } from '@/apps/mail/utils/mentionSuggestion'
 import { undoSendPeriodOf } from '@/apps/mail/utils/undoSend'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
@@ -337,6 +338,36 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 		onError: (error: { message: string }) => raiseToast(error.message, 'error'),
 	})
 
+	const { setUndoAction, retireUndoAction } = useUndo()
+
+	// The sent toast, with Undo on it for as long as the server holds delivery. The same undo goes in
+	// the ⌘Z slot for the same time, so the key that takes back an archive takes back a send too.
+	// The two are one action: whichever fires takes the toast and the slot with it, so the other
+	// cannot cancel twice. When the window closes the slot is only vacated if it is still this
+	// send's — a list action taken since has its own undo in there, and the toasts are its.
+	const offerUndoSend = (submissionId: string, windowMs: number, threadId?: string) => {
+		const undoSendNow = () => {
+			toast.dismiss(sentToast)
+			retireUndoAction(undoSendNow)
+			undoSend.submit({ id: submissionId })
+		}
+		setUndoAction(undoSendNow)
+		setTimeout(() => retireUndoAction(undoSendNow), windowMs)
+
+		// Two buttons, and they are not equals: Undo expires with the toast, so it takes the urgent
+		// slot; View is an aside you could reach any time from Sent, offered only when the thread
+		// isn't already the one in front of you.
+		const sentToast = raiseToast(
+			__('Message sent.'),
+			'success',
+			{ label: __('Undo'), onClick: undoSendNow },
+			windowMs,
+			threadId && route.params.threadID !== threadId
+				? { label: __('View'), onClick: () => viewSentMessage(threadId) }
+				: undefined,
+		)
+	}
+
 	const onMailUpdateSuccess = ({
 		id,
 		status,
@@ -378,18 +409,7 @@ export const useComposeMail = (options: ComposeMailOptions) => {
 
 		if (status === 'Drafted' && isSavingDraft.value) raiseToast(__('Draft saved.'))
 		else if (status === 'Submitted' && send_at && submission_id && sendMode.value === 'undo')
-			// Two buttons, and they are not equals: Undo expires with the toast, so it takes the
-			// urgent slot; View is an aside you could reach any time from Sent, offered only when the
-			// thread isn't already the one in front of you.
-			raiseToast(
-				__('Message sent.'),
-				'success',
-				{ label: __('Undo'), onClick: () => undoSend.submit({ id: submission_id }) },
-				undoSendWindowMs(undo_send_period),
-				thread_id && route.params.threadID !== thread_id
-					? { label: __('View'), onClick: () => viewSentMessage(thread_id) }
-					: undefined,
-			)
+			offerUndoSend(submission_id, undoSendWindowMs(undo_send_period), thread_id)
 		else if (status === 'Submitted' && send_at && sendMode.value === 'scheduled')
 			raiseToast(__('Send scheduled.'), 'success', {
 				label: __('View'),

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -463,12 +463,6 @@ const handleThreadActions = (e: KeyboardEvent, key: string) => {
 
 const handleKeyDown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
-	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
-		e.preventDefault()
-		gPrefix.disarm()
-		return undo()
-	}
-
 	if (shouldIgnoreKeypress(e)) return
 
 	// Escape backs out of the open thread, then clears the cursor.
@@ -754,7 +748,7 @@ const handleSetSpamStatus = (spam: boolean, target?: Thread) => {
 // The merged list is inbox-scoped, so its rows always summarise from the whole conversation — never
 // from a folder, as Sent and Drafts do. No undo yet: the undo requests would have to be scoped to the
 // row's own account rather than the active one.
-const { setUndoAction, undo } = useUndo()
+const { setUndoAction } = useUndo()
 
 const { runMailRemoval } = useMailRemoval({
 	row: () => openRow.value,

--- a/frontend/src/apps/mail/pages/MailLayout.vue
+++ b/frontend/src/apps/mail/pages/MailLayout.vue
@@ -21,7 +21,7 @@ import { mailServerUnavailable } from '@/boot/config'
 import { type RouteLocationRaw, useRouter } from 'vue-router'
 import { shouldIgnoreKeypress } from '@/apps/mail/utils'
 import { useGPrefix } from '@/apps/mail/utils/listNavigation'
-import { useScreenSize, useTheme } from '@/apps/mail/utils/composables'
+import { useScreenSize, useTheme, useUndo } from '@/apps/mail/utils/composables'
 import { showNotification } from '@/apps/mail/utils/push-notifications'
 import { initSocket } from '@/apps/mail/socket'
 import dayjs from '@/apps/mail/utils/dayjs'
@@ -60,8 +60,9 @@ const gPrefix = useGPrefix()
 // `g` is also the prefix each list uses for its own g g / G jump to the ends. Both listeners
 // see the key and keep their own prefix state; this one only ever acts on a following letter,
 // so a `g g` falls through to the list untouched.
-// `g` then a letter. Beyond the account's own folders this reaches the two views that are not
-// folders at all — the merged list and the Screener — so the map holds routes, not mailbox ids.
+// `g` then a letter. Beyond the account's own folders this reaches the three views that are not
+// folders at all — the merged list, the Screener and the Outbox — so the map holds routes, not
+// mailbox ids.
 //
 // `a` is All Inboxes (as in Gmail's All Mail), which pushes Archive to `e` — the letter that
 // already archives a thread, so one letter means archive throughout. The Screener takes `r` for
@@ -71,6 +72,7 @@ const mailboxRoute = (mailbox: string) => ({ name: 'mail-mailbox', params: { acc
 const GO_TO_KEYS: Record<string, () => RouteLocationRaw> = {
 	a: () => ({ name: 'mail-all-inboxes' }),
 	r: () => ({ name: 'mail-screener', params: { accountId } }),
+	o: () => ({ name: 'mail-outbox', params: { accountId } }),
 	i: () => mailboxRoute(mailboxIds.inbox),
 	f: () => mailboxRoute('starred'),
 	s: () => mailboxRoute(mailboxIds.sent),
@@ -80,8 +82,21 @@ const GO_TO_KEYS: Record<string, () => RouteLocationRaw> = {
 	t: () => mailboxRoute(mailboxIds.trash),
 }
 
+// ⌘Z takes back the last undoable action, wherever it was taken. The slot is app-wide (useUndo),
+// and so is what can fill it: a send is undoable from the composer window, which is open on every
+// page — so the key lives here rather than in each list, where it was dead on the pages without one.
+const { undo } = useUndo()
+
 const handleGlobalShortcuts = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
+
+	// Above the guard, which drops every modified key: this is the one shortcut here that has one.
+	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
+		e.preventDefault()
+		gPrefix.disarm()
+		return undo()
+	}
+
 	if (shouldIgnoreKeypress(e)) return
 
 	if (e.key === '?') {

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -543,7 +543,7 @@ const router = useRouter()
 const { isMobile } = useScreenSize()
 const { listReloadRequest } = useListReload()
 const { setMobileSelectionActive } = useMobileSelection()
-const { undo, setUndoAction } = useUndo()
+const { setUndoAction } = useUndo()
 
 const socket = inject('$socket')
 const user = inject('$user') as UserResource
@@ -772,13 +772,6 @@ const handleKeyDown = (e: KeyboardEvent) => {
 		e.preventDefault()
 		gPrefix.disarm()
 		return toggleSelectAll(true)
-	}
-
-	// Handle Ctrl/Cmd+Z (Undo)
-	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
-		e.preventDefault()
-		gPrefix.disarm()
-		return undo()
 	}
 
 	if (shouldIgnoreKeypress(e)) return

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -543,7 +543,7 @@ const router = useRouter()
 const { isMobile } = useScreenSize()
 const { listReloadRequest } = useListReload()
 const { setMobileSelectionActive } = useMobileSelection()
-const { setUndoAction } = useUndo()
+const { dropViewUndo } = useUndo()
 
 const socket = inject('$socket')
 const user = inject('$user') as UserResource
@@ -1351,7 +1351,7 @@ onUnmounted(() => {
 	window.removeEventListener('keyup', handleKeyUp)
 	if (reloadInterval.value) clearInterval(reloadInterval.value)
 	// Leaving the mailbox drops any pending undo so a lingering toast can't undo into another view.
-	setUndoAction(undefined)
+	dropViewUndo()
 })
 
 const goToMailbox = () =>

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -668,14 +668,6 @@ watch(openSender, (sender) => {
 // allow the sender straight to Archive or Trash, and Esc closes. Else inert.
 const handleKeydown = (e: KeyboardEvent) => {
 	const key = e.key.toLowerCase()
-
-	// Above the guard below: a verdict is just as often given from a list row with nothing open, and
-	// that is exactly when you'd reach for undo — the row is gone and there is nothing else to press.
-	if ((e.metaKey || e.ctrlKey) && key === 'z' && !shouldIgnoreKeypress(e, true)) {
-		e.preventDefault()
-		return undo()
-	}
-
 	if (!openSender.value || shouldIgnoreKeypress(e)) return
 
 	if (key === 'escape') {

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -487,7 +487,7 @@ const showReadingPane = useReadingPane()
 
 // The same undo the thread lists hang Cmd/Ctrl+Z off — one shared slot, so the last thing you did in
 // mail is the thing that key takes back, wherever you did it.
-const { setUndoAction, undo } = useUndo()
+const { setUndoAction, undo, dropViewUndo } = useUndo()
 
 // The Screener only exists when screening is enabled. If it's off, render nothing and send the user to
 // their inbox (the route is still reachable by URL even though the sidebar hides it).
@@ -742,7 +742,7 @@ onMounted(() => {
 onUnmounted(() => {
 	window.removeEventListener('keydown', handleKeydown)
 	// Don't leave a verdict undoable from a view that can't show what came back.
-	setUndoAction(undefined)
+	dropViewUndo()
 	clearInterval(pollInterval)
 	// Don't strand a queued batch on navigation — the acted rows were already removed optimistically.
 	if (flushTimer) {

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -324,6 +324,13 @@ export const useUndo = () => {
 		undoAction.value = undefined
 	}
 
+	// Take one action out of the slot, and only if it is still the one there: for an undo that lapses
+	// on its own — a send, once the server's hold is over. Unlike clearing, it leaves the toasts alone:
+	// this action's is long gone by then, and whatever is on screen belongs to a later one.
+	const retireUndoAction = (action: () => void) => {
+		if (undoAction.value === action) undoAction.value = undefined
+	}
+
 	// Wrap the current undo so `step` runs first — lets a side effect (e.g. a junk-list entry) be
 	// reverted on top of the primary undo without replacing it.
 	const prependUndoAction = (step: () => void) => {
@@ -334,7 +341,7 @@ export const useUndo = () => {
 		}
 	}
 
-	return { setUndoAction, undo, prependUndoAction }
+	return { setUndoAction, undo, prependUndoAction, retireUndoAction }
 }
 
 // Shared state for the compose window. A single <SendMail> (rendered in DefaultLayout) reacts to

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -308,14 +308,27 @@ export const useKeyboardOpen = () => {
 
 const undoAction = ref<() => void>()
 
+// The action in the slot that is the app's rather than a view's, if that is what is there. A list's
+// undo puts rows back into a list that has to still be on screen, so it dies with its view; a send's
+// undo is a server call, as good from the next page as from this one, and stays.
+let outlivingAction: (() => void) | undefined
+
 export const useUndo = () => {
-	const setUndoAction = (action?: () => void) => {
+	const setUndoAction = (action?: () => void, { outlivesView = false } = {}) => {
 		undoAction.value = action
+		outlivingAction = outlivesView ? action : undefined
 		// Clearing the undo with no replacement toast (e.g. leaving the mailbox) leaves a lingering toast
 		// whose "Undo" button is now dead — dismiss toasts. When a new action is set instead, the toast it
 		// raises right after (via raiseOptimisticToast/raisePromiseToast) does the removeAll, and doing it
 		// here too would dismiss the reconcile paths' in-flight loading toast — so only clear on undefined.
 		if (!action) toast.removeAll()
+	}
+
+	// What a view does on the way out: its own undo goes, toast and all, so nothing can undo into a
+	// list that is no longer there. An undo that outlives views is left alone, toast included.
+	const dropViewUndo = () => {
+		if (undoAction.value && undoAction.value === outlivingAction) return
+		setUndoAction(undefined)
 	}
 
 	const undo = () => {
@@ -341,7 +354,7 @@ export const useUndo = () => {
 		}
 	}
 
-	return { setUndoAction, undo, prependUndoAction, retireUndoAction }
+	return { setUndoAction, undo, prependUndoAction, retireUndoAction, dropViewUndo }
 }
 
 // Shared state for the compose window. A single <SendMail> (rendered in DefaultLayout) reacts to


### PR DESCRIPTION
## Summary
- **Cmd/Ctrl+Shift+Enter** in the composer opens *Schedule send* (Cmd/Ctrl+Enter still sends); the split-send chevron's tooltip shows the key.
- **Cmd/Ctrl+Z** undoes a just-sent mail while the server is still holding it. It rides the existing undo slot (`useUndo`), so the toast's Undo button and the key are one action: whichever fires dismisses the toast and vacates the slot, and the slot lapses with the hold window, but only if it is still this send's. Adds `retireUndoAction` to `useUndo` for that.
- **g then o** jumps to the Outbox.
- All three are listed in the `?` Shortcuts modal.
- Cmd/Ctrl+Z moves from the three list views (`MailboxView`, `AllInboxesView`, `ScreenerView`) into `MailLayout`: the composer window is open on every page, so the key has to be too, rather than dead on the Outbox and settings pages.

### Follow-up (review)
- A send's undo now outlives the view it was sent from: `useUndo` learns which action outlives views (`setUndoAction(action, { outlivesView: true })`), and the Mailbox/Screener teardown calls `dropViewUndo()`, which still drops a list's undo (toast and all) but leaves a send's alone.
- The cancel names the account pinned at send time rather than the composer scope's current account, which follows the active account and can change inside the hold window.

## Test plan
- [x] `vitest run src/apps/mail`: 16 files, 230 tests pass; `tsc --noEmit` clean for the touched files.
- [x] Driven on a bench with Playwright: `g o` lands on `/outbox`; the modal shows the three rows; Cmd+Shift+Enter opens the Schedule dialog and Esc closes only it; Cmd+Enter then Cmd+Z from the Outbox page shows "Sending undone" and dismisses the sent toast; a second Cmd+Z is a no-op; Cmd+Z still undoes an archive in the mailbox.
- [x] Follow-up, same setup: an archive's undo (toast + Cmd+Z) is dropped when the mailbox view unmounts; a send's toast survives `g o` and Cmd+Z undoes it from the Outbox; after switching to another account, Cmd+Z still cancels the sending account's submission.
- [ ] Manual: send from a thread's inline reply and from the docked composer, then Cmd+Z within the window.