### PR TITLE
fix(mail): give the mail actions menu its options back

### DIFF
--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -146,13 +146,14 @@ interface MailAction {
 
 interface GroupedAction {
 	group: string
-	items: MailAction[]
+	// `options`, not `items`: a menu group keyed on `items` renders nothing.
+	options: MailAction[]
 }
 
 const moreActions = (mail: Mail): GroupedAction[] => [
 	{
 		group: '',
-		items: [
+		options: [
 			{
 				label: __('Reply'),
 				onClick: () => setTimeout(() => reply(mail), 300),
@@ -175,7 +176,7 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 	},
 	{
 		group: '',
-		items: [
+		options: [
 			{
 				label: __('Unstar'),
 				onClick: () => emit('setFlagged', mail.id, false),
@@ -254,7 +255,7 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 	},
 	{
 		group: '',
-		items: [
+		options: [
 			{
 				label: __('Download Email'),
 				onClick: () => downloadEmail.submit(),


### PR DESCRIPTION
The ⋯ menu on a mail opened on "No options": frappe-ui's menu groups are `{ group, options }` now, and a group keyed on `items` renders nothing.

`AdaptiveDropdown` already read `options`, so the mobile bottom sheet was dropping the same groups — same one-word fix covers both.