### PR TITLE
chore: simplify unvouched PR message

### DIFF
--- a/.github/vouch-pr-unvouched.md
+++ b/.github/vouch-pr-unvouched.md
@@ -1,5 +1,3 @@
 Hi @{author}, thanks for your interest in contributing!
 
-This repository uses self-hosted CI runners, so pull request authors must be trusted before their code can run. You are not currently in the [list of vouched contributors](https://github.com/{owner}/{repo}/blob/{default_branch}/.github/VOUCHED.td).
-
-This pull request will be closed automatically. A maintainer can vouch for you by adding your GitHub username to that list, after which the pull request can be reopened.
+You are not currently in the [list of vouched contributors](https://github.com/{owner}/{repo}/blob/{default_branch}/.github/VOUCHED.td), so this pull request is being closed.


### PR DESCRIPTION
Simplify the automatic closure message to state only that the author is not in the vouched contributors list and the pull request is therefore being closed.