### PR TITLE
feat(mail): lay the submission details page out as a ledger

### DIFF
--- a/frontend/src/apps/mail/components/LedgerRow.vue
+++ b/frontend/src/apps/mail/components/LedgerRow.vue
@@ -1,0 +1,12 @@
+<template>
+	<div class="flex items-baseline gap-4 py-1.5">
+		<div class="text-ink-gray-5 w-20 shrink-0 text-sm sm:w-36">{{ label }}</div>
+		<div class="text-ink-gray-9 min-w-0 flex-1 text-base leading-[18px] break-words">
+			<slot>{{ value || '—' }}</slot>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+defineProps<{ label: string; value?: string }>()
+</script>

--- a/frontend/src/apps/mail/components/LedgerSection.vue
+++ b/frontend/src/apps/mail/components/LedgerSection.vue
@@ -1,0 +1,15 @@
+<template>
+	<section class="flex flex-col gap-2">
+		<div class="flex items-center justify-between gap-3">
+			<!-- !text-xs: the mail layout's h2 rule sizes every h2 to 16/15px. -->
+			<h2 class="text-ink-gray-5 !text-xs font-medium tracking-wider uppercase">{{ title }}</h2>
+			<slot name="action" />
+		</div>
+		<p v-if="note" class="text-ink-gray-5 text-sm">{{ note }}</p>
+		<slot />
+	</section>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title: string; note?: string }>()
+</script>

--- a/frontend/src/apps/mail/components/SubmissionActivity.vue
+++ b/frontend/src/apps/mail/components/SubmissionActivity.vue
@@ -1,0 +1,42 @@
+<template>
+	<ol class="flex flex-col">
+		<li v-for="(entry, index) in entries" :key="entry.key" class="flex gap-3.5">
+			<!-- Dots take their colour from the text colour: filled for what happened, an
+			outline for what is still to come. -->
+			<div class="flex w-3 shrink-0 flex-col items-center" :class="themeInkClass(entry.theme)">
+				<span
+					class="mt-1 h-2 w-2 shrink-0 rounded-full"
+					:class="entry.pending ? 'bg-surface-base border-[1.5px] border-current' : 'bg-current'"
+				/>
+				<span v-if="index < entries.length - 1" class="border-outline-gray-2 mt-1 flex-1 border-l" />
+			</div>
+			<div class="flex min-w-0 flex-1 flex-col gap-1 pb-4">
+				<!-- The time leads on a phone and takes a right-hand lane on wider screens. -->
+				<div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
+					<span
+						v-if="entry.time"
+						class="text-ink-gray-5 order-first text-xs sm:order-last sm:w-28 sm:shrink-0 sm:text-right"
+						:title="formatDateTime(entry.time)"
+					>
+						{{ formatDateTime(entry.time, 'MMM D, h:mm A') }}
+					</span>
+					<span class="text-ink-gray-9 min-w-0 flex-1 text-base">{{ entry.title }}</span>
+				</div>
+				<p v-if="entry.detail" class="text-ink-gray-6 text-sm">{{ entry.detail }}</p>
+				<code
+					v-if="entry.reply"
+					class="bg-surface-gray-1 text-ink-gray-7 self-start rounded-2 px-1.5 py-0.5 font-mono text-xs break-words whitespace-pre-wrap"
+				>
+					{{ entry.reply }}
+				</code>
+			</div>
+		</li>
+	</ol>
+</template>
+
+<script setup lang="ts">
+import { formatDateTime } from '@/apps/mail/utils/datetime'
+import { themeInkClass, type ActivityEntry } from '@/apps/mail/utils/submissionActivity'
+
+defineProps<{ entries: ActivityEntry[] }>()
+</script>

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -1,12 +1,11 @@
 <template>
 	<div class="flex h-full flex-col">
-		<header
-			class="flex items-center justify-between gap-2 border-b px-3 py-2.5 max-sm:p-0 sm:px-5"
-		>
+		<header class="flex items-center border-b px-3 py-2.5 max-sm:p-0 sm:px-5">
+			<!-- The subject heads the page itself, so the mobile bar names where back leads. -->
 			<MobileTitleHeader
 				v-if="isMobile"
 				class="min-w-0 flex-1"
-				:title="title"
+				:title="__('Outbox')"
 				with-back
 				@back="backToList"
 			/>
@@ -19,130 +18,113 @@
 				]"
 				class="-ml-0.5 min-w-0"
 			/>
-			<!-- All actions live in one menu (sheet on mobile) so the long subject keeps
-			the header's width instead of a row of buttons. -->
-			<AdaptiveDropdown
-				v-if="actions.length"
-				:options="actions"
-				:title="__('Actions')"
-				align="end"
-			>
-				<Button variant="ghost" :title="__('Actions')" class="shrink-0 max-sm:mr-2">
-					<template #icon>
-						<EllipsisVertical class="text-ink-gray-5 h-4 w-4" />
-					</template>
-				</Button>
-			</AdaptiveDropdown>
 		</header>
 
-		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 sm:px-5">
-			<!-- Two independent stacks, not a grid: rows in a grid stretch to the tallest
-			card, leaving dead space under the shorter one. md, not lg — the page should
-			pair up as soon as two cards fit. -->
-			<div class="mx-auto flex max-w-5xl flex-col gap-5 md:flex-row md:items-start">
-				<div class="flex min-w-0 flex-1 flex-col gap-5">
-					<DashboardCard :title="__('Delivery')">
-						<!-- Status is the raw JMAP undoStatus, as on the list page; the merged
-						delivery state is not shown but still drives the header actions. -->
-						<InformationField :label="__('Status')">
-							<Badge
-								:label="undoStatusLabel(data.undo_status)"
-								:theme="undoStatusTheme(data.undo_status)"
+		<!-- One narrow column read top to bottom: where the send stands and what can be done
+		about it, its history, then the facts. max-sm:pb-20 keeps the last section clear of
+		the tab bar and compose button, as the lists do. -->
+		<div v-if="data" class="flex-1 overflow-y-auto px-3 py-4 max-sm:pb-20 sm:px-5 sm:py-6">
+			<div class="mx-auto flex max-w-2xl flex-col gap-7">
+				<div class="flex flex-col gap-2.5">
+					<h1 class="text-ink-gray-9 text-2xl">{{ title }}</h1>
+					<div class="flex flex-wrap items-baseline gap-x-2 gap-y-1 text-base">
+						<span class="text-ink-gray-9 flex items-center gap-2 font-medium">
+							<span
+								class="h-2 w-2 rounded-full bg-current"
+								:class="themeInkClass(statusTheme(data.status))"
 							/>
-						</InformationField>
-						<InformationField
-							:label="data.status === 'scheduled' ? __('Scheduled for') : __('Released at')"
-							:value="sendAtLabel"
-						/>
-						<InformationField :label="__('Retries')" :value="String(data.retries ?? '—')" />
-						<InformationField :label="__('Next retry')" :value="formatDateTime(data.next_retry)" />
-						<InformationField :label="__('Priority')" :value="priorityLabel" />
-						<InformationField :label="__('Delivery reports')" :value="String(data.dsn_count)" />
-						<InformationField :label="__('Read receipts')" :value="String(data.mdn_count)" />
-					</DashboardCard>
-
-					<DashboardCard :title="__('Recipients')">
-						<template v-if="data.recipients_status.length">
-							<div
-								v-for="r in data.recipients_status"
-								:key="r.email"
-								class="flex items-start gap-3 border-b px-5 py-3 last:border-b-0"
-							>
-								<div class="min-w-0 flex-1">
-									<p class="truncate text-base">{{ r.email }}</p>
-									<!-- The server's raw SMTP reply, whatever the outcome. -->
-									<p
-										v-if="r.smtp_reply || r.reason"
-										class="text-ink-gray-6 mt-0.5 text-xs break-words"
-									>
-										{{ r.smtp_reply || r.reason }}
-									</p>
-									<p v-if="deliverySummary(r)" class="text-ink-gray-5 mt-0.5 text-xs">
-										{{ deliverySummary(r) }}
-									</p>
-								</div>
-							</div>
-						</template>
-						<div v-else class="text-ink-gray-5 px-5 py-6 text-center text-sm">
-							{{ __('No recipients.') }}
-						</div>
-					</DashboardCard>
+							{{ statusLabel(data.status) }}
+						</span>
+						<span class="text-ink-gray-4 max-sm:hidden">·</span>
+						<span class="text-ink-gray-6 max-sm:basis-full">{{ summary }}</span>
+					</div>
+					<!-- The state's first action leads; the rest stay visible but quiet. -->
+					<div v-if="actions.length" class="flex flex-wrap gap-2 pt-1">
+						<Button
+							v-for="(action, index) in actions"
+							:key="action.label"
+							:variant="index ? 'ghost' : 'subtle'"
+							:theme="action.theme || 'gray'"
+							:label="action.label"
+							@click="action.onClick"
+						>
+							<template #prefix><component :is="action.icon" class="h-4 w-4" /></template>
+						</Button>
+					</div>
 				</div>
 
-				<div class="flex min-w-0 flex-1 flex-col gap-5">
-					<DashboardCard :title="__('Message')">
-						<InformationField :label="__('Subject')" :value="subjectLabel(data)" />
-						<InformationField :label="__('From')" :value="fromLabel" />
-						<InformationField
-							v-for="type in ['To', 'Cc', 'Bcc']"
-							:key="type"
-							:label="__(type)"
-							:value="recipientsOfType(type)"
-						/>
-						<div v-if="data.email_deleted" class="text-ink-gray-5 px-5 py-3.5 text-sm">
-							{{
-								__(
+				<LedgerSection :title="__('Activity')">
+					<SubmissionActivity :entries="activity" />
+				</LedgerSection>
+
+				<LedgerSection
+					:title="__('Message')"
+					:note="
+						data.email_deleted
+							? __(
 									'The original message was deleted after scheduling, so only the envelope details remain.',
 								)
-							}}
-						</div>
-					</DashboardCard>
+							: undefined
+					"
+				>
+					<template #action>
+						<button
+							v-if="canOpenEmail"
+							class="text-ink-gray-6 hover:text-ink-gray-8 flex items-center gap-1 text-sm"
+							@click="openEmail"
+						>
+							{{ __('Open email') }}
+							<ArrowUpRight class="h-3.5 w-3.5" />
+						</button>
+					</template>
+					<div>
+						<LedgerRow :label="__('From')" :value="fromLabel" />
+						<LedgerRow :label="__('To')" :value="recipientsOfType('To')" />
+						<LedgerRow v-if="recipientsOfType('Cc')" :label="__('Cc')" :value="recipientsOfType('Cc')" />
+						<LedgerRow v-if="recipientsOfType('Bcc')" :label="__('Bcc')" :value="recipientsOfType('Bcc')" />
+						<LedgerRow :label="__('Subject')" :value="subjectLabel(data)" />
+					</div>
+				</LedgerSection>
 
-					<DashboardCard :title="__('References')">
-						<InformationField :label="__('Submission ID')" :value="data.id" />
-						<InformationField :label="__('Email ID')" :value="data.email_id" />
-						<InformationField :label="__('Thread ID')" :value="data.thread_id" />
-						<InformationField :label="__('Identity')" :value="data.identity_email" />
-						<InformationField :label="__('Envelope sender')" :value="data.envelope_from" />
-						<InformationField
-							:label="__('Envelope recipients')"
-							:value="data.envelope_recipients.join(', ')"
-						/>
-					</DashboardCard>
-				</div>
+				<LedgerSection :title="__('Envelope')">
+					<div>
+						<LedgerRow :label="__('Sender')" :value="data.envelope_from" />
+						<LedgerRow :label="__('Recipients')" :value="data.envelope_recipients.join(', ')" />
+						<LedgerRow :label="__('Priority')" :value="priorityLabel(data.priority)" />
+						<LedgerRow :label="__('Reports')" :value="reportsLabel" />
+					</div>
+				</LedgerSection>
+
+				<LedgerSection :title="__('Identifiers')">
+					<p class="text-ink-gray-6 font-mono text-sm break-all">{{ identifiers }}</p>
+				</LedgerSection>
 			</div>
 		</div>
 		<!-- Mirrors the settled layout so list → details (and details → replacement) transitions
 		without a blank frame. -->
 		<div
 			v-else
-			class="flex-1 overflow-y-auto px-3 py-4 sm:px-5"
+			class="flex-1 overflow-y-auto px-3 py-4 max-sm:pb-20 sm:px-5 sm:py-6"
 			:aria-label="__('Loading')"
 			role="status"
 		>
-			<div class="mx-auto flex max-w-5xl flex-col gap-5 md:flex-row md:items-start">
-				<div v-for="stack in 2" :key="stack" class="flex min-w-0 flex-1 flex-col gap-5">
-					<div v-for="card in 2" :key="card" class="rounded-4 border">
-						<div class="flex h-13 items-center border-b px-4">
-							<Skeleton class="h-3.5 w-24 rounded-4" />
-						</div>
-						<div v-for="row in 5" :key="row" class="flex items-center px-5 py-4">
-							<Skeleton class="h-3 w-1/4 rounded-4" />
-							<Skeleton
-								class="ml-12 h-3 rounded-4"
-								:style="{ width: `${20 + ((stack * 5 + card * 7 + row * 13) % 25)}%` }"
-							/>
-						</div>
+			<div class="mx-auto flex max-w-2xl flex-col gap-7">
+				<div class="flex flex-col gap-3">
+					<Skeleton class="h-5 w-2/3 rounded-4" />
+					<Skeleton class="h-3.5 w-1/2 rounded-4" />
+					<div class="flex gap-2 pt-1">
+						<Skeleton class="h-7 w-24 rounded-4" />
+						<Skeleton class="h-7 w-28 rounded-4" />
+					</div>
+				</div>
+				<div v-for="section in 3" :key="section" class="flex flex-col gap-3">
+					<Skeleton class="h-3 w-16 rounded-4" />
+					<div v-for="row in 3" :key="row" class="flex items-center gap-4 py-1.5">
+						<Skeleton class="h-3 w-20 shrink-0 rounded-4 sm:w-36" />
+						<Skeleton
+							class="h-3 rounded-4"
+							:style="{ width: `${25 + ((section * 7 + row * 13) % 30)}%` }"
+						/>
 					</div>
 				</div>
 			</div>
@@ -163,34 +145,31 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
-import { EllipsisVertical } from 'lucide-vue-next'
-import {
-	Badge,
-	Breadcrumbs,
-	Button,
-	Dialog,
-	Skeleton,
-	createResource,
-	usePageMeta,
-} from 'frappe-ui'
+import { ArrowUpRight } from 'lucide-vue-next'
+import { Breadcrumbs, Button, Dialog, Skeleton, createResource, usePageMeta } from 'frappe-ui'
 
 import { raiseToast } from '@/apps/mail/utils'
-import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
+import { formatDateTime } from '@/apps/mail/utils/datetime'
 import {
+	priorityLabel,
+	statusLabel,
+	statusTheme,
 	subjectLabel,
 	submissionActions,
-	undoStatusLabel,
-	undoStatusTheme,
-	type RecipientState,
 	type SubmissionDetails,
 } from '@/apps/mail/utils/submission'
+import {
+	activityEntries,
+	statusSummary,
+	themeInkClass,
+} from '@/apps/mail/utils/submissionActivity'
 import { useScreenSize } from '@/apps/mail/utils/composables'
 import { userStore } from '@/apps/mail/stores/user'
-import AdaptiveDropdown from '@/apps/mail/components/AdaptiveDropdown.vue'
-import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
-import InformationField from '@/apps/mail/components/InformationField.vue'
+import LedgerRow from '@/apps/mail/components/LedgerRow.vue'
+import LedgerSection from '@/apps/mail/components/LedgerSection.vue'
 import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
+import SubmissionActivity from '@/apps/mail/components/SubmissionActivity.vue'
 
 const { accountId, submissionId } = defineProps<{ accountId: string; submissionId: string }>()
 
@@ -235,16 +214,19 @@ const data = computed<SubmissionDetails | null>(() =>
 )
 
 // The subject once known; until then the tab keeps saying "Outbox" (where the user came
-// from) and the breadcrumb/mobile header render no second crumb — a placeholder title
-// would just flash and be replaced.
+// from) and the breadcrumb renders no second crumb — a placeholder title would just flash
+// and be replaced.
 const title = computed(() => (data.value ? subjectLabel(data.value) : ''))
 
 usePageMeta(() => ({ title: title.value || __('Outbox') }))
 
+const summary = computed(() => (data.value ? statusSummary(data.value) : ''))
+const activity = computed(() => (data.value ? activityEntries(data.value) : []))
+
+// Opening the email is a link by the message, not one of the state's actions.
 const actions = computed(() => {
 	if (!data.value) return []
 	return submissionActions(data.value, {
-		openEmail,
 		sendNow: () => (showSendNow.value = true),
 		reschedule: () => (showReschedule.value = true),
 		cancelDelivery: () => (showCancel.value = true),
@@ -254,10 +236,8 @@ const actions = computed(() => {
 	})
 })
 
-const sendAtLabel = computed(() =>
-	data.value?.send_at
-		? `${formatDateTime(data.value.send_at)} (${fromNow(data.value.send_at)})`
-		: undefined,
+const canOpenEmail = computed(
+	() => !!data.value?.thread_id && !data.value.email_deleted && !!store.mailboxIds.sent,
 )
 
 const fromLabel = computed(() => {
@@ -267,35 +247,33 @@ const fromLabel = computed(() => {
 	return from_name && email ? `${from_name} <${email}>` : email
 })
 
-// The MT-Priority values MailQueue submits with (RFC 6710).
-const priorityLabel = computed(() => {
-	const labels: Record<number, string> = { 4: __('High'), 0: __('Normal'), [-4]: __('Low') }
-	return labels[data.value?.priority ?? 0] || String(data.value?.priority)
-})
-
 const recipientsOfType = (type: string) =>
 	data.value?.recipients
 		.filter((r) => r.type === type)
 		.map((r) => (r.display_name ? `${r.display_name} <${r.email}>` : r.email))
 		.join(', ') || undefined
 
-// The DeliveryStatus enums, spelled out for the reader.
-const DELIVERED_LABELS: Record<string, string> = {
-	queued: __('Queued'),
-	yes: __('Yes'),
-	no: __('No'),
-	unknown: __('Unknown'),
-}
+const reportsLabel = computed(() =>
+	data.value
+		? __('{0} delivery reports, {1} read receipts', [
+				String(data.value.dsn_count),
+				String(data.value.mdn_count),
+			])
+		: undefined,
+)
 
-const deliverySummary = (r: RecipientState) => {
-	const parts = []
-	if (r.delivered) parts.push(__('Delivered: {0}', [DELIVERED_LABELS[r.delivered] || r.delivered]))
-	if (r.displayed)
-		parts.push(__('Displayed: {0}', [DELIVERED_LABELS[r.displayed] || r.displayed]))
-	if (r.retries) parts.push(__('Retries: {0}', [String(r.retries)]))
-	if (r.next_retry) parts.push(__('Next retry {0}', [fromNow(r.next_retry)]))
-	return parts.join(' · ')
-}
+const identifiers = computed(() => {
+	if (!data.value) return ''
+	const { id, email_id, thread_id, identity_email } = data.value
+	return [
+		__('submission {0}', [id]),
+		email_id && __('email {0}', [email_id]),
+		thread_id && __('thread {0}', [thread_id]),
+		identity_email && __('identity {0}', [identity_email]),
+	]
+		.filter(Boolean)
+		.join(' · ')
+})
 
 // A held message sits in Sent until delivery, so its thread opens there.
 const openEmail = () => {

--- a/frontend/src/apps/mail/utils/submission.ts
+++ b/frontend/src/apps/mail/utils/submission.ts
@@ -102,12 +102,20 @@ export const statusLabel = (status: SubmissionStatus | string) =>
 		cancelled: __('Cancelled'),
 	})[status] || status
 
-export const statusTheme = (status: SubmissionStatus | string) => {
+export type StatusTheme = 'red' | 'amber' | 'blue' | 'green' | 'gray'
+
+export const statusTheme = (status: SubmissionStatus | string): StatusTheme => {
 	if (status === 'failed') return 'red'
 	if (status === 'retrying') return 'amber'
 	if (status === 'scheduled' || status === 'queued') return 'blue'
 	if (status === 'delivered' || status === 'displayed') return 'green'
 	return 'gray'
+}
+
+// The MT-Priority values MailQueue submits with (RFC 6710).
+export const priorityLabel = (priority: number) => {
+	const labels: Record<number, string> = { 4: __('High'), 0: __('Normal'), [-4]: __('Low') }
+	return labels[priority] || String(priority)
 }
 
 // Both pages badge the raw JMAP undoStatus as the submission's status; the merged delivery

--- a/frontend/src/apps/mail/utils/submissionActivity.test.ts
+++ b/frontend/src/apps/mail/utils/submissionActivity.test.ts
@@ -1,0 +1,145 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import dayjs from '@/apps/mail/utils/dayjs'
+
+import type { RecipientState, SubmissionDetails } from './submission'
+
+vi.mock('@/apps/mail/stores/user', () => ({
+	userStore: () => ({ userResource: { data: { time_zone: 'UTC' } } }),
+}))
+
+// Times below are asserted in UTC, whatever zone the machine running the tests is in.
+vi.spyOn(dayjs.tz, 'guess').mockReturnValue('UTC')
+
+// `__` is installed on window by the translation plugin at app boot; the helpers format their
+// arguments through it, so the stand-in must substitute {n} placeholders too.
+beforeAll(() => {
+	window.__ = (message: string, args: string[] = []) =>
+		message.replace(/\{(\d+)\}/g, (_, index) => args[Number(index)])
+})
+
+const load = async () => await import('./submissionActivity')
+
+const recipient = (email: string, overrides: Partial<RecipientState> = {}): RecipientState => ({
+	email,
+	status: 'sent',
+	...overrides,
+})
+
+const details = (overrides: Partial<SubmissionDetails> = {}): SubmissionDetails => ({
+	id: '9',
+	email_id: 'wneaaaftj',
+	thread_id: 'ftj',
+	subject: 'Invoice #2219 for July services',
+	from_name: 'John Doe',
+	from_email: 'j.doe@example.com',
+	recipients: [],
+	recipients_status: [recipient('bob@example.com')],
+	send_at: '2026-08-31T08:00:00Z',
+	undo_status: 'final',
+	status: 'sent',
+	retries: null,
+	delivery_errors: [],
+	email_deleted: false,
+	envelope_recipients: ['bob@example.com'],
+	priority: 0,
+	dsn_count: 0,
+	mdn_count: 0,
+	...overrides,
+})
+
+const titles = (entries: { title: string }[]) => entries.map((e) => e.title)
+
+describe('statusSummary', () => {
+	it('names the release time of a scheduled send', async () => {
+		const { statusSummary } = await load()
+		expect(statusSummary(details({ status: 'scheduled' }))).toMatch(/^Sends Aug 31 2026, 8:00 AM \(/)
+	})
+
+	it('names the next attempt while retrying, or the fact that the server keeps trying', async () => {
+		const { statusSummary } = await load()
+		const retrying = details({ status: 'retrying', next_retry: '2026-08-31T08:42:00Z' })
+		expect(statusSummary(retrying)).toMatch(/^Next attempt Aug 31 2026, 8:42 AM \(/)
+		expect(statusSummary(details({ status: 'retrying' }))).toBe('The mail server will keep trying')
+	})
+
+	it('counts the failed recipients', async () => {
+		const { statusSummary } = await load()
+		const failed = details({
+			status: 'failed',
+			recipients_status: [
+				recipient('a@example.com', { status: 'failed' }),
+				recipient('b@example.com', { status: 'delivered' }),
+				recipient('c@example.com'),
+			],
+		})
+		expect(statusSummary(failed)).toBe('Could not be delivered to 1 of 3 recipients')
+		expect(statusSummary(details({ status: 'failed', recipients_status: [recipient('a@example.com', { status: 'failed' })] }))).toBe('Could not be delivered')
+	})
+
+	it('counts the read receipts among delivered recipients', async () => {
+		const { statusSummary } = await load()
+		const delivered = details({
+			status: 'delivered',
+			recipients_status: [
+				recipient('a@example.com', { status: 'displayed' }),
+				recipient('b@example.com', { status: 'delivered' }),
+			],
+		})
+		expect(statusSummary(delivered)).toBe('Delivered to all 2 recipients, read by 1')
+		expect(statusSummary(details({ status: 'delivered', recipients_status: [recipient('a@example.com', { status: 'delivered' })] }))).toBe('Delivery confirmed')
+	})
+
+	it('names the release a cancelled send was meant to have', async () => {
+		const { statusSummary } = await load()
+		expect(statusSummary(details({ status: 'cancelled' }))).toBe('Was scheduled for Aug 31 2026, 8:00 AM')
+	})
+})
+
+describe('activityEntries', () => {
+	it('tells a scheduled send as the release still to come', async () => {
+		const { activityEntries } = await load()
+		const entries = activityEntries(details({ status: 'scheduled', recipients_status: [recipient('bob@example.com', { status: 'scheduled' })] }))
+		expect(titles(entries)).toEqual(['Release to the mail server'])
+		expect(entries[0]).toMatchObject({ pending: true, time: '2026-08-31T08:00:00Z', theme: 'blue' })
+		expect(entries[0].detail).toMatch(/· 1 recipient$/)
+	})
+
+	it('tells a plain send as its release and what each recipient got', async () => {
+		const { activityEntries } = await load()
+		expect(titles(activityEntries(details()))).toEqual(['Released to the mail server', 'Accepted for bob@example.com'])
+	})
+
+	it('tells each recipient where its delivery stands, then the next attempt', async () => {
+		const { activityEntries } = await load()
+		const entries = activityEntries(
+			details({
+				status: 'retrying',
+				next_retry: '2026-08-31T08:42:00Z',
+				priority: 4,
+				recipients_status: [
+					recipient('bob@example.com', { smtp_reply: '250 2.1.5 Queued' }),
+					recipient('priya@example.com', { status: 'retrying', reason: '451 4.7.1 Greylisted', retries: 2 }),
+					recipient('marcus@example.com', { status: 'delivered', smtp_reply: '250 2.0.0 OK' }),
+				],
+			}),
+		)
+		expect(titles(entries)).toEqual([
+			'Released to the mail server',
+			'Accepted for bob@example.com',
+			'Deferred for priya@example.com',
+			'Delivered to marcus@example.com',
+			'Next attempt',
+		])
+		expect(entries[0].detail).toBe('3 recipients · High priority')
+		expect(entries[2]).toMatchObject({ theme: 'amber', reply: '451 4.7.1 Greylisted', detail: 'Retried 2 times, the server will keep trying' })
+		expect(entries[4]).toMatchObject({ pending: true, time: '2026-08-31T08:42:00Z' })
+	})
+
+	it('tells a cancelled send as just that, undated', async () => {
+		const { activityEntries } = await load()
+		const entries = activityEntries(details({ status: 'cancelled' }))
+		expect(entries).toEqual([{ key: 'cancelled', title: 'Delivery cancelled', detail: undefined, theme: 'gray' }])
+		expect(activityEntries(details({ status: 'cancelled', email_deleted: true }))[0].detail).toBe('The message itself was deleted afterwards')
+	})
+})

--- a/frontend/src/apps/mail/utils/submissionActivity.ts
+++ b/frontend/src/apps/mail/utils/submissionActivity.ts
@@ -1,0 +1,171 @@
+// The ledger the submission details page reads: one clause on where the delivery stands, and
+// its history as far as the server tells it. There is no event log behind this — the
+// submission, its per-recipient DeliveryStatus and the MTA queue hold the present state only,
+// whichever client submitted the mail — so the entries are that state, told in the order it
+// happened, and only the release and the next attempt carry a time.
+
+import { formatDateTime, fromNow } from '@/apps/mail/utils/datetime'
+import {
+	priorityLabel,
+	type RecipientState,
+	type StatusTheme,
+	type SubmissionDetails,
+	type SubmissionStatus,
+} from '@/apps/mail/utils/submission'
+
+export type ActivityEntry = {
+	key: string
+	title: string
+	detail?: string
+	// The server's raw SMTP reply, verbatim.
+	reply?: string
+	// UTC wire timestamp; only the release and the next attempt have one.
+	time?: string
+	theme: StatusTheme
+	// Yet to happen: an unreleased hold, the next retry.
+	pending?: boolean
+}
+
+/** The clause after the status label: what the state means for this send. */
+export const statusSummary = (s: SubmissionDetails): string => {
+	const total = s.recipients_status.length
+	switch (s.status) {
+		case 'scheduled':
+			return __('Sends {0} ({1})', [formatDateTime(s.send_at), fromNow(s.send_at)])
+		case 'queued':
+			return __('Handed to the mail server, waiting for the first attempt')
+		case 'retrying':
+			return s.next_retry
+				? __('Next attempt {0} ({1})', [formatDateTime(s.next_retry), fromNow(s.next_retry)])
+				: __('The mail server will keep trying')
+		case 'failed':
+			return total > 1
+				? __('Could not be delivered to {0} of {1} recipients', [
+						String(countOf(s, 'failed')),
+						String(total),
+					])
+				: __('Could not be delivered')
+		case 'delivered':
+			return deliveredSummary(total, countOf(s, 'displayed'))
+		case 'displayed':
+			return total > 1 ? __('Delivered and read by every recipient') : __('Delivered and read')
+		case 'cancelled':
+			return __('Was scheduled for {0}', [formatDateTime(s.send_at)])
+		default:
+			return __('Accepted by the mail server, no delivery report yet')
+	}
+}
+
+/** The delivery's history, oldest first. */
+export const activityEntries = (s: SubmissionDetails): ActivityEntry[] => {
+	if (s.status === 'cancelled') return [cancelledEntry(s)]
+	if (s.status === 'scheduled') return [releaseEntry(s)]
+
+	const entries = [releasedEntry(s)]
+	for (const recipient of s.recipients_status) {
+		const entry = recipientEntry(recipient)
+		if (entry) entries.push(entry)
+	}
+	if (s.status === 'retrying' && s.next_retry) entries.push(nextAttemptEntry(s.next_retry))
+	return entries
+}
+
+/** Text colour per theme; dots take it through `bg-current` / `border-current`. */
+export const themeInkClass = (theme: StatusTheme) =>
+	({
+		gray: 'text-ink-gray-4',
+		blue: 'text-ink-blue-7',
+		amber: 'text-ink-amber-7',
+		green: 'text-ink-green-7',
+		red: 'text-ink-red-7',
+	})[theme]
+
+const deliveredSummary = (total: number, read: number) => {
+	if (total <= 1) return __('Delivery confirmed')
+	return read
+		? __('Delivered to all {0} recipients, read by {1}', [String(total), String(read)])
+		: __('Delivered to all {0} recipients', [String(total)])
+}
+
+const countOf = (s: SubmissionDetails, status: SubmissionStatus) =>
+	s.recipients_status.filter((r) => r.status === status).length
+
+const recipientCount = (s: SubmissionDetails) => {
+	const total = s.recipients_status.length
+	return total === 1 ? __('1 recipient') : __('{0} recipients', [String(total)])
+}
+
+// When it was cancelled is not recorded anywhere; the summary line carries the release it
+// was meant to have.
+const cancelledEntry = (s: SubmissionDetails): ActivityEntry => ({
+	key: 'cancelled',
+	title: __('Delivery cancelled'),
+	detail: s.email_deleted ? __('The message itself was deleted afterwards') : undefined,
+	theme: 'gray',
+})
+
+const releaseEntry = (s: SubmissionDetails): ActivityEntry => ({
+	key: 'release',
+	time: s.send_at,
+	title: __('Release to the mail server'),
+	detail: [fromNow(s.send_at), recipientCount(s)].join(' · '),
+	theme: 'blue',
+	pending: true,
+})
+
+const releasedEntry = (s: SubmissionDetails): ActivityEntry => ({
+	key: 'released',
+	time: s.send_at,
+	title: __('Released to the mail server'),
+	detail: [recipientCount(s), ...(s.priority ? [__('{0} priority', [priorityLabel(s.priority)])] : [])].join(
+		' · ',
+	),
+	theme: 'gray',
+})
+
+const nextAttemptEntry = (time: string): ActivityEntry => ({
+	key: 'next-attempt',
+	time,
+	title: __('Next attempt'),
+	detail: fromNow(time),
+	theme: 'amber',
+	pending: true,
+})
+
+// The queue's last error is the reason a troubled delivery stands where it does; for a settled
+// one only the raw reply remains.
+const recipientEntry = (r: RecipientState): ActivityEntry | null => {
+	const key = `recipient:${r.email}`
+	const retries = String(r.retries ?? 0)
+	switch (r.status) {
+		case 'queued':
+			return { key, theme: 'blue', title: __('Queued for {0}', [r.email]), detail: __('Waiting for the first attempt'), reply: r.reason || r.smtp_reply }
+		case 'retrying':
+			return {
+				key,
+				theme: 'amber',
+				title: __('Deferred for {0}', [r.email]),
+				detail: r.retries
+					? __('Retried {0} times, the server will keep trying', [retries])
+					: __('The server will keep trying'),
+				reply: r.reason || r.smtp_reply,
+			}
+		case 'failed':
+			return {
+				key,
+				theme: 'red',
+				title: __('Delivery failed for {0}', [r.email]),
+				detail: r.retries ? __('Gave up after {0} retries', [retries]) : undefined,
+				reply: r.reason || r.smtp_reply,
+			}
+		case 'sent':
+			return { key, theme: 'gray', title: __('Accepted for {0}', [r.email]), detail: __('No delivery report yet'), reply: r.smtp_reply }
+		case 'delivered':
+			return { key, theme: 'green', title: __('Delivered to {0}', [r.email]), detail: __('Delivery report received'), reply: r.smtp_reply }
+		case 'displayed':
+			return { key, theme: 'green', title: __('Read by {0}', [r.email]), detail: __('Read receipt received'), reply: r.smtp_reply }
+		default:
+			// Still held: the release entry tells that, nothing has happened per recipient.
+			return null
+	}
+}

--- a/suite/mail/api/scheduled.py
+++ b/suite/mail/api/scheduled.py
@@ -6,10 +6,10 @@
 The server's submissions are the source of truth: the listing browses all of them — held
 (FUTURERELEASE), in flight, and concluded — through EmailSubmission/query with the RFC 8621
 §7.3 filters (undoStatus, identity, email, thread, and a sendAt window), newest sends first.
-Emails submitted by other clients appear too, and nothing is reconciled into the Mail Queue —
-its rows are only a log of what this app submitted. Every action is keyed on the
-EmailSubmission id. Since undoStatus is a submission's only mutable property (RFC 8621 §7.5),
-reschedule and send-now cancel the held submission and create a replacement.
+Emails submitted by other clients appear too, and the Mail Queue is neither read nor written
+here — its rows only log what this app submitted, as it was submitted. Every action is keyed
+on the EmailSubmission id. Since undoStatus is a submission's only mutable property
+(RFC 8621 §7.5), reschedule and send-now cancel the held submission and create a replacement.
 
 Where the delivery actually stands is computed per recipient from the submission's
 deliveryStatus — delivered (queued/yes/no/unknown), displayed (unknown/yes, a read receipt),
@@ -195,7 +195,6 @@ def reschedule_mail(account: str, id: str, send_at: str) -> dict:
     send_at = _validate_send_at(service, from_utc_z(send_at))
 
     created = _replace_submission(account, service, submission, hold_until=_hold_until(send_at))
-    _sync_queue_log(id, submission_id=created["id"], send_at=send_at)
 
     return {"id": created["id"], "send_at": to_utc_z(send_at)}
 
@@ -211,7 +210,6 @@ def send_scheduled_mail_now(account: str, id: str) -> dict:
     submission = _get_pending_submission(service, id)
 
     created = _replace_submission(account, service, submission, hold_until=None)
-    _sync_queue_log(id, submission_id=created["id"], submitted_at=now(), send_at=None)
 
     return {"id": created["id"], "thread_id": submission.get("threadId")}
 
@@ -234,8 +232,6 @@ def cancel_scheduled_mail(account: str, id: str) -> dict:
     # Already canceled (e.g. a retried undo whose move below failed): skip straight to the move.
 
     email_id = _move_email_to_drafts(account, submission.get("emailId"))
-    # The row stays Submitted — it did get submitted; cancelled_at records the undone hold.
-    _sync_queue_log(id, cancelled_at=now())
 
     return {"id": email_id}
 
@@ -283,7 +279,6 @@ def retry_failed_mail(account: str, id: str) -> dict:
         **_resubmit_args(account, submission), envelope_id=str(uuid7()), hold_until=None
     )
     service.destroy(id)
-    _sync_queue_log(id, submission_id=created["id"], submitted_at=now(), send_at=None)
 
     return {"id": created["id"]}
 
@@ -632,7 +627,6 @@ def _replace_submission(
         # message lands back in Drafts instead of sitting in Sent never sending.
         log_mail_error(_("Failed to resubmit scheduled email"), frappe.get_traceback(with_context=True))
         _move_email_to_drafts(account, args["email_id"])
-        _sync_queue_log(submission["id"], cancelled_at=now())
         frappe.throw(
             _(
                 "The email could not be resubmitted; its delivery was cancelled and the message "
@@ -700,11 +694,3 @@ def _move_email_to_drafts(account: str, email_id: str | None) -> str | None:
     )
 
     return email_id
-
-
-def _sync_queue_log(current_submission_id: str, **values) -> None:
-    """Best-effort mirror into the Mail Queue log for sends that originated here — submissions
-    created by other clients have no row. `values` may carry a replacement submission_id."""
-
-    if name := frappe.db.get_value("Mail Queue", {"submission_id": current_submission_id}):
-        frappe.db.set_value("Mail Queue", name, values)

--- a/suite/mail/tests/test_mail_scheduled_send.py
+++ b/suite/mail/tests/test_mail_scheduled_send.py
@@ -273,12 +273,6 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         submission = self._get_submission(account, scheduled.submission_id)
         self.assertEqual(submission["undoStatus"], "canceled")
 
-        # The queue log mirrors the cancellation via cancelled_at; the row stays Submitted.
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.status, "Submitted")
-        self.assertTrue(doc.cancelled_at)
-
         # Back in Drafts only (mailboxIds replaced, not patched) with $draft restored.
         with self.set_user(self.sender.email):
             from suite.mail.jmap import get_mailbox_id_by_role
@@ -330,12 +324,6 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         self.assertEqual(new_submission["undoStatus"], "pending")
         self.assertLessEqual(abs(_epoch(new_submission["sendAt"]) - _epoch(new_send_at)), 5)
 
-        # The queue log follows the replacement submission.
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.submission_id, result["id"])
-        self.assertLessEqual(abs(_epoch(to_utc_z(doc.send_at)) - _epoch(new_send_at)), 5)
-
     def test_send_now_delivers(self):
         scheduled = self._schedule(minutes=60 * 24)
         account = self.personal_account(self.sender)
@@ -343,11 +331,6 @@ class TestMailScheduledSend(StalwartIntegrationTestCase):
         with self.set_user(self.sender.email):
             result = send_scheduled_mail_now(account, scheduled.submission_id)
         self.assertTrue(result["id"])
-
-        with self.set_user("Administrator"):
-            doc = frappe.get_doc("Mail Queue", scheduled.name)
-        self.assertEqual(doc.submission_id, result["id"])
-        self.assertFalse(doc.send_at)
 
         def find_thread():
             threads = self.get_inbox_threads(self.recipient)


### PR DESCRIPTION
## Summary
- The Outbox's submission details page is one narrow column instead of four identical cards: the subject, the merged delivery state ("Retrying", not the raw undoStatus "Final") with a one-clause summary, the state's actions inline, then an activity list in time order, and the message / envelope / identifier facts as flat sections. Empty rows are gone and the sender's address appears once.
- `utils/submissionActivity.ts` derives the summary clause and the activity entries from the details: the release, each recipient's standing with its raw SMTP reply, and the next attempt. Everything comes from the JMAP submission and the MTA queue, whichever client sent the mail, so only the release and the next attempt carry a time.
- New `SubmissionActivity`, `LedgerSection` and `LedgerRow` components; `priorityLabel` moved into `utils/submission.ts`.
- The Outbox actions no longer write to the Mail Queue: `_sync_queue_log` mirrored the replacement submission id and the send / cancel moments into the row that logged the original submission, for the desk form only. Nothing read those fields, and overwriting `submitted_at` skewed `submitted_after`; the row stays a log of what was submitted, and the server's EmailSubmission is the only state that matters.

## Test plan
- `npx vitest run src/apps/mail`: 239 pass, including 10 new cases for `statusSummary` / `activityEntries` across scheduled, sent, retrying, failed, delivered and cancelled sends.
- `bench run-tests --module suite.mail.tests.test_mail_scheduled_send`: 23 pass (the assertions on the mirrored Mail Queue fields are gone; the ones on the original submit remain).
- Built and checked on a bench against real submissions: a scheduled send (send now / reschedule / cancel inline), a sent one, a cancelled one and a deleted-message one, on desktop and phone (the last section clears the tab bar and compose button).
- The actions (send now, reschedule, cancel, try again now, send again, remove) are the unchanged resources; replacements still follow to the successor's page.