### PR TITLE
feat(calendar): event reminders that reach the browser

### DIFF
--- a/frontend/src/apps/calendar/components/AppSidebar.vue
+++ b/frontend/src/apps/calendar/components/AppSidebar.vue
@@ -72,7 +72,9 @@ const upcoming = computed(() => {
 			// An all-day event covers the whole of today; a timed one is over once its end has passed.
 			return event.isAllDay || dayjs(`${event.toDate} ${event.toTime}`).isAfter(current)
 		})
-		.sort((a, b) => a.fromDateTime.localeCompare(b.fromDateTime))
+		// Sorted on the shape transformEvent hands over — date plus wall clock. An
+		// all-day event starts at midnight, so it leads the day on its own.
+		.sort((a, b) => `${a.fromDate} ${a.fromTime}`.localeCompare(`${b.fromDate} ${b.fromTime}`))
 })
 
 const isOpen = (event: any) =>
@@ -97,8 +99,10 @@ const title = computed(() =>
 )
 
 const subtitle = computed(() => {
+	// A user with no personal account and no stored id leaves `accountId` empty,
+	// and the find unmatched — as mail's sidebar already allows for.
 	const currentAccount = user.data.accounts.find((a) => a.id === store.accountId)
-	if (currentAccount.is_personal) return toTitleCase(user.data.full_name)
+	if (!currentAccount || currentAccount.is_personal) return toTitleCase(user.data.full_name)
 	return currentAccount._name
 })
 

--- a/frontend/src/apps/calendar/components/EventAlertList.vue
+++ b/frontend/src/apps/calendar/components/EventAlertList.vue
@@ -1,7 +1,17 @@
 <script setup lang="ts">
+import { watch } from 'vue'
 import { Button, FormControl } from 'frappe-ui'
 
+import { requestAlertPermission } from '@/utils/calendarAlert'
+
 const { alerts } = defineProps<{ alerts: any[] }>()
+
+// Adding a reminder is the user saying they want to be told: the one moment
+// to ask the browser for system notifications, while the click still counts.
+watch(
+	() => alerts.length,
+	(count, previous) => count > previous && requestAlertPermission(),
+)
 
 const emit = defineEmits(['update:alerts'])
 
@@ -15,10 +25,13 @@ const removeAlert = (i: number) => {
 	emit('update:alerts', updated)
 }
 
+// Display is delivered as a device push and an in-app toast; Email is sent by
+// the calendar server. `Audio` exists in the schema only so imported calendars
+// keep their alarms — it plays nothing here, so it is not offered and an
+// existing one reads as Display.
 const ALERT_ACTION_OPTIONS = [
-	{ label: __('Screen Pop-up'), value: 'Display' },
-	{ label: __('Email Notice'), value: 'Email' },
-	{ label: __('Sound Alert'), value: 'Audio' },
+	{ label: __('Notification'), value: 'Display' },
+	{ label: __('Email'), value: 'Email' },
 ]
 
 const UNIT_OPTIONS = [
@@ -42,7 +55,7 @@ const RELATIVE_TO_OPTIONS = [
 <template>
 	<div v-for="(alert, i) in alerts" :key="i" class="flex space-x-2">
 		<FormControl
-			:model-value="alert.action"
+			:model-value="alert.action === 'Audio' ? 'Display' : alert.action"
 			:label="i === 0 ? (alerts.length > 1 ? __('Alerts') : __('Alert')) : ''"
 			type="select"
 			:options="ALERT_ACTION_OPTIONS"

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -537,16 +537,24 @@ const openUrl = (location: string) => {
 					</span>
 				</div>
 
-				<!-- Alerts -->
+				<!-- Alerts. Every reminder is the same kind of thing, so the bell is
+				     drawn once and the rows below it keep the text column — the group
+				     reads as one list rather than as several details. -->
 				<div
-					v-for="(alert, i) in calendarEvent.alerts"
-					:key="i"
-					class="flex items-center gap-2.5 px-4.5 py-2"
+					v-if="calendarEvent.alerts?.length"
+					class="flex flex-col gap-1 px-4.5 py-2"
 				>
-					<Bell class="icon text-ink-gray-5 size-4 shrink-0" />
-					<span class="text-ink-gray-7 min-w-0 break-words text-sm">
-						{{ formatAlert(alert) }}
-					</span>
+					<div
+						v-for="(alert, i) in calendarEvent.alerts"
+						:key="i"
+						class="flex items-center gap-2.5"
+					>
+						<Bell v-if="i === 0" class="icon text-ink-gray-5 size-4 shrink-0" />
+						<span v-else class="size-4 shrink-0" />
+						<span class="text-ink-gray-7 min-w-0 break-words text-sm">
+							{{ formatAlert(alert) }}
+						</span>
+					</div>
 				</div>
 
 				<!-- Availability -->

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -167,6 +167,8 @@ const eventParams = computed(() => {
 	// so omitting them would strip Meet links from the event.
 	if (event.links?.length) params.links = event.links
 	if (event.participants?.length) params.participants = event.participants
+	// No reminder set means the calendar's default one, not silence.
+	params.use_default_alerts = !event.alerts?.length
 	if (event.alerts?.length) {
 		params.alerts = event.alerts.map((a) => {
 			const base = { action: a.action, type: a.type }

--- a/frontend/src/apps/calendar/socket.ts
+++ b/frontend/src/apps/calendar/socket.ts
@@ -1,27 +1,3 @@
-import { io } from 'socket.io-client'
-import { getCachedListResource, getCachedResource } from 'frappe-ui'
+import { createSiteSocket } from '@/realtime'
 
-declare global {
-	interface Window {
-		site_name?: string
-	}
-}
-
-export const initSocket = () => {
-	const host = window.location.hostname
-	const siteName = window.site_name || host
-	const socketio_port = __SOCKETIO_PORT__
-	const port = window.location.port ? `:${socketio_port}` : ''
-	const protocol = port ? 'http' : 'https'
-	const url = `${protocol}://${host}${port}/${siteName}`
-
-	const socket = io(url, { withCredentials: true, reconnectionAttempts: 5 })
-	socket.on('refetch_resource', (data) => {
-		if (data.cache_key) {
-			const resource =
-				getCachedResource(data.cache_key) || getCachedListResource(data.cache_key)
-			if (resource) resource.reload()
-		}
-	})
-	return socket
-}
+export const initSocket = () => createSiteSocket()

--- a/frontend/src/apps/drive/socket.js
+++ b/frontend/src/apps/drive/socket.js
@@ -1,22 +1,11 @@
-import { io } from 'socket.io-client'
+import { createSiteSocket } from '@/realtime'
 
 let socketInstance = null
 
 export function initSocket() {
   if (socketInstance) return socketInstance
 
-  let siteName = window.site_name || 'drive.localhost'
-
-  let default_port = __SOCKETIO_PORT__
-  let port = window.location.port ? `:${default_port}` : ''
-  let protocol = port ? 'http' : 'https'
-  let host = window.location.hostname
-
-  let url = `${protocol}://${host}${port}/${siteName}`
-  socketInstance = io(url, {
-    withCredentials: true,
-    reconnectionAttempts: 5,
-  })
+  socketInstance = createSiteSocket()
   socketInstance.on('connect_error', (data) => {
     console.log(data)
   })

--- a/frontend/src/apps/mail/socket.ts
+++ b/frontend/src/apps/mail/socket.ts
@@ -1,27 +1,3 @@
-import { io } from 'socket.io-client'
-import { getCachedListResource, getCachedResource } from 'frappe-ui'
+import { createSiteSocket } from '@/realtime'
 
-declare global {
-	interface Window {
-		site_name?: string
-	}
-}
-
-export const initSocket = () => {
-	const host = window.location.hostname
-	const siteName = window.site_name || host
-	const socketio_port = __SOCKETIO_PORT__
-	const port = window.location.port ? `:${socketio_port}` : ''
-	const protocol = port ? 'http' : 'https'
-	const url = `${protocol}://${host}${port}/${siteName}`
-
-	const socket = io(url, { withCredentials: true, reconnectionAttempts: 5 })
-	socket.on('refetch_resource', (data) => {
-		if (data.cache_key) {
-			const resource =
-				getCachedResource(data.cache_key) || getCachedListResource(data.cache_key)
-			if (resource) resource.reload()
-		}
-	})
-	return socket
-}
+export const initSocket = () => createSiteSocket()

--- a/frontend/src/apps/meet/socket.ts
+++ b/frontend/src/apps/meet/socket.ts
@@ -1,21 +1,11 @@
-import { io, type Socket } from "socket.io-client";
+import { type Socket } from "socket.io-client";
+
+import { createSiteSocket } from "@/realtime";
 
 let socket: Socket | null = null;
 
 export function initSocket(): Socket {
-	const host = window.location.hostname;
-	const siteName = window.site_name || __SITE_NAME__;
-	const socketio_port = window.socketio_port || __SOCKETIO_PORT__;
-	const port = window.location.port ? `:${socketio_port}` : "";
-	const protocol = port ? "http" : "https";
-	const url = `${protocol}://${host}${port}/${siteName}`;
-
-	socket = io(url, {
-		withCredentials: true,
-		transports: ["websocket", "polling"],
-		reconnectionAttempts: 5,
-	});
-
+	socket = createSiteSocket({ transports: ["websocket", "polling"] });
 	return socket;
 }
 

--- a/frontend/src/realtime.ts
+++ b/frontend/src/realtime.ts
@@ -9,28 +9,41 @@ declare global {
 	}
 }
 
-/**
- * One way to reach the site's socket.io server, shared by every app's socket
- * module — they each keep their own options (meet insists on websocket-first,
- * for one), but the URL arithmetic lives once, and so do the listeners the
- * whole suite wants regardless of app, like event reminders.
- */
-export function createSiteSocket(options: Parameters<typeof io>[1] = {}): Socket {
+const socketUrl = () => {
 	const host = window.location.hostname
-	const siteName = window.site_name || host
+	// The build-time site name, not the hostname: in development Vite may be
+	// reached on a hostname that is not the Frappe site, and the hostname would
+	// name a socket.io namespace that does not exist.
+	const siteName = window.site_name || __SITE_NAME__
 	const socketio_port = window.socketio_port || __SOCKETIO_PORT__
 	const port = window.location.port ? `:${socketio_port}` : ''
 	const protocol = port ? 'http' : 'https'
-	const socket = io(`${protocol}://${host}${port}/${siteName}`, {
+	return `${protocol}://${host}${port}/${siteName}`
+}
+
+/**
+ * One way to reach the site's socket.io server, shared by every app's socket
+ * module — they each keep their own options (meet insists on websocket-first,
+ * for one), but the URL arithmetic lives once.
+ */
+export function createSiteSocket(options: Parameters<typeof io>[1] = {}): Socket {
+	ensureSuiteSocket()
+	return io(socketUrl(), {
 		withCredentials: true,
 		reconnectionAttempts: 5,
 		...options,
 	})
-	attachSuiteListeners(socket)
-	return socket
 }
 
-/** Listeners every suite app subscribes to, whichever one is open. */
-export function attachSuiteListeners(socket: Socket) {
-	socket.on('calendar_alert', showCalendarAlert)
+// The listeners the whole suite wants regardless of app — event reminders —
+// live on one connection of their own. App layouts create a socket per mount
+// and never dispose it, so putting these on every app socket would replay one
+// alert once per accumulated connection. This socket is created once and
+// reconnects without a cap: a reminder should survive a laptop lid.
+let suiteSocket: Socket | null = null
+
+function ensureSuiteSocket() {
+	if (suiteSocket) return
+	suiteSocket = io(socketUrl(), { withCredentials: true })
+	suiteSocket.on('calendar_alert', showCalendarAlert)
 }

--- a/frontend/src/realtime.ts
+++ b/frontend/src/realtime.ts
@@ -1,0 +1,36 @@
+import { io, type Socket } from 'socket.io-client'
+
+import { showCalendarAlert } from '@/utils/calendarAlert'
+
+declare global {
+	interface Window {
+		site_name?: string
+		socketio_port?: string
+	}
+}
+
+/**
+ * One way to reach the site's socket.io server, shared by every app's socket
+ * module — they each keep their own options (meet insists on websocket-first,
+ * for one), but the URL arithmetic lives once, and so do the listeners the
+ * whole suite wants regardless of app, like event reminders.
+ */
+export function createSiteSocket(options: Parameters<typeof io>[1] = {}): Socket {
+	const host = window.location.hostname
+	const siteName = window.site_name || host
+	const socketio_port = window.socketio_port || __SOCKETIO_PORT__
+	const port = window.location.port ? `:${socketio_port}` : ''
+	const protocol = port ? 'http' : 'https'
+	const socket = io(`${protocol}://${host}${port}/${siteName}`, {
+		withCredentials: true,
+		reconnectionAttempts: 5,
+		...options,
+	})
+	attachSuiteListeners(socket)
+	return socket
+}
+
+/** Listeners every suite app subscribes to, whichever one is open. */
+export function attachSuiteListeners(socket: Socket) {
+	socket.on('calendar_alert', showCalendarAlert)
+}

--- a/frontend/src/utils/calendarAlert.ts
+++ b/frontend/src/utils/calendarAlert.ts
@@ -1,0 +1,41 @@
+import { toast } from 'frappe-ui'
+
+import router from '@/router'
+
+/**
+ * A triggered event alert, as the server publishes it over the socket
+ * (`calendar_alert`): the same title and line the device push carries, and
+ * the in-app path to the event. Reaches an open tab in any suite app,
+ * whether or not device push is set up.
+ */
+export const showCalendarAlert = (alert: { title: string; body: string; path: string }) => {
+	// Both surfaces, deliberately: the toast is the in-app affordance with an
+	// Open action, the system notification is the one the OS manages — Do Not
+	// Disturb, stacking, and (via the tag) deduping across open tabs.
+	toast.info(alert.title, {
+		description: alert.body,
+		duration: 15_000,
+		action: { label: __('Open'), onClick: () => router.push(alert.path) },
+	})
+	if (typeof Notification !== 'undefined' && Notification.permission === 'granted') {
+		const notification = new Notification(alert.title, {
+			body: alert.body,
+			tag: alert.path,
+			icon: '/assets/suite/calendar/images/logo.png',
+		})
+		notification.onclick = () => {
+			window.focus()
+			router.push(alert.path)
+			notification.close()
+		}
+	}
+}
+
+/**
+ * Asks once for system notifications, the first time the user sets a
+ * reminder — the moment they have just said they want to be told.
+ */
+export const requestAlertPermission = () => {
+	if (typeof Notification === 'undefined' || Notification.permission !== 'default') return
+	Notification.requestPermission()
+}

--- a/frontend/src/utils/calendarAlert.ts
+++ b/frontend/src/utils/calendarAlert.ts
@@ -1,3 +1,4 @@
+import { h } from 'vue'
 import { toast } from 'frappe-ui'
 
 import router from '@/router'
@@ -12,7 +13,8 @@ export const showCalendarAlert = (alert: { title: string; body: string; path: st
 	// Both surfaces, deliberately: the toast is the in-app affordance with an
 	// Open action, the system notification is the one the OS manages — Do Not
 	// Disturb, stacking, and (via the tag) deduping across open tabs.
-	toast.info(alert.title, {
+	toast.message(alert.title, {
+		icon: () => h('span', { class: 'lucide-bell size-4' }),
 		description: alert.body,
 		duration: 15_000,
 		action: { label: __('Open'), onClick: () => router.push(alert.path) },

--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -4,7 +4,7 @@ import frappe
 from frappe import _
 
 from suite.calendar.api.rsvp import record_rsvp
-from suite.calendar.doctype.calendar.calendar import fetch_calendars
+from suite.calendar.doctype.calendar.calendar import ensure_default_alerts, fetch_calendars
 from suite.calendar.doctype.calendar_event.calendar_event import (
     fetch_calendar_events,
     update_calendar_event,
@@ -21,6 +21,7 @@ from suite.utils.rate_limiter import dynamic_rate_limit
 def get_calendars(account: str) -> list[dict[str, str]]:
     """Returns a list of the specified account's calendars."""
 
+    ensure_default_alerts(account)
     calendars = fetch_calendars(account)
 
     return [{key: cal[key] for key in ["name", "_name"]} for cal in calendars]

--- a/suite/calendar/api/invites.py
+++ b/suite/calendar/api/invites.py
@@ -121,6 +121,11 @@ def _ensure_on_calendar(service: CalendarEventService, events: list[dict]) -> st
         event = {k: v for k, v in event.items() if k not in SERVER_MANAGED_KEYS}
         event["@type"] = "Event"
         event["calendarIds"] = {default_calendar_id: True}
+        # Invitations arrive without alarms (organizers' are stripped in transit), so
+        # the attendee's copy leans on the calendar's defaults — the invitee gets a
+        # reminder without ever opening the event.
+        if not event.get("alerts"):
+            event["useDefaultAlerts"] = True
         payload[str(uuid7())] = event
 
     created_ids = []

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -310,7 +310,9 @@ def ensure_default_alerts(account: str) -> None:
         return
 
     service = get_calendar_service(account)
-    response = service._get(properties=["id", "myRights", "defaultAlertsWithTime", "defaultAlertsWithoutTime"])
+    response = service._get(
+        properties=["id", "myRights", "defaultAlertsWithTime", "defaultAlertsWithoutTime"]
+    )
     method_responses = response.get("methodResponses") or []
     calendars = method_responses[0][1].get("list", []) if method_responses else []
 

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -12,6 +12,7 @@ from frappe.utils import cint, today
 
 from suite.mail.doctype.user_account.user_account import get_user_for_jmap_account
 from suite.mail.jmap import get_calendar_service
+from suite.mail.utils import log_mail_error
 from suite.utils import parse_filters
 from suite.utils.rate_limiter import dynamic_rate_limit
 
@@ -309,27 +310,33 @@ def ensure_default_alerts(account: str) -> None:
     if frappe.cache.get_value(cache_key):
         return
 
-    service = get_calendar_service(account)
-    response = service._get(
-        properties=["id", "myRights", "defaultAlertsWithTime", "defaultAlertsWithoutTime"]
-    )
-    method_responses = response.get("methodResponses") or []
-    calendars = method_responses[0][1].get("list", []) if method_responses else []
+    try:
+        service = get_calendar_service(account)
+        response = service._get(
+            properties=["id", "myRights", "defaultAlertsWithTime", "defaultAlertsWithoutTime"]
+        )
+        method_responses = response.get("methodResponses") or []
+        calendars = method_responses[0][1].get("list", []) if method_responses else []
 
-    update = {}
-    for calendar in calendars:
-        if not (calendar.get("myRights") or {}).get("mayWriteAll", True):
-            continue
-        patch = {}
-        if not calendar.get("defaultAlertsWithTime"):
-            patch["defaultAlertsWithTime"] = DEFAULT_ALERTS_WITH_TIME
-        if not calendar.get("defaultAlertsWithoutTime"):
-            patch["defaultAlertsWithoutTime"] = DEFAULT_ALERTS_WITHOUT_TIME
-        if patch:
-            update[calendar["id"]] = patch
+        update = {}
+        for calendar in calendars:
+            if not (calendar.get("myRights") or {}).get("mayWriteAll", True):
+                continue
+            patch = {}
+            if not calendar.get("defaultAlertsWithTime"):
+                patch["defaultAlertsWithTime"] = DEFAULT_ALERTS_WITH_TIME
+            if not calendar.get("defaultAlertsWithoutTime"):
+                patch["defaultAlertsWithoutTime"] = DEFAULT_ALERTS_WITHOUT_TIME
+            if patch:
+                update[calendar["id"]] = patch
 
-    if update:
-        service._update(update)
+        if update:
+            service._update(update)
+    except Exception:
+        # Best-effort: a seeding failure must never break calendar listing. The mark
+        # stays unset, so the next load retries.
+        log_mail_error("Calendar Default Alerts Seeding")
+        return
 
     frappe.cache.set_value(cache_key, True, expires_in_sec=24 * 60 * 60)
 

--- a/suite/calendar/doctype/calendar/calendar.py
+++ b/suite/calendar/doctype/calendar/calendar.py
@@ -277,6 +277,61 @@ def delete_calendars(account: str, ids: list[str], remove_events: bool = True) -
         )
 
 
+# What a calendar reminds about when an event carries no alerts of its own
+# (`useDefaultAlerts`): ten minutes before a timed event, nine in the morning on
+# the day of an all-day one. Per-user, per-calendar state on the JMAP server —
+# every client honouring JSCalendar sees the same defaults.
+DEFAULT_ALERTS_WITH_TIME = {
+    "default-10m": {
+        "@type": "Alert",
+        "action": "display",
+        "trigger": {"@type": "OffsetTrigger", "offset": "-PT10M", "relativeTo": "start"},
+    }
+}
+DEFAULT_ALERTS_WITHOUT_TIME = {
+    "default-9am": {
+        "@type": "Alert",
+        "action": "display",
+        "trigger": {"@type": "OffsetTrigger", "offset": "PT9H", "relativeTo": "start"},
+    }
+}
+
+
+def ensure_default_alerts(account: str) -> None:
+    """Seeds the account's calendars with default alerts, where they have none.
+
+    Idempotent, and deliberately only fills emptiness: a calendar whose defaults were set —
+    by this, by another client, by a future settings page — is left alone. Until there is a
+    place to clear defaults on purpose, empty always means unseeded. A day-long cache mark
+    keeps the extra round-trip off every sidebar load."""
+
+    cache_key = f"calendar|default_alerts_seeded|{account}"
+    if frappe.cache.get_value(cache_key):
+        return
+
+    service = get_calendar_service(account)
+    response = service._get(properties=["id", "myRights", "defaultAlertsWithTime", "defaultAlertsWithoutTime"])
+    method_responses = response.get("methodResponses") or []
+    calendars = method_responses[0][1].get("list", []) if method_responses else []
+
+    update = {}
+    for calendar in calendars:
+        if not (calendar.get("myRights") or {}).get("mayWriteAll", True):
+            continue
+        patch = {}
+        if not calendar.get("defaultAlertsWithTime"):
+            patch["defaultAlertsWithTime"] = DEFAULT_ALERTS_WITH_TIME
+        if not calendar.get("defaultAlertsWithoutTime"):
+            patch["defaultAlertsWithoutTime"] = DEFAULT_ALERTS_WITHOUT_TIME
+        if patch:
+            update[calendar["id"]] = patch
+
+    if update:
+        service._update(update)
+
+    frappe.cache.set_value(cache_key, True, expires_in_sec=24 * 60 * 60)
+
+
 @frappe.whitelist()
 def fetch_calendars(account: str, page: int = 1, limit: int = 10) -> list:
     """Returns a list of calendars for the given account."""

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -779,11 +779,6 @@ def send_event_alert_notification(user: str, alert: dict, ctx: dict | None = Non
         return
 
     try:
-        pn = PushNotification("mail")
-        if not pn.is_enabled():
-            logger.debug("push-notifications-disabled")
-            return
-
         service = CalendarEventService(account, get_jmap_connection(user))
 
         events = service.get([event_id])
@@ -826,9 +821,24 @@ def send_event_alert_notification(user: str, alert: dict, ctx: dict | None = Non
             if recurrence_id:
                 link += f"&recurrence={quote(recurrence_id, safe='')}"
 
+        title = event.get("title") or _("[No title]")
+
+        # An open tab hears the alert over the socket whether or not device push is set
+        # up; the path is the link without the host, for the app's router.
+        frappe.publish_realtime(
+            "calendar_alert",
+            {"title": title, "body": body, "path": link[len(url) :]},
+            user=user,
+        )
+
+        pn = PushNotification("mail")
+        if not pn.is_enabled():
+            logger.debug("push-notifications-disabled")
+            return
+
         pn.send_notification_to_user(
             user,
-            event.get("title") or _("[No title]"),
+            title,
             body,
             link,
             f"{url}/assets/suite/calendar/images/logo.png",

--- a/suite/templates/emails/event_reminder.html
+++ b/suite/templates/emails/event_reminder.html
@@ -1,0 +1,114 @@
+<!-- Calendar alarm ("upcoming event") email, restyled to the Frappe event-email family
+     (see _event_base.html / the "Calendar Event Emails" design, frame 4).
+
+     NOT a suite/Jinja template: this file is rendered by the Stalwart mail server, which
+     sends the alarm emails. Deploy by setting it as `template` on the CalendarAlarm
+     singleton (WebUI: Settings > Calendar & Contacts > Alarms) — an Enterprise Edition
+     feature. Placeholders are Stalwart's own double-brace variables and if/each blocks
+     (kept out of this comment: the server parses braces even here). `logo_cid` arrives
+     as a complete img src.
+
+     Deliberately absent: the stock footer ("log in to the self-service portal...") —
+     reminders are managed on the event in Frappe Calendar, so the line only misled. -->
+<!DOCTYPE html>
+<html lang="{{lang}}" dir="{{dir}}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<meta name="x-apple-disable-message-reformatting" content="" />
+<meta name="color-scheme" content="light" />
+<meta name="supported-color-schemes" content="light" />
+<title>{{page_title}}</title>
+<style>
+	@media only screen and (max-width: 480px) {
+		.evt-page { padding: 20px 12px !important; }
+		.evt-card { padding: 24px 20px !important; border-radius: 14px !important; }
+		.evt-title { font-size: 20px !important; }
+		.evt-detail-pad { padding: 2px 14px !important; }
+	}
+</style>
+</head>
+<body data-fixed-palette style="margin: 0; padding: 0; background-color: #f3f3f3;">
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f3f3f3; margin: 0; padding: 0;">
+	<tr>
+		<td align="center" class="evt-page" style="padding: 32px 16px;">
+			<!--[if mso]><table role="presentation" width="600" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+			<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px;">
+				<tr>
+					<td align="center" style="padding: 8px 0 26px;">
+						<table role="presentation" cellpadding="0" cellspacing="0">
+							<tr>
+								<td style="vertical-align: middle; padding-right: 9px;">
+									<img src="{{logo_cid}}" width="22" height="22" alt="" style="display: block; border: 0; width: 22px; height: 22px;" />
+								</td>
+								<td style="vertical-align: middle; font-family: 'Inter', -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif; font-size: 19px; font-weight: 600; color: #171717; letter-spacing: -0.01em;">Frappe Calendar</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+				<tr>
+					<td class="evt-card" style="background-color: #ffffff; border: 1px solid #ededed; border-radius: 16px; padding: 36px; font-family: 'Inter', -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+{{#if header}}
+						<table role="presentation" cellpadding="0" cellspacing="0" style="margin: 0 0 20px;">
+							<tr>
+								<td style="vertical-align: middle; padding-right: 8px; font-size: 0; line-height: 0;">
+									<span style="display: inline-block; width: 8px; height: 8px; border-radius: 8px; background-color: #999999;">&nbsp;</span>
+								</td>
+								<td style="vertical-align: middle; font-size: 13px; color: #7c7c7c; letter-spacing: 0.01em;">{{header}}</td>
+							</tr>
+						</table>
+{{/if header}}
+{{#if event_title}}
+						<h1 class="evt-title" style="margin: 0; font-size: 22px; line-height: 1.25; font-weight: 700; letter-spacing: -0.01em; color: #171717;">{{event_title}}</h1>
+{{/if event_title}}
+{{#if event_details}}
+						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f8f8f8; border-radius: 12px; margin: 22px 0;">
+							<tr>
+								<td class="evt-detail-pad" style="padding: 6px 18px;">
+									<table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+{{#each event_details}}
+										<tr>
+											<td style="padding: 12px 0; font-size: 14px; color: #7c7c7c; width: 88px; vertical-align: top;">{{key}}</td>
+											<td style="padding: 12px 0; font-size: 14px; color: #383838; line-height: 1.5; word-break: break-word;">{{#if link}}<a href="{{link}}" style="color: #007be0; text-decoration: none;">{{/if link}}{{value}}{{#if link}}</a>{{/if link}}</td>
+										</tr>
+{{/each event_details}}
+									</table>
+								</td>
+							</tr>
+						</table>
+{{/if event_details}}
+{{#if event_description}}
+						<p style="margin: 4px 0 22px; font-size: 15px; line-height: 1.6; color: #383838;">{{event_description}}</p>
+{{/if event_description}}
+{{#if attendees}}
+						<p style="margin: 0 0 8px; font-size: 14px; color: #7c7c7c;">{{attendees_title}}</p>
+						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin: 0 0 22px;">
+{{#each attendees}}
+							<tr>
+								<td style="padding: 4px 0; font-size: 14px; line-height: 1.45; color: #171717;">{{key}} <span style="color: #7c7c7c;">{{value}}</span></td>
+							</tr>
+{{/each attendees}}
+						</table>
+{{/if attendees}}
+						<table role="presentation" cellpadding="0" cellspacing="0">
+							<tr>
+								<td align="center" valign="middle" style="border-radius: 10px; background-color: #171717; mso-padding-alt: 10px 20px;">
+									<a href="{{action_url}}" target="_blank" style="display: inline-block; padding: 10px 20px; font-size: 14px; font-weight: 600; line-height: 1.4; color: #ffffff; text-decoration: none; border-radius: 10px;">{{action_name}}</a>
+								</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+				<tr>
+					<td align="center" style="padding: 18px 8px 4px; font-size: 13px; color: #7c7c7c; font-family: 'Inter', -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+						This email was sent by Frappe Mail.
+					</td>
+				</tr>
+			</table>
+			<!--[if mso]></td></tr></table><![endif]-->
+		</td>
+	</tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
Reminders existed as data — the server fires a `CalendarAlert` at the trigger time — but the only delivery was an FCM device push, and only where push notifications were configured. Now:

- The alert handler publishes a `calendar_alert` realtime event to the user before attempting the push, so any open suite tab hears it.
- In the browser it becomes a toast with an **Open** action *and* a system notification (when permitted): the OS handles Do Not Disturb and stacking, the `tag` dedupes across tabs. Clicking either lands on the event.
- It works from any app with a socket — calendar, mail, meet, drive — via a new shared `createSiteSocket()` that replaces the four drifting copies of the same URL arithmetic. The never-published `refetch_resource` listener is removed.
- The Alert picker offers what actually exists: **Notification** and **Email**. "Sound Alert" is gone (an imported `Audio` alert reads as Notification), and adding a first reminder is when the browser asks for notification permission.

Verified end-to-end against the real mail server (webhook → job → toast + notification + phone push). Two known gaps, not in this PR: the server does send `email` alarm mails (verified on the minute), though it appears to skip them when a display alert shares the same trigger time — upstream repro being narrowed, The invitee gap is closed in this PR too: calendars are seeded with default alerts (10 min before timed events, 9 am for all-day), invite copies use them, and an event saved with no explicit reminder falls back to them — verified end to end, two seeded events alarmed to the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
