### PR TITLE
feat(calendar): pre-filled default reminders, all-day alert fixes

### DIFF
--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -592,11 +592,18 @@ const shouldShowRecurringEventModal = computed(
 
 // --- Alerts ---
 
+// Touching the alert UI is a choice about reminders: from here on an empty
+// list means cleared, not "still following the calendar's defaults".
+const addAlert = (alert: object) => {
+	event.followsDefaults = false
+	event.alerts.push(alert)
+}
+
 const addAlertOptions = computed(() => [
 	{
 		label: __('Relative to Event'),
 		onClick: () =>
-			event.alerts.push({
+			addAlert({
 				type: 'OffsetTrigger',
 				action: 'Display',
 				number: 10,
@@ -608,7 +615,7 @@ const addAlertOptions = computed(() => [
 	{
 		label: __('On Specific Date'),
 		onClick: () =>
-			event.alerts.push({
+			addAlert({
 				type: 'AbsoluteTrigger',
 				action: 'Display',
 				date: dayjs(event.startDate).subtract(1, 'day').format('YYYY-MM-DD'),

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -55,6 +55,9 @@ const getEventData = () => {
 		locations: ev.locations.map((l) => l._name),
 		links: ev.links ? [...ev.links] : [],
 		alerts: ev.alerts?.map(parseAlert) ?? [],
+		// True only while the server follows its defaults without spelling them out
+		// as alert rows — an empty list then means "no rows shown", not "cleared".
+		followsDefaults: !!ev.use_default_alerts && !ev.alerts?.length,
 		description: ev.description || '',
 		participants: [...ev.participants],
 		recurrence_rule: ev.recurrence_rule,
@@ -100,6 +103,7 @@ const getDefaultEventData = () => {
 		locations: [],
 		links: [],
 		alerts: [defaultAlert(!selectedEvent?.time, dayjs(selectedEvent.date).format('YYYY-MM-DD'))],
+		followsDefaults: false,
 		description: '',
 		free_busy_status: 'Busy',
 		privacy: 'Public',
@@ -202,6 +206,10 @@ const eventParams = computed(() => {
 				relative_to: a.relative_to,
 			}
 		})
+	} else if (event.followsDefaults) {
+		// updates send these params whole, so an unrelated edit must say the
+		// event still follows the calendar's defaults.
+		params.use_default_alerts = true
 	} else {
 		// An empty list is a choice: removing the pre-filled default row means
 		// no reminder at all, so the clear must reach the server.
@@ -318,6 +326,7 @@ watch(
 
 		// An untouched default reminder follows the event to its new day.
 		if (
+			event.isAllDay &&
 			event.alerts?.length === 1 &&
 			JSON.stringify(event.alerts[0]) === JSON.stringify(defaultAlert(true, previous.date))
 		)

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -65,6 +65,22 @@ const getEventData = () => {
 // How long an event runs when the end hasn't been set by hand.
 const DEFAULT_DURATION_MINUTES = 60
 
+// The calendar's default reminder, pre-filled as an ordinary row the user can
+// edit or remove (removing it means no reminder at all): ten minutes before a
+// timed event, at nine in the morning on the day of an all-day one — spelled
+// as a concrete date and time, which reads better than '9 hours after start'.
+const defaultAlert = (isAllDay: boolean, startDate: string) =>
+	isAllDay
+		? { type: 'AbsoluteTrigger', action: 'Display', date: startDate, time: '09:00' }
+		: {
+				type: 'OffsetTrigger',
+				action: 'Display',
+				number: 10,
+				unit: 'minutes',
+				direction: -1,
+				relative_to: 'Start',
+			}
+
 const getDefaultEventData = () => {
 	const startTime = selectedEvent?.time
 		? dayjs(selectedEvent.time, 'h a').format('HH:mm')
@@ -83,7 +99,7 @@ const getDefaultEventData = () => {
 		endTime: dayjs(startTime, 'HH:mm').add(DEFAULT_DURATION_MINUTES, 'minute').format('HH:mm'),
 		locations: [],
 		links: [],
-		alerts: [],
+		alerts: [defaultAlert(!selectedEvent?.time, dayjs(selectedEvent.date).format('YYYY-MM-DD'))],
 		description: '',
 		free_busy_status: 'Busy',
 		privacy: 'Public',
@@ -170,8 +186,6 @@ const eventParams = computed(() => {
 	// so omitting them would strip Meet links from the event.
 	if (event.links?.length) params.links = event.links
 	if (event.participants?.length) params.participants = event.participants
-	// No reminder set means the calendar's default one, not silence.
-	params.use_default_alerts = !event.alerts?.length
 	if (event.alerts?.length) {
 		params.alerts = event.alerts.map((a) => {
 			const base = { action: a.action, type: a.type }
@@ -188,6 +202,10 @@ const eventParams = computed(() => {
 				relative_to: a.relative_to,
 			}
 		})
+	} else {
+		// An empty list is a choice: removing the pre-filled default row means
+		// no reminder at all, so the clear must reach the server.
+		params.alerts = []
 	}
 
 	return params
@@ -202,6 +220,9 @@ const patch = computed(() => {
 	// A changed start is a wall clock in the viewer's zone; without the zone alongside it the
 	// server would reinterpret those numbers in the event's stored zone.
 	if ('start' in changed && !('time_zone' in changed)) changed.time_zone = eventParams.value.time_zone
+	// Alert edits must also switch a defaults-following event off useDefaultAlerts,
+	// or the server would keep overriding them with the calendar's defaults.
+	if ('alerts' in changed) changed.use_default_alerts = false
 	return changed
 })
 
@@ -294,6 +315,13 @@ watch(
 
 		if (!previous?.date || !startDate) return
 		if (previous.date === startDate && previous.time === startTime) return
+
+		// An untouched default reminder follows the event to its new day.
+		if (
+			event.alerts?.length === 1 &&
+			JSON.stringify(event.alerts[0]) === JSON.stringify(defaultAlert(true, previous.date))
+		)
+			event.alerts = [defaultAlert(true, startDate)]
 
 		if (event.isAllDay) {
 			const days = dayjs(event.endDate).diff(dayjs(previous.date), 'day')
@@ -580,6 +608,16 @@ const addAlertOptions = computed(() => [
 	},
 ])
 
+// Flipping All Day swaps an untouched default reminder for the other mode's;
+// a reminder the user has edited is theirs and stays put.
+const setAllDay = (isAllDay: boolean) => {
+	const untouched =
+		event.alerts?.length === 1 &&
+		JSON.stringify(event.alerts[0]) === JSON.stringify(defaultAlert(event.isAllDay, event.startDate))
+	event.isAllDay = isAllDay
+	if (untouched) event.alerts = [defaultAlert(isAllDay, event.startDate)]
+}
+
 // --- Dialog options ---
 
 const isSaving = computed(
@@ -687,10 +725,11 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 									{{ __('Date & Time') }}
 								</span>
 								<FormControl
-									v-model="event.isAllDay"
+									:model-value="event.isAllDay"
 									:label="__('All Day')"
 									type="checkbox"
 									class="dark:[&_input:not(:checked)]:bg-surface-gray-2"
+									@update:model-value="setAllDay"
 								/>
 							</div>
 							<div class="flex gap-3 p-3.5">

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -145,6 +145,9 @@ const eventParams = computed(() => {
 		organizer: event.organizer,
 		start: startsAt.value.format('YYYY-MM-DD[T]HH:mm:ss'),
 		duration: duration.value,
+		// Without this the server sees a timed midnight event and applies the
+		// wrong default alert (10 mins before instead of 9am day-of).
+		show_without_time: event.isAllDay,
 	}
 
 	if (event.title) params.title = event.title

--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -666,7 +666,7 @@ def format_calendar_event(account: str, calendar_map: dict, event: dict) -> dict
             "uid": uid,
             "action": a.get("action", "").title(),
             "type": a.get("trigger", {}).get("@type", ""),
-            "relative_to": a.get("trigger", {}).get("relativeTo", "").title(),
+            "relative_to": (a.get("trigger", {}).get("relativeTo") or "start").title(),
             "offset": a.get("trigger", {}).get("offset", "").upper(),
             # AbsoluteTrigger.when is a UTCDateTime; serve it in the canonical ``...Z`` form.
             "when": normalize_utc_z(a.get("trigger", {}).get("when")) or "",


### PR DESCRIPTION
New events open with the default reminder pre-filled as an ordinary, editable alert row — 10 minutes before a timed event, 9am on the day of an all-day one — instead of an invisible empty-means-defaults rule. Removing the row now really means no reminder. Flipping All Day swaps an untouched row between the two defaults, and an untouched dated row follows the event when its start date moves.

Fixes along the way:

- The modal never sent `show_without_time`, so all-day events were stored as timed midnight events and got the timed default alert (10 minutes before midnight).
- A server alert without `relativeTo` rendered an empty relative-to select; it now defaults to start, per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)