### PR TITLE
feat(meet): version recording contracts

### DIFF
--- a/frontend/recorder/RecorderSocketController.test.ts
+++ b/frontend/recorder/RecorderSocketController.test.ts
@@ -1,14 +1,39 @@
 import { describe, expect, it, vi } from "vitest";
-import type { Participant, ParticipantData } from "../src/apps/meet/utils/media/ParticipantManager";
-import type { RecorderParticipantData, RecorderParticipantUpdate } from "./protocol";
-import { RecorderSocketController, trustedAvatar, type RecorderState } from "./RecorderSocketController";
+import type {
+	Participant,
+	ParticipantData,
+} from "../src/apps/meet/utils/media/ParticipantManager";
+import type {
+	RecorderParticipantData,
+	RecorderParticipantUpdate,
+} from "./protocol";
+import {
+	RecorderSocketController,
+	type RecorderState,
+	trustedAvatar,
+} from "./RecorderSocketController";
 import type { RecorderConfig, RecordingChallenge } from "./rendererBridge";
 
 vi.stubGlobal("MediaStream", class MediaStream {});
 
-const config: RecorderConfig = { job: "j", grant: "g", meetingId: "r", sfuOrigin: "https://sfu.test", frappeOrigin: "https://frappe.test", socketPath: "/socket.io", startedAt: 0 };
-const challenge: RecordingChallenge = { version: 1, jti: "jti", socket_id: "socket", nonce: "nonce", issued_at: 1, expires_at: 2 };
-type ChallengeFixture = RecordingChallenge | { version: 2 };
+const config: RecorderConfig = {
+	job: "j",
+	grant: "g",
+	meetingId: "r",
+	sfuOrigin: "https://sfu.test",
+	frappeOrigin: "https://frappe.test",
+	socketPath: "/socket.io",
+	acceptedAt: "2026-08-30T12:00:00.000Z",
+};
+const challenge: RecordingChallenge = {
+	protocol_version: 1,
+	jti: "jti",
+	socket_id: "socket",
+	nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	issued_at: 1,
+	expires_at: 11,
+};
+type ChallengeFixture = RecordingChallenge | { protocol_version: 2 };
 
 interface ProducerFixture {
 	id: string;
@@ -27,7 +52,11 @@ interface ConsumerFixture {
 interface ParticipantHandlers {
 	onParticipantAdded?: (participant: Participant) => void;
 	onParticipantRemoved?: (participantId: string) => void;
-	onParticipantUpdated?: (participantId: string, participant: Participant, updates: RecorderParticipantUpdate) => void;
+	onParticipantUpdated?: (
+		participantId: string,
+		participant: Participant,
+		updates: RecorderParticipantUpdate,
+	) => void;
 }
 
 interface ConsumerHandlers {
@@ -36,7 +65,11 @@ interface ConsumerHandlers {
 }
 
 interface MediaHandlers {
-	onScreenShareStarted?: (value: { participantId: string; stream: MediaStream; consumer: ConsumerFixture }) => void;
+	onScreenShareStarted?: (value: {
+		participantId: string;
+		stream: MediaStream;
+		consumer: ConsumerFixture;
+	}) => void;
 }
 
 const participantFixture = (data: RecorderParticipantData): Participant => ({
@@ -51,7 +84,12 @@ const participantFixture = (data: RecorderParticipantData): Participant => ({
 	userData: data.userData,
 });
 
-function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixture | null, state: RecorderState = {}, challengeFixture: ChallengeFixture = challenge) {
+function harness(
+	existing: ProducerFixture[] = [],
+	subscription?: ConsumerFixture | null,
+	state: RecorderState = {},
+	challengeFixture: ChallengeFixture = challenge,
+) {
 	const calls: string[] = [];
 	const socketHandlers = new Map<string, (...args: unknown[]) => void>();
 	const sfuHandlers = new Map<string, (...args: unknown[]) => void>();
@@ -59,12 +97,41 @@ function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixtur
 	let participantHandlers: ParticipantHandlers = {};
 	let mediaHandlers: MediaHandlers = {};
 	const channel = {
-		on: vi.fn((event: string, handler: (...args: unknown[]) => void) => socketHandlers.set(event, handler)),
-		connect: vi.fn(async () => { calls.push("connect"); socketHandlers.get("recording:challenge")?.(challengeFixture); }),
-		emit: vi.fn((event: string, _data: { signature: string } | { roomId: string }, callback?: (value: unknown) => void) => { calls.push(event); callback?.({ success: true }); }),
-		disconnect: vi.fn(), off: vi.fn(), isConnected: vi.fn(), id: vi.fn(), updateAuth: vi.fn(),
+		on: vi.fn((event: string, handler: (...args: unknown[]) => void) =>
+			socketHandlers.set(event, handler),
+		),
+		connect: vi.fn(async () => {
+			calls.push("connect");
+			socketHandlers.get("recording:challenge")?.(challengeFixture);
+		}),
+		emit: vi.fn(
+			(
+				event: string,
+				_data: { protocol_version: 1; signature: string } | { roomId: string },
+				callback?: (value: unknown) => void,
+			) => {
+				calls.push(event);
+				callback?.(
+					event === "recording:proof"
+						? { protocol_version: 1, success: true }
+						: { success: true },
+				);
+			},
+		),
+		disconnect: vi.fn(),
+		off: vi.fn(),
+		isConnected: vi.fn(),
+		id: vi.fn(),
+		updateAuth: vi.fn(),
 	};
-	const bridge = { sign: vi.fn(async () => "signature"), reportCaptureReady: vi.fn(), reportInterruption: vi.fn(), reportProofComplete: vi.fn(), reportJoinComplete: vi.fn(), reportFailure: vi.fn() };
+	const bridge = {
+		sign: vi.fn(async () => "signature"),
+		reportCaptureReady: vi.fn(),
+		reportInterruption: vi.fn(),
+		reportProofComplete: vi.fn(),
+		reportJoinComplete: vi.fn(),
+		reportFailure: vi.fn(),
+	};
 	const participants = new Map<string, Participant>();
 	const consumers = new Map<string, ConsumerFixture>();
 	const removeConsumer = vi.fn((id: string) => {
@@ -75,50 +142,218 @@ function harness(existing: ProducerFixture[] = [], subscription?: ConsumerFixtur
 		return consumer;
 	});
 	const dependencies = {
-		sfuClient: { connected: false, connectionDetails: {}, on: vi.fn((event: string, handler: (...args: unknown[]) => void) => sfuHandlers.set(event, handler)), registerEventHandlers: vi.fn(), getRoomParticipants: vi.fn(async (): Promise<ParticipantData[]> => { calls.push("participants"); return []; }), getExistingProducers: vi.fn(async () => { calls.push("producers"); return existing; }), disconnect: vi.fn() },
-		transportManager: { initializeDevice: vi.fn(async () => calls.push("device")), createReceiveTransport: vi.fn(async () => calls.push("recv")), setEventHandlers: vi.fn(), cleanup: vi.fn() },
-		consumerManager: { setEventHandlers: vi.fn((handlers: ConsumerHandlers) => { consumerHandlers = { ...consumerHandlers, ...handlers }; }), getConsumersByParticipant: vi.fn((id: string) => [...consumers.values()].filter((consumer) => consumer.participantId === id)), getScreenShareConsumers: vi.fn(() => [...consumers.values()].filter((consumer) => consumer.isScreen)), cleanupParticipantConsumers: vi.fn((id: string) => { for (const consumer of [...consumers.values()]) if (consumer.participantId === id) removeConsumer(consumer.id); }), clear: vi.fn(() => { for (const consumer of [...consumers.values()]) removeConsumer(consumer.id); }), removeConsumer },
-		participantManager: { setEventHandlers: vi.fn((handlers: ParticipantHandlers) => { participantHandlers = handlers; }), syncParticipants: vi.fn((values: RecorderParticipantData[]) => values.forEach((value) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); })), addParticipant: vi.fn((value: RecorderParticipantData) => { const participant = participantFixture(value); participants.set(participant.user_id, participant); participantHandlers.onParticipantAdded?.(participant); return participant; }), removeParticipant: vi.fn((id: string) => { const removed = participants.delete(id); if (removed) participantHandlers.onParticipantRemoved?.(id); return removed; }), updateMediaState: vi.fn(), getAllParticipants: vi.fn(() => [...participants.values()]), hasParticipant: vi.fn((id: string) => participants.has(id)) },
-		videoManager: { removeVideoElement: vi.fn(), cancelDeferredAttachment: vi.fn(), cleanup: vi.fn() },
-		mediaManager: { setEventHandlers: vi.fn((handlers: MediaHandlers) => { mediaHandlers = handlers; }), handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => { if (consumer.isScreen) mediaHandlers.onScreenShareStarted?.({ participantId: consumer.participantId, stream: new MediaStream(), consumer }); }), handleConsumerLost: vi.fn(), subscribeToRemoteProducer: vi.fn(async (event: { producerId: string; participantId: string; isScreen: boolean }) => { if (subscription === null) return null; const consumer: ConsumerFixture = subscription || { id: `c-${event.producerId}`, producerId: event.producerId, participantId: event.participantId, kind: event.isScreen ? "video" : "audio", isScreen: event.isScreen }; consumers.set(consumer.id, consumer); consumerHandlers.onConsumerAdded?.(consumer); return consumer; }), cancelPendingSubscriptions: vi.fn(async () => undefined), cleanup: vi.fn() },
+		sfuClient: {
+			connected: false,
+			connectionDetails: {},
+			on: vi.fn((event: string, handler: (...args: unknown[]) => void) =>
+				sfuHandlers.set(event, handler),
+			),
+			registerEventHandlers: vi.fn(),
+			getRoomParticipants: vi.fn(async (): Promise<ParticipantData[]> => {
+				calls.push("participants");
+				return [];
+			}),
+			getExistingProducers: vi.fn(async () => {
+				calls.push("producers");
+				return existing;
+			}),
+			disconnect: vi.fn(),
+		},
+		transportManager: {
+			initializeDevice: vi.fn(async () => calls.push("device")),
+			createReceiveTransport: vi.fn(async () => calls.push("recv")),
+			setEventHandlers: vi.fn(),
+			cleanup: vi.fn(),
+		},
+		consumerManager: {
+			setEventHandlers: vi.fn((handlers: ConsumerHandlers) => {
+				consumerHandlers = { ...consumerHandlers, ...handlers };
+			}),
+			getConsumersByParticipant: vi.fn((id: string) =>
+				[...consumers.values()].filter(
+					(consumer) => consumer.participantId === id,
+				),
+			),
+			getScreenShareConsumers: vi.fn(() =>
+				[...consumers.values()].filter((consumer) => consumer.isScreen),
+			),
+			cleanupParticipantConsumers: vi.fn((id: string) => {
+				for (const consumer of [...consumers.values()])
+					if (consumer.participantId === id) removeConsumer(consumer.id);
+			}),
+			clear: vi.fn(() => {
+				for (const consumer of [...consumers.values()])
+					removeConsumer(consumer.id);
+			}),
+			removeConsumer,
+		},
+		participantManager: {
+			setEventHandlers: vi.fn((handlers: ParticipantHandlers) => {
+				participantHandlers = handlers;
+			}),
+			syncParticipants: vi.fn((values: RecorderParticipantData[]) =>
+				values.forEach((value) => {
+					const participant = participantFixture(value);
+					participants.set(participant.user_id, participant);
+				}),
+			),
+			addParticipant: vi.fn((value: RecorderParticipantData) => {
+				const participant = participantFixture(value);
+				participants.set(participant.user_id, participant);
+				participantHandlers.onParticipantAdded?.(participant);
+				return participant;
+			}),
+			removeParticipant: vi.fn((id: string) => {
+				const removed = participants.delete(id);
+				if (removed) participantHandlers.onParticipantRemoved?.(id);
+				return removed;
+			}),
+			updateMediaState: vi.fn(),
+			getAllParticipants: vi.fn(() => [...participants.values()]),
+			hasParticipant: vi.fn((id: string) => participants.has(id)),
+		},
+		videoManager: {
+			removeVideoElement: vi.fn(),
+			cancelDeferredAttachment: vi.fn(),
+			cleanup: vi.fn(),
+		},
+		mediaManager: {
+			setEventHandlers: vi.fn((handlers: MediaHandlers) => {
+				mediaHandlers = handlers;
+			}),
+			handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => {
+				if (consumer.isScreen)
+					mediaHandlers.onScreenShareStarted?.({
+						participantId: consumer.participantId,
+						stream: new MediaStream(),
+						consumer,
+					});
+			}),
+			handleConsumerLost: vi.fn(),
+			subscribeToRemoteProducer: vi.fn(
+				async (event: {
+					producerId: string;
+					participantId: string;
+					isScreen: boolean;
+				}) => {
+					if (subscription === null) return null;
+					const consumer: ConsumerFixture = subscription || {
+						id: `c-${event.producerId}`,
+						producerId: event.producerId,
+						participantId: event.participantId,
+						kind: event.isScreen ? "video" : "audio",
+						isScreen: event.isScreen,
+					};
+					consumers.set(consumer.id, consumer);
+					consumerHandlers.onConsumerAdded?.(consumer);
+					return consumer;
+				},
+			),
+			cancelPendingSubscriptions: vi.fn(async () => undefined),
+			cleanup: vi.fn(),
+		},
 	};
-	const controller = new RecorderSocketController(bridge as never, channel, state, dependencies as never);
-	return { calls, channel, bridge, consumers, dependencies, sfuHandlers, getConsumerHandlers: () => consumerHandlers, getParticipantHandlers: () => participantHandlers, participants, controller };
+	const controller = new RecorderSocketController(
+		bridge as never,
+		channel,
+		state,
+		dependencies as never,
+	);
+	return {
+		calls,
+		channel,
+		bridge,
+		consumers,
+		dependencies,
+		sfuHandlers,
+		getConsumerHandlers: () => consumerHandlers,
+		getParticipantHandlers: () => participantHandlers,
+		participants,
+		controller,
+	};
 }
 
 describe("RecorderSocketController", () => {
 	it("waits for proof, receive transport, and initial sync before reporting ready", async () => {
 		const h = harness();
 		await h.controller.connect(config);
-		expect(h.calls).toEqual(["connect", "recording:proof", "recording:join", "device", "recv", "participants", "producers"]);
+		expect(h.calls).toEqual([
+			"connect",
+			"recording:proof",
+			"recording:join",
+			"device",
+			"recv",
+			"participants",
+			"producers",
+		]);
+		expect(h.channel.emit).toHaveBeenCalledWith(
+			"recording:proof",
+			{ protocol_version: 1, signature: "signature" },
+			expect.any(Function),
+		);
 		expect(h.controller.ready.value).toBe(true);
 		expect(h.bridge.reportCaptureReady).toHaveBeenCalledOnce();
 	});
 
 	it("deduplicates snapshot and live producers during sync", async () => {
 		const h = harness([{ id: "p1", participantId: "alice" }]);
-		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(async () => { h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: "alice" }); return [{ id: "p1", participantId: "alice" }]; });
+		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(
+			async () => {
+				h.sfuHandlers.get("producer_created")?.({
+					producerId: "p1",
+					participantId: "alice",
+				});
+				return [{ id: "p1", participantId: "alice" }];
+			},
+		);
 		await h.controller.connect(config);
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce();
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).toHaveBeenCalledOnce();
 	});
 
 	it("claims duplicate live producers synchronously", async () => {
 		const h = harness();
 		await h.controller.connect(config);
 
-		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: "alice" });
-		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: "alice" });
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "p1",
+			participantId: "alice",
+		});
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "p1",
+			participantId: "alice",
+		});
 		await vi.waitFor(() =>
-			expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce(),
+			expect(
+				h.dependencies.mediaManager.subscribeToRemoteProducer,
+			).toHaveBeenCalledOnce(),
 		);
 	});
 
 	it("tombstones producer closes and participant leaves during snapshots", async () => {
 		const h = harness([{ id: "p1", participantId: "alice" }]);
-		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(async () => { h.sfuHandlers.get("participant_left")?.({ participantId: "alice" }); h.sfuHandlers.get("producer_closed")?.({ producerId: "p1", participantId: "alice" }); return [{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } }]; });
+		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(
+			async () => {
+				h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
+				h.sfuHandlers.get("producer_closed")?.({
+					producerId: "p1",
+					participantId: "alice",
+				});
+				return [
+					{
+						participantId: "alice",
+						user_id: "alice",
+						userData: { name: "Alice" },
+					},
+				];
+			},
+		);
 		await h.controller.connect(config);
 		expect(h.participants.has("alice")).toBe(false);
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).not.toHaveBeenCalled();
 	});
 
 	it("does not resurrect old producers when a participant leaves and rejoins", async () => {
@@ -126,17 +361,26 @@ describe("RecorderSocketController", () => {
 		h.dependencies.sfuClient.getRoomParticipants.mockResolvedValueOnce([
 			{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } },
 		]);
-		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(async () => {
-			h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
-			h.sfuHandlers.get("participant_joined")?.({ participantId: "alice" });
-			h.sfuHandlers.get("producer_created")?.({ producerId: "new", participantId: "alice" });
-			return [{ id: "old", participantId: "alice" }];
-		});
+		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(
+			async () => {
+				h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
+				h.sfuHandlers.get("participant_joined")?.({ participantId: "alice" });
+				h.sfuHandlers.get("producer_created")?.({
+					producerId: "new",
+					participantId: "alice",
+				});
+				return [{ id: "old", participantId: "alice" }];
+			},
+		);
 
 		await h.controller.connect(config);
 
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledOnce();
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledWith({
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).toHaveBeenCalledOnce();
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).toHaveBeenCalledWith({
 			producerId: "new",
 			participantId: "alice",
 			isScreen: false,
@@ -145,7 +389,9 @@ describe("RecorderSocketController", () => {
 
 	it("fails readiness when an initial producer returns no consumer", async () => {
 		const h = harness([{ id: "p1", participantId: "alice" }], null);
-		await expect(h.controller.connect(config)).rejects.toThrow("did not create a consumer");
+		await expect(h.controller.connect(config)).rejects.toThrow(
+			"did not create a consumer",
+		);
 		expect(h.controller.ready.value).toBe(false);
 		expect(h.bridge.reportCaptureReady).not.toHaveBeenCalled();
 		expect(h.bridge.reportFailure).toHaveBeenCalled();
@@ -156,15 +402,22 @@ describe("RecorderSocketController", () => {
 		const h = harness([]);
 		await h.controller.connect(config);
 		expect(h.controller.ready.value).toBe(true);
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).not.toHaveBeenCalled();
 	});
 
 	it("rejects a malformed recording challenge", async () => {
-		const h = harness([], undefined, {}, { version: 2 });
+		const h = harness([], undefined, {}, { protocol_version: 2 });
 
-		await expect(h.controller.connect(config)).rejects.toThrow("Invalid recording challenge");
+		await expect(h.controller.connect(config)).rejects.toThrow(
+			"Invalid recording challenge",
+		);
 		expect(h.bridge.sign).not.toHaveBeenCalled();
-		expect(h.bridge.reportFailure).toHaveBeenCalledWith("Invalid recording challenge");
+		expect(h.bridge.reportFailure).toHaveBeenCalledWith(
+			"configuration_failed",
+			"Invalid recording challenge",
+		);
 	});
 
 	it("defaults missing snapshot media state to off", async () => {
@@ -202,7 +455,12 @@ describe("RecorderSocketController", () => {
 
 		h.getParticipantHandlers().onParticipantRemoved?.("alice");
 		vi.advanceTimersByTime(5_000);
-		h.getParticipantHandlers().onParticipantAdded?.({ user_id: "alice", user_name: "Alice", avatar: null, initials: "A" });
+		h.getParticipantHandlers().onParticipantAdded?.({
+			user_id: "alice",
+			user_name: "Alice",
+			avatar: null,
+			initials: "A",
+		});
 		vi.advanceTimersByTime(5_000);
 
 		expect(roomEmpty).not.toHaveBeenCalled();
@@ -211,9 +469,24 @@ describe("RecorderSocketController", () => {
 
 	it("waits for the renderer to acknowledge an initial screen attachment", async () => {
 		let acknowledge!: () => void;
-		const screenStarted = vi.fn(() => new Promise<void>((resolve) => { acknowledge = resolve; }));
-		const consumer = { id: "screen-c1", producerId: "p1", participantId: "alice", kind: "video", isScreen: true };
-		const h = harness([{ id: "p1", participantId: "alice", isScreen: true }], consumer, { screenStarted });
+		const screenStarted = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					acknowledge = resolve;
+				}),
+		);
+		const consumer = {
+			id: "screen-c1",
+			producerId: "p1",
+			participantId: "alice",
+			kind: "video",
+			isScreen: true,
+		};
+		const h = harness(
+			[{ id: "p1", participantId: "alice", isScreen: true }],
+			consumer,
+			{ screenStarted },
+		);
 		const connected = h.controller.connect(config);
 		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledOnce());
 		expect(h.controller.ready.value).toBe(false);
@@ -225,9 +498,24 @@ describe("RecorderSocketController", () => {
 	it("cancels an initial screen attachment removed before mount", async () => {
 		vi.useFakeTimers();
 		let acknowledge!: () => void;
-		const screenStarted = vi.fn(() => new Promise<void>((resolve) => { acknowledge = resolve; }));
-		const consumer = { id: "screen-c1", producerId: "p1", participantId: "alice", kind: "video", isScreen: true } as const;
-		const h = harness([{ id: "p1", participantId: "alice", isScreen: true }], consumer, { screenStarted });
+		const screenStarted = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					acknowledge = resolve;
+				}),
+		);
+		const consumer = {
+			id: "screen-c1",
+			producerId: "p1",
+			participantId: "alice",
+			kind: "video",
+			isScreen: true,
+		} as const;
+		const h = harness(
+			[{ id: "p1", participantId: "alice", isScreen: true }],
+			consumer,
+			{ screenStarted },
+		);
 		const connected = h.controller.connect(config);
 		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledOnce());
 
@@ -240,12 +528,8 @@ describe("RecorderSocketController", () => {
 		await connected;
 		expect(h.controller.ready.value).toBe(true);
 		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
-		expect(
-			Reflect.get(h.controller, "attachmentPromises").size,
-		).toBe(0);
-		expect(
-			Reflect.get(h.controller, "screenAttachmentPromises").size,
-		).toBe(0);
+		expect(Reflect.get(h.controller, "attachmentPromises").size).toBe(0);
+		expect(Reflect.get(h.controller, "screenAttachmentPromises").size).toBe(0);
 		await vi.advanceTimersByTimeAsync(
 			RecorderSocketController.ATTACHMENT_TIMEOUT_MS,
 		);
@@ -334,7 +618,9 @@ describe("RecorderSocketController", () => {
 			isScreen: true,
 		});
 		await vi.waitFor(() =>
-			expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalled(),
+			expect(
+				h.dependencies.mediaManager.subscribeToRemoteProducer,
+			).toHaveBeenCalled(),
 		);
 		h.dependencies.consumerManager.removeConsumer.mockClear();
 
@@ -343,7 +629,9 @@ describe("RecorderSocketController", () => {
 			producerId: "screen-1",
 		});
 
-		expect(h.dependencies.consumerManager.removeConsumer).not.toHaveBeenCalled();
+		expect(
+			h.dependencies.consumerManager.removeConsumer,
+		).not.toHaveBeenCalled();
 		expect(screenStopped).not.toHaveBeenCalled();
 	});
 
@@ -399,7 +687,9 @@ describe("RecorderSocketController", () => {
 			isScreen: true,
 		});
 		await vi.waitFor(() =>
-			expect(Reflect.get(h.controller, "activeScreens").has("alice")).toBe(true),
+			expect(Reflect.get(h.controller, "activeScreens").has("alice")).toBe(
+				true,
+			),
 		);
 
 		h.controller.disconnect();
@@ -410,10 +700,27 @@ describe("RecorderSocketController", () => {
 	});
 
 	it("reports only failure when initial screen playback is rejected", async () => {
-		const consumer = { id: "screen-c1", producerId: "p1", participantId: "alice", kind: "video", isScreen: true };
-		const h = harness([{ id: "p1", participantId: "alice", isScreen: true }], consumer, { screenStarted: () => Promise.reject(new Error("screen decoder failed")) });
-		await expect(h.controller.connect(config)).rejects.toThrow("screen decoder failed");
-		expect(h.bridge.reportFailure).toHaveBeenCalledWith("screen decoder failed");
+		const consumer = {
+			id: "screen-c1",
+			producerId: "p1",
+			participantId: "alice",
+			kind: "video",
+			isScreen: true,
+		};
+		const h = harness(
+			[{ id: "p1", participantId: "alice", isScreen: true }],
+			consumer,
+			{
+				screenStarted: () => Promise.reject(new Error("screen decoder failed")),
+			},
+		);
+		await expect(h.controller.connect(config)).rejects.toThrow(
+			"screen decoder failed",
+		);
+		expect(h.bridge.reportFailure).toHaveBeenCalledWith(
+			"configuration_failed",
+			"screen decoder failed",
+		);
 		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
 	});
 
@@ -423,13 +730,23 @@ describe("RecorderSocketController", () => {
 		await h.controller.connect(config);
 
 		h.sfuHandlers.get("participant_joined")?.({ participantId: 42 });
-		h.sfuHandlers.get("producer_created")?.({ producerId: "p1", participantId: null });
-		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: { type: "audio", enabled: "yes" } });
+		h.sfuHandlers.get("producer_created")?.({
+			producerId: "p1",
+			participantId: null,
+		});
+		h.sfuHandlers.get("media_control_update")?.({
+			participantId: "alice",
+			action: { type: "audio", enabled: "yes" },
+		});
 		h.sfuHandlers.get("active_speaker")?.({ participantIds: ["alice", 42] });
 
 		expect(h.participants).toHaveLength(0);
-		expect(h.dependencies.mediaManager.subscribeToRemoteProducer).not.toHaveBeenCalled();
-		expect(h.dependencies.participantManager.updateMediaState).not.toHaveBeenCalled();
+		expect(
+			h.dependencies.mediaManager.subscribeToRemoteProducer,
+		).not.toHaveBeenCalled();
+		expect(
+			h.dependencies.participantManager.updateMediaState,
+		).not.toHaveBeenCalled();
 		expect(activeSpeakersChanged).not.toHaveBeenCalled();
 	});
 
@@ -438,22 +755,44 @@ describe("RecorderSocketController", () => {
 		const h = harness([], undefined, { participantUpdated });
 		await h.controller.connect(config);
 
-		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: "unmute" });
-		h.sfuHandlers.get("media_control_update")?.({ participantId: "alice", action: { type: "video", enabled: true } });
+		h.sfuHandlers.get("media_control_update")?.({
+			participantId: "alice",
+			action: "unmute",
+		});
+		h.sfuHandlers.get("media_control_update")?.({
+			participantId: "alice",
+			action: { type: "video", enabled: true },
+		});
 		h.getParticipantHandlers().onParticipantUpdated?.(
 			"alice",
 			{ user_id: "alice", user_name: "Alice", avatar: null, initials: "A" },
 			{ audio_enabled: true },
 		);
 
-		expect(h.dependencies.participantManager.updateMediaState).toHaveBeenNthCalledWith(1, "alice", { audioEnabled: true });
-		expect(h.dependencies.participantManager.updateMediaState).toHaveBeenNthCalledWith(2, "alice", { videoEnabled: true });
-		expect(participantUpdated).toHaveBeenCalledWith("alice", { audio_enabled: true });
+		expect(
+			h.dependencies.participantManager.updateMediaState,
+		).toHaveBeenNthCalledWith(1, "alice", { audioEnabled: true });
+		expect(
+			h.dependencies.participantManager.updateMediaState,
+		).toHaveBeenNthCalledWith(2, "alice", { videoEnabled: true });
+		expect(participantUpdated).toHaveBeenCalledWith("alice", {
+			audio_enabled: true,
+		});
 	});
 
 	it("rewrites only public avatars on the trusted Frappe origin", () => {
-		expect(trustedAvatar("/files/avatar.png", "https://frappe.test")).toBe("https://frappe.test/files/avatar.png");
-		expect(trustedAvatar("/files/avatar.png", "http://frappe.test")).toBe("http://frappe.test/files/avatar.png");
-		for (const value of ["https://evil.test/a.png", "//evil.test/a.png", "/private/files/a.png", "data:image/png,x"]) expect(trustedAvatar(value, "https://frappe.test")).toBeNull();
+		expect(trustedAvatar("/files/avatar.png", "https://frappe.test")).toBe(
+			"https://frappe.test/files/avatar.png",
+		);
+		expect(trustedAvatar("/files/avatar.png", "http://frappe.test")).toBe(
+			"http://frappe.test/files/avatar.png",
+		);
+		for (const value of [
+			"https://evil.test/a.png",
+			"//evil.test/a.png",
+			"/private/files/a.png",
+			"data:image/png,x",
+		])
+			expect(trustedAvatar(value, "https://frappe.test")).toBeNull();
 	});
 });

--- a/frontend/recorder/RecorderSocketController.ts
+++ b/frontend/recorder/RecorderSocketController.ts
@@ -1,19 +1,27 @@
-import { readonly, ref, type Ref } from "vue";
+import { type Ref, readonly, ref } from "vue";
 import { ConsumerManager } from "../src/apps/meet/utils/media/ConsumerManager";
-import { ParticipantManager, type Participant } from "../src/apps/meet/utils/media/ParticipantManager";
-import { SocketIOSignalChannel, type SignalChannel } from "../src/apps/meet/utils/media/SignalChannel";
+import {
+	type Participant,
+	ParticipantManager,
+} from "../src/apps/meet/utils/media/ParticipantManager";
+import {
+	type SignalChannel,
+	SocketIOSignalChannel,
+} from "../src/apps/meet/utils/media/SignalChannel";
 import { TransportManager } from "../src/apps/meet/utils/media/TransportManager";
 import { VideoElementManager } from "../src/apps/meet/utils/media/VideoElementManager";
 import { SFUClient } from "../src/apps/meet/utils/SFUClient";
-import { SFUMediaManager } from "../src/apps/meet/utils/sfu/SFUMediaManager";
 import {
 	applyMeetingReconciliationEvent,
 	createMeetingReconciliationState,
-	reconcileMeetingSnapshot,
 	type MeetingReconciliationEvent,
 	type MeetingReconciliationState,
+	reconcileMeetingSnapshot,
 } from "../src/apps/meet/utils/sfu/MeetingSnapshotReconciler";
+import { SFUMediaManager } from "../src/apps/meet/utils/sfu/SFUMediaManager";
 import {
+	type MediaControlMessage,
+	type ProducerEvent,
 	parseActiveSpeakers,
 	parseChatMessage,
 	parseConsumerId,
@@ -26,29 +34,48 @@ import {
 	parseRaisedHands,
 	parseReaction,
 	parseRecordingChallenge,
+	parseRecordingProofResponse,
 	parseRequestResponse,
 	parseScreenShareStarted,
 	parseScreenShareStopped,
-	type MediaControlMessage,
-	type ProducerEvent,
 	type RecorderParticipantData,
 	type RecorderParticipantUpdate,
 } from "./protocol";
-import type { RecorderConfig, RecorderRendererBridge } from "./rendererBridge";
+import type {
+	RecorderConfig,
+	RecorderRendererBridge,
+	RendererReasonCode,
+} from "./rendererBridge";
 
-type ReconciledRecorderParticipant = RecorderParticipantData & { participantId: string };
+type ReconciledRecorderParticipant = RecorderParticipantData & {
+	participantId: string;
+};
 type SyncEvent = MeetingReconciliationEvent<ReconciledRecorderParticipant>;
 export type RecorderState = {
 	participantAdded?: (participant: Participant) => void;
 	participantRemoved?: (participantId: string) => void;
-	participantUpdated?: (participantId: string, updates: RecorderParticipantUpdate) => void;
+	participantUpdated?: (
+		participantId: string,
+		updates: RecorderParticipantUpdate,
+	) => void;
 	activeSpeakersChanged?: (participantIds: string[]) => void;
-	screenStarted?: (data: { participantId: string; consumerId: string; producerId: string; stream: MediaStream; startedAt: number }) => Promise<void> | void;
+	screenStarted?: (data: {
+		participantId: string;
+		consumerId: string;
+		producerId: string;
+		stream: MediaStream;
+		startedAt: number;
+	}) => Promise<void> | void;
 	screenStopped?: (participantId: string, producerId: string) => void;
 	reactionReceived?: (userId: string, reaction: string) => void;
 	handChanged?: (userId: string, raised: boolean, timestamp: string) => void;
 	handsSynced?: (hands: Record<string, string>) => void;
-	chatReceived?: (message: { id: string; participantId?: string; author: string; text: string }) => void;
+	chatReceived?: (message: {
+		id: string;
+		participantId?: string;
+		author: string;
+		text: string;
+	}) => void;
 	roomEmpty?: () => void;
 };
 
@@ -94,7 +121,9 @@ export class RecorderSocketController {
 	private _ready = ref(false);
 	private _interruption = ref<string | null>(null);
 	readonly ready: Readonly<Ref<boolean>> = readonly(this._ready);
-	readonly interruption: Readonly<Ref<string | null>> = readonly(this._interruption);
+	readonly interruption: Readonly<Ref<string | null>> = readonly(
+		this._interruption,
+	);
 
 	constructor(
 		private bridge: RecorderRendererBridge,
@@ -111,7 +140,9 @@ export class RecorderSocketController {
 			const transportManager = new TransportManager();
 			const consumerManager = new ConsumerManager();
 			const participantManager = new ParticipantManager();
-			const videoManager = new VideoElementManager(RecorderSocketController.ATTACHMENT_TIMEOUT_MS);
+			const videoManager = new VideoElementManager(
+				RecorderSocketController.ATTACHMENT_TIMEOUT_MS,
+			);
 			transportManager.initialize(sfuClient);
 			this.deps = {
 				sfuClient,
@@ -119,38 +150,57 @@ export class RecorderSocketController {
 				consumerManager,
 				participantManager,
 				videoManager,
-				mediaManager: new SFUMediaManager({ transportManager, consumerManager, participantManager, videoManager }, () => null),
+				mediaManager: new SFUMediaManager(
+					{
+						transportManager,
+						consumerManager,
+						participantManager,
+						videoManager,
+					},
+					() => null,
+				),
 			};
 		}
 		this.setupManagerEvents();
 		this.setupSFUEvents();
 	}
 
-	get videoManager(): VideoElementManager { return this.deps.videoManager; }
+	get videoManager(): VideoElementManager {
+		return this.deps.videoManager;
+	}
 
 	async connect(config: RecorderConfig): Promise<void> {
-		this.captureStartedAt = config.startedAt;
+		this.captureStartedAt = Date.parse(config.acceptedAt);
 		this.frappeOrigin = new URL(config.frappeOrigin).origin;
 		let resolveProof!: () => void;
 		let rejectProof!: (error: Error) => void;
-		const proved = new Promise<void>((resolve, reject) => { resolveProof = resolve; rejectProof = reject; });
+		const proved = new Promise<void>((resolve, reject) => {
+			resolveProof = resolve;
+			rejectProof = reject;
+		});
 		this.channel.on("recording:challenge", (value) => {
 			const challenge = parseRecordingChallenge(value);
 			if (!challenge) {
 				rejectProof(new Error("Invalid recording challenge"));
 				return;
 			}
-			this.bridge.sign(challenge)
-				.then((signature) => this.request("recording:proof", { signature }))
+			this.bridge
+				.sign(challenge)
+				.then((signature) => this.requestProof(signature))
 				.then(resolveProof, rejectProof);
 		});
 		this.channel.on("disconnect", () => {
 			if (this.cleaningUp) return;
-			this.interrupt("SFU connection lost");
+			this.interrupt("sfu_disconnected", "SFU connection lost");
 			this.cleanup();
 		});
 		try {
-			await this.channel.connect({ origin: config.sfuOrigin, path: config.socketPath, auth: { token: config.grant }, reconnection: false });
+			await this.channel.connect({
+				origin: config.sfuOrigin,
+				path: config.socketPath,
+				auth: { token: config.grant },
+				reconnection: false,
+			});
 			await proved;
 			this.bridge.reportProofComplete();
 			await this.request("recording:join", { roomId: config.meetingId });
@@ -164,10 +214,13 @@ export class RecorderSocketController {
 			this._ready.value = true;
 			this.bridge.reportCaptureReady();
 		} catch (error) {
-			const reason = error instanceof Error ? error.message : "Recorder connection interrupted";
+			const reason =
+				error instanceof Error
+					? error.message
+					: "Recorder connection interrupted";
 			this._ready.value = false;
 			this._interruption.value = reason;
-			this.bridge.reportFailure(reason);
+			this.bridge.reportFailure("configuration_failed", reason);
 			this.cleanup();
 			throw error;
 		}
@@ -178,7 +231,9 @@ export class RecorderSocketController {
 		this.cleanup();
 	}
 
-	reportPlaybackFailure(reason: string): void { this.interrupt(reason); }
+	reportPlaybackFailure(reason: string): void {
+		this.interrupt("media_attachment_failed", reason);
+	}
 
 	private setupManagerEvents(): void {
 		this.deps.participantManager.setEventHandlers({
@@ -200,22 +255,28 @@ export class RecorderSocketController {
 		});
 		this.deps.consumerManager.setEventHandlers({
 			onConsumerAdded: (consumer) => {
-				const operation = this.deps.mediaManager.handleNewConsumer(consumer).then(async () => {
-					if (consumer.isScreen) {
-						await this.screenAttachmentPromises.get(consumer.id)?.promise;
-					}
-				});
+				const operation = this.deps.mediaManager
+					.handleNewConsumer(consumer)
+					.then(async () => {
+						if (consumer.isScreen) {
+							await this.screenAttachmentPromises.get(consumer.id)?.promise;
+						}
+					});
 				const pending = this.cancellableAttachment(consumer, operation);
 				this.attachmentPromises.set(consumer.producerId, pending);
 				if (!consumer.isScreen) {
-					this.currentParticipantAttachments.set(
-						consumer.participantId,
-						{ consumerId: consumer.id, producerId: consumer.producerId },
-					);
+					this.currentParticipantAttachments.set(consumer.participantId, {
+						consumerId: consumer.id,
+						producerId: consumer.producerId,
+					});
 				}
 				void pending.promise
 					.catch((error) => {
-						if (this._ready.value) this.interrupt(`Media attachment failed: ${error instanceof Error ? error.message : "unknown error"}`);
+						if (this._ready.value)
+							this.interrupt(
+								"media_attachment_failed",
+								error instanceof Error ? error.message : "unknown error",
+							);
 					})
 					.finally(() => {
 						if (this.attachmentPromises.get(consumer.producerId) === pending) {
@@ -225,9 +286,15 @@ export class RecorderSocketController {
 			},
 			onConsumerRemoved: (_id, consumer) => {
 				this.cancelConsumerAttachment(consumer);
-				if (consumer.isScreen) this.finishScreen(consumer.participantId, consumer.producerId, consumer.id);
+				if (consumer.isScreen)
+					this.finishScreen(
+						consumer.participantId,
+						consumer.producerId,
+						consumer.id,
+					);
 			},
-			onConsumerLost: (info) => void this.deps.mediaManager.handleConsumerLost(info),
+			onConsumerLost: (info) =>
+				void this.deps.mediaManager.handleConsumerLost(info),
 		});
 		this.deps.mediaManager.setEventHandlers({
 			onScreenShareStarted: (value) => {
@@ -257,7 +324,13 @@ export class RecorderSocketController {
 					producerId: data.producerId,
 				});
 				const acknowledged = Promise.resolve().then(() =>
-					this.state.screenStarted?.({ participantId: data.participantId, consumerId: data.consumerId, producerId: data.producerId, stream: data.stream, startedAt: Date.now() }),
+					this.state.screenStarted?.({
+						participantId: data.participantId,
+						consumerId: data.consumerId,
+						producerId: data.producerId,
+						stream: data.stream,
+						startedAt: Date.now(),
+					}),
 				);
 				const pending = this.withTimeout(
 					data,
@@ -272,30 +345,93 @@ export class RecorderSocketController {
 				};
 				void pending.promise.then(cleanupPending, cleanupPending);
 			},
-			onRecoveryExhausted: () => this.interrupt("Media subscription recovery exhausted"),
+			onRecoveryExhausted: () =>
+				this.interrupt(
+					"media_subscription_failed",
+					"Media subscription recovery exhausted",
+				),
 		});
-		this.deps.transportManager.setEventHandlers({ onTransportConnectionStateChange: ({ direction, state }) => {
-			if (direction === "recv" && (state === "failed" || state === "disconnected" || state === "closed") && this._ready.value) this.interrupt(`Receive transport ${state}`);
-		} });
+		this.deps.transportManager.setEventHandlers({
+			onTransportConnectionStateChange: ({ direction, state }) => {
+				if (
+					direction === "recv" &&
+					(state === "failed" ||
+						state === "disconnected" ||
+						state === "closed") &&
+					this._ready.value
+				)
+					this.interrupt(
+						"receive_transport_failed",
+						`Receive transport ${state}`,
+					);
+			},
+		});
 	}
 
 	private setupSFUEvents(): void {
 		const client = this.deps.sfuClient;
-		client.on("participant_joined", (value) => { const event = parseParticipantMessage("participant-joined", value); if (event) this.queueOrApply(event); });
-		client.on("participant_left", (value) => { const event = parseParticipantMessage("participant-left", value); if (event) this.queueOrApply(event); });
-		client.on("producer_created", (value) => { const event = parseProducerMessage("producer-created", value); if (event) this.queueOrApply(event); });
-		client.on("producer_closed", (value) => { const event = parseProducerMessage("producer-closed", value); if (event) this.queueOrApply(event); });
-		client.on("consumer_closed", (value) => { const id = parseConsumerId(value); if (id) this.deps.consumerManager.removeConsumer(id); });
-		client.on("media_control_update", (value) => { const message = parseMediaControlMessage(value); if (message) this.updateMedia(message); });
-		client.on("active_speaker", (value) => { const ids = parseActiveSpeakers(value); if (ids) this.state.activeSpeakersChanged?.(ids); });
+		client.on("participant_joined", (value) => {
+			const event = parseParticipantMessage("participant-joined", value);
+			if (event) this.queueOrApply(event);
+		});
+		client.on("participant_left", (value) => {
+			const event = parseParticipantMessage("participant-left", value);
+			if (event) this.queueOrApply(event);
+		});
+		client.on("producer_created", (value) => {
+			const event = parseProducerMessage("producer-created", value);
+			if (event) this.queueOrApply(event);
+		});
+		client.on("producer_closed", (value) => {
+			const event = parseProducerMessage("producer-closed", value);
+			if (event) this.queueOrApply(event);
+		});
+		client.on("consumer_closed", (value) => {
+			const id = parseConsumerId(value);
+			if (id) this.deps.consumerManager.removeConsumer(id);
+		});
+		client.on("media_control_update", (value) => {
+			const message = parseMediaControlMessage(value);
+			if (message) this.updateMedia(message);
+		});
+		client.on("active_speaker", (value) => {
+			const ids = parseActiveSpeakers(value);
+			if (ids) this.state.activeSpeakersChanged?.(ids);
+		});
 		client.on("screen_share_stopped", (value) => {
 			const stopped = parseScreenShareStopped(value);
 			if (stopped) this.stopScreen(stopped.participantId, stopped.producerId);
 		});
-		client.on("reaction:message", (value) => { const reaction = parseReaction(value); if (reaction) this.state.reactionReceived?.(reaction.fromUser, reaction.reaction); });
-		client.on("hand_raised", (value) => { const hand = parseHandChange(value); if (hand) this.state.handChanged?.(hand.participantId, hand.raised, hand.timestamp); });
-		client.on("existing_raised_hands", (value) => { const hands = parseRaisedHands(value); if (hands) this.state.handsSynced?.(hands); });
-		client.on("chat:message", (value) => { const message = parseChatMessage(value); if (!message) return; const time = Date.parse(message.timestamp || ""); if (!Number.isFinite(time) || time >= this.captureStartedAt) this.state.chatReceived?.({ id: `${message.fromUser || "unknown"}-${message.timestamp || Date.now()}`, participantId: message.fromUser, author: message.fromName || message.fromUser || "Unknown", text: message.message }); });
+		client.on("reaction:message", (value) => {
+			const reaction = parseReaction(value);
+			if (reaction)
+				this.state.reactionReceived?.(reaction.fromUser, reaction.reaction);
+		});
+		client.on("hand_raised", (value) => {
+			const hand = parseHandChange(value);
+			if (hand)
+				this.state.handChanged?.(
+					hand.participantId,
+					hand.raised,
+					hand.timestamp,
+				);
+		});
+		client.on("existing_raised_hands", (value) => {
+			const hands = parseRaisedHands(value);
+			if (hands) this.state.handsSynced?.(hands);
+		});
+		client.on("chat:message", (value) => {
+			const message = parseChatMessage(value);
+			if (!message) return;
+			const time = Date.parse(message.timestamp || "");
+			if (!Number.isFinite(time) || time >= this.captureStartedAt)
+				this.state.chatReceived?.({
+					id: `${message.fromUser || "unknown"}-${message.timestamp || Date.now()}`,
+					participantId: message.fromUser,
+					author: message.fromName || message.fromUser || "Unknown",
+					text: message.message,
+				});
+		});
 	}
 
 	private async initialSynchronize(): Promise<void> {
@@ -328,23 +464,33 @@ export class RecorderSocketController {
 						false,
 				});
 			})
-			.filter((participant): participant is ReconciledRecorderParticipant => participant !== null);
+			.filter(
+				(participant): participant is ReconciledRecorderParticipant =>
+					participant !== null,
+			);
 		const existing = await this.deps.sfuClient.getExistingProducers();
 		const producers: ProducerEvent[] = [];
 		for (const value of existing) {
 			const producer = parseProducerSnapshot(value);
 			if (!producer) continue;
-			producers.push({ producerId: producer.id, participantId: producer.participantId, isScreen: producer.isScreen });
+			producers.push({
+				producerId: producer.id,
+				participantId: producer.participantId,
+				isScreen: producer.isScreen,
+			});
 		}
 		this.reconciliation = reconcileMeetingSnapshot(
 			this.reconciliation,
 			{ participants: participantSnapshot, producers },
 			this.bufferedEvents.splice(0),
 		);
-		this.deps.participantManager.syncParticipants([...this.reconciliation.participants.values()]);
+		this.deps.participantManager.syncParticipants([
+			...this.reconciliation.participants.values(),
+		]);
 		if (this.reconciliation.participants.size === 0) this.scheduleRoomEmpty();
 		this.initialSync = false;
-		for (const event of this.reconciliation.producers.values()) await this.subscribeRequired(event);
+		for (const event of this.reconciliation.producers.values())
+			await this.subscribeRequired(event);
 	}
 
 	private queueOrApply(event: SyncEvent): void {
@@ -356,8 +502,13 @@ export class RecorderSocketController {
 		this.reconciliation = applyMeetingReconciliationEvent(previous, event);
 		if (event.type === "participant-joined") {
 			const id = event.value.participantId;
-			if (!previous.participants.has(id) || previous.departedParticipantIds.has(id)) {
-				this.deps.participantManager.addParticipant(this.sanitizeParticipant(event.value));
+			if (
+				!previous.participants.has(id) ||
+				previous.departedParticipantIds.has(id)
+			) {
+				this.deps.participantManager.addParticipant(
+					this.sanitizeParticipant(event.value),
+				);
 			}
 		} else if (event.type === "participant-left") {
 			const id = event.value.participantId;
@@ -369,21 +520,37 @@ export class RecorderSocketController {
 			if (
 				!previous.producers.has(event.value.producerId) &&
 				this.reconciliation.producers.has(event.value.producerId)
-			) void this.subscribeLive(event.value);
+			)
+				void this.subscribeLive(event.value);
 		} else {
-			if (!previous.closedProducerIds.has(event.value.producerId)) this.removeProducer(event.value);
+			if (!previous.closedProducerIds.has(event.value.producerId))
+				this.removeProducer(event.value);
 		}
 	}
 	private async subscribeRequired(event: ProducerEvent): Promise<void> {
-		if (!this.isCurrentProducer(event) || this.producerClaims.has(event.producerId)) return;
+		if (
+			!this.isCurrentProducer(event) ||
+			this.producerClaims.has(event.producerId)
+		)
+			return;
 		this.producerClaims.add(event.producerId);
 		try {
 			if (!this.isCurrentProducer(event)) return;
-			const result = await this.deps.mediaManager.subscribeToRemoteProducer(event);
-			if (!this.isCurrentProducer(event)) { this.removeProducer(event); return; }
-			if (!result) throw new Error(`Initial producer ${event.producerId} did not create a consumer`);
+			const result =
+				await this.deps.mediaManager.subscribeToRemoteProducer(event);
+			if (!this.isCurrentProducer(event)) {
+				this.removeProducer(event);
+				return;
+			}
+			if (!result)
+				throw new Error(
+					`Initial producer ${event.producerId} did not create a consumer`,
+				);
 			const attached = this.attachmentPromises.get(event.producerId)?.promise;
-			if (!attached) throw new Error(`Initial producer ${event.producerId} was not attached`);
+			if (!attached)
+				throw new Error(
+					`Initial producer ${event.producerId} was not attached`,
+				);
 			await attached;
 			if (!this.isCurrentProducer(event)) this.removeProducer(event);
 		} finally {
@@ -391,10 +558,27 @@ export class RecorderSocketController {
 		}
 	}
 	private async subscribeLive(event: ProducerEvent): Promise<void> {
-		try { await this.subscribeRequired(event); } catch (error) { this.interrupt(error instanceof Error ? error.message : "Media subscription failed"); }
+		try {
+			await this.subscribeRequired(event);
+		} catch (error) {
+			this.interrupt(
+				"media_subscription_failed",
+				error instanceof Error ? error.message : "Media subscription failed",
+			);
+		}
 	}
-	private isCurrentProducer(event: ProducerEvent): boolean { return this.reconciliation.producers.get(event.producerId) === event; }
-	private sanitizeParticipant(p: RecorderParticipantData): RecorderParticipantData { const avatar = trustedAvatar(p.userData?.avatar || p.avatar, this.frappeOrigin); return { ...p, avatar, userData: { ...p.userData, avatar } }; }
+	private isCurrentProducer(event: ProducerEvent): boolean {
+		return this.reconciliation.producers.get(event.producerId) === event;
+	}
+	private sanitizeParticipant(
+		p: RecorderParticipantData,
+	): RecorderParticipantData {
+		const avatar = trustedAvatar(
+			p.userData?.avatar || p.avatar,
+			this.frappeOrigin,
+		);
+		return { ...p, avatar, userData: { ...p.userData, avatar } };
+	}
 	private frappeOrigin = "";
 	private removeProducer(event: ProducerEvent): void {
 		const consumers = this.deps.consumerManager
@@ -404,14 +588,16 @@ export class RecorderSocketController {
 			this.deps.consumerManager.removeConsumer(consumer.id);
 		}
 		if (!consumers.length) this.cancelProducerAttachment(event);
-		if (event.isScreen) this.finishScreen(event.participantId, event.producerId);
+		if (event.isScreen)
+			this.finishScreen(event.participantId, event.producerId);
 	}
 	private stopScreen(participantId: string, producerId: string): void {
 		const consumer = this.deps.consumerManager
 			.getScreenShareConsumers()
-			.find((candidate) =>
-				candidate.participantId === participantId &&
-				candidate.producerId === producerId,
+			.find(
+				(candidate) =>
+					candidate.participantId === participantId &&
+					candidate.producerId === producerId,
 			);
 		if (consumer) {
 			this.deps.consumerManager.removeConsumer(consumer.id);
@@ -428,13 +614,29 @@ export class RecorderSocketController {
 		if (
 			screen?.producerId !== producerId ||
 			(consumerId && screen.consumerId !== consumerId)
-		) return;
+		)
+			return;
 		this.activeScreens.delete(participantId);
 		this.screenAttachmentPromises.get(screen.consumerId)?.cancel();
 		this.state.screenStopped?.(participantId, producerId);
 	}
-	private updateMedia(data: MediaControlMessage): void { const action = data.action; const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {}; if (typeof action === "object") action.type === "audio" ? update.audioEnabled = action.enabled : update.videoEnabled = action.enabled; else if (action === "mute" || action === "unmute") update.audioEnabled = action === "unmute"; else update.videoEnabled = action === "video_on"; this.deps.participantManager.updateMediaState(data.participantId, update); }
-	private interrupt(reason: string): void { if (!this._ready.value && this._interruption.value) return; this._ready.value = false; this._interruption.value = reason; this.bridge.reportInterruption(reason); }
+	private updateMedia(data: MediaControlMessage): void {
+		const action = data.action;
+		const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {};
+		if (typeof action === "object") {
+			if (action.type === "audio") update.audioEnabled = action.enabled;
+			else update.videoEnabled = action.enabled;
+		} else if (action === "mute" || action === "unmute")
+			update.audioEnabled = action === "unmute";
+		else update.videoEnabled = action === "video_on";
+		this.deps.participantManager.updateMediaState(data.participantId, update);
+	}
+	private interrupt(reasonCode: RendererReasonCode, diagnostic: string): void {
+		if (!this._ready.value && this._interruption.value) return;
+		this._ready.value = false;
+		this._interruption.value = diagnostic;
+		this.bridge.reportInterruption(reasonCode, diagnostic);
+	}
 	private cancellableAttachment(
 		consumer: { id: string; participantId: string },
 		operation: Promise<void>,
@@ -469,7 +671,7 @@ export class RecorderSocketController {
 	}
 	private withTimeout(
 		consumer: { consumerId: string; participantId: string },
-		operation: Promise<void | undefined>,
+		operation: Promise<void>,
 		message: string,
 	): PendingAttachment {
 		let settled = false;
@@ -521,7 +723,9 @@ export class RecorderSocketController {
 			this.screenAttachmentPromises.get(consumer.id)?.cancel();
 			return;
 		}
-		const current = this.currentParticipantAttachments.get(consumer.participantId);
+		const current = this.currentParticipantAttachments.get(
+			consumer.participantId,
+		);
 		if (
 			current?.producerId === consumer.producerId &&
 			current.consumerId === consumer.id
@@ -533,8 +737,8 @@ export class RecorderSocketController {
 	private cancelProducerAttachment(event: ProducerEvent): void {
 		this.attachmentPromises.get(event.producerId)?.cancel();
 		if (
-			this.currentParticipantAttachments.get(event.participantId)?.producerId ===
-			event.producerId
+			this.currentParticipantAttachments.get(event.participantId)
+				?.producerId === event.producerId
 		) {
 			this.currentParticipantAttachments.delete(event.participantId);
 			this.deps.videoManager.cancelDeferredAttachment(event.participantId);
@@ -548,7 +752,8 @@ export class RecorderSocketController {
 		for (const [participantId, screen] of [...this.activeScreens]) {
 			this.finishScreen(participantId, screen.producerId, screen.consumerId);
 		}
-		for (const pending of this.screenAttachmentPromises.values()) pending.cancel();
+		for (const pending of this.screenAttachmentPromises.values())
+			pending.cancel();
 		this.attachmentPromises.clear();
 		this.screenAttachmentPromises.clear();
 		this.currentParticipantAttachments.clear();
@@ -556,7 +761,8 @@ export class RecorderSocketController {
 		void this.deps.mediaManager.cancelPendingSubscriptions();
 		this.deps.mediaManager.cleanup();
 		this.deps.consumerManager.clear();
-		for (const participant of this.deps.participantManager.getAllParticipants()) this.deps.participantManager.removeParticipant(participant.user_id);
+		for (const participant of this.deps.participantManager.getAllParticipants())
+			this.deps.participantManager.removeParticipant(participant.user_id);
 		this.deps.videoManager.cleanup();
 		this.deps.transportManager.cleanup();
 		this.deps.sfuClient.disconnect();
@@ -570,15 +776,55 @@ export class RecorderSocketController {
 				this.state.roomEmpty?.();
 		}, 10_000);
 	}
-	private request(event: string, data: { signature: string } | { roomId: string }): Promise<void> { return new Promise((resolve, reject) => this.channel.emit(event, data, (value) => { const response = parseRequestResponse(value); response?.success ? resolve() : reject(new Error(response?.error || `${event} failed`)); })); }
+	private request(event: string, data: { roomId: string }): Promise<void> {
+		return new Promise((resolve, reject) =>
+			this.channel.emit(event, data, (value) => {
+				const response = parseRequestResponse(value);
+				response?.success
+					? resolve()
+					: reject(new Error(response?.error || `${event} failed`));
+			}),
+		);
+	}
+	private requestProof(signature: string): Promise<void> {
+		return new Promise((resolve, reject) =>
+			this.channel.emit(
+				"recording:proof",
+				{ protocol_version: 1, signature },
+				(value) => {
+					const response = parseRecordingProofResponse(value);
+					response?.success
+						? resolve()
+						: reject(
+								new Error(response?.diagnostic || "recording:proof failed"),
+							);
+				},
+			),
+		);
+	}
 }
 
-export function trustedAvatar(value: unknown, frappeOrigin: string): string | null {
-	if (typeof value !== "string" || !value || !frappeOrigin || value.startsWith("//")) return null;
+export function trustedAvatar(
+	value: unknown,
+	frappeOrigin: string,
+): string | null {
+	if (
+		typeof value !== "string" ||
+		!value ||
+		!frappeOrigin ||
+		value.startsWith("//")
+	)
+		return null;
 	try {
 		const origin = new URL(frappeOrigin);
 		const url = new URL(value, origin);
-		if (!["http:", "https:"].includes(origin.protocol) || url.origin !== origin.origin || url.protocol !== origin.protocol || url.pathname.startsWith("/private/")) return null;
+		if (
+			!["http:", "https:"].includes(origin.protocol) ||
+			url.origin !== origin.origin ||
+			url.protocol !== origin.protocol ||
+			url.pathname.startsWith("/private/")
+		)
+			return null;
 		return url.href;
 	} catch {
 		return null;

--- a/frontend/recorder/protocol.test.ts
+++ b/frontend/recorder/protocol.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseRecordingChallenge,
+	parseRecordingProofResponse,
+} from "./protocol";
+
+const challenge = {
+	protocol_version: 1,
+	jti: "grant-1",
+	socket_id: "socket-1",
+	nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+	issued_at: 1_700_000_000,
+	expires_at: 1_700_000_010,
+};
+
+describe("recording proof protocol", () => {
+	it("accepts the exact version 1 challenge", () => {
+		expect(parseRecordingChallenge(challenge)).toEqual(challenge);
+	});
+
+	it.each([
+		{ ...challenge, protocol_version: 2 },
+		{ ...challenge, protocol_version: 1.5 },
+		{ ...challenge, issued_at: 1.5 },
+		{ ...challenge, extra: true },
+		(({ protocol_version: _, ...value }) => value)(challenge),
+	])("rejects a non-contract challenge %#", (value) => {
+		expect(parseRecordingChallenge(value)).toBeNull();
+	});
+
+	it.each([
+		{ protocol_version: 1, success: true },
+		{
+			protocol_version: 1,
+			success: false,
+			reason_code: "invalid_proof",
+			diagnostic: "Invalid proof",
+		},
+	])("accepts the exact proof response %#", (value) => {
+		expect(parseRecordingProofResponse(value)).toEqual(value);
+	});
+
+	it.each([
+		{ success: true },
+		{ protocol_version: 2, success: true },
+		{ protocol_version: 1, success: true, error: "unexpected" },
+		{ protocol_version: 1, success: false },
+		{ protocol_version: 1, success: false, error: "", extra: true },
+	])("rejects a non-contract proof response %#", (value) => {
+		expect(parseRecordingProofResponse(value)).toBeNull();
+	});
+});

--- a/frontend/recorder/protocol.ts
+++ b/frontend/recorder/protocol.ts
@@ -1,3 +1,8 @@
+import type {
+	RecordingProofChallenge,
+	RecordingProofResponse,
+} from "../../suite/meet/types";
+
 export interface RecorderParticipantUserData {
 	name?: string;
 	avatar?: string | null;
@@ -30,7 +35,10 @@ export interface RecorderParticipantUpdate {
 }
 
 export type ParticipantMessage =
-	| { type: "participant-joined"; value: RecorderParticipantData & { participantId: string } }
+	| {
+			type: "participant-joined";
+			value: RecorderParticipantData & { participantId: string };
+	  }
 	| { type: "participant-left"; value: { participantId: string } };
 
 export interface ProducerEvent {
@@ -55,7 +63,10 @@ export type MediaControlAction =
 
 export type MediaControlMessage =
 	| { participantId: string; action: LegacyMediaControlAction }
-	| { participantId: string; action: { type: "audio" | "video"; enabled: boolean } };
+	| {
+			participantId: string;
+			action: { type: "audio" | "video"; enabled: boolean };
+	  };
 
 export interface ParticipantSnapshot {
 	id: string;
@@ -76,14 +87,19 @@ export interface ChatMessage {
 	timestamp?: string;
 }
 
-export interface RecordingChallengeMessage {
-	version: 1;
-	jti: string;
-	socket_id: string;
-	nonce: string;
-	issued_at: number;
-	expires_at: number;
-}
+export type RecordingChallengeMessage = RecordingProofChallenge;
+
+const exactKeys = (
+	value: object,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean => {
+	const keys = Object.keys(value);
+	return (
+		required.every((key) => keys.includes(key)) &&
+		keys.every((key) => required.includes(key) || optional.includes(key))
+	);
+};
 
 const optionalString = (value: unknown): value is string | undefined =>
 	value === undefined || typeof value === "string";
@@ -109,7 +125,8 @@ const parseParticipantUserData = (
 		!optionalBoolean(audioEnabled) ||
 		!optionalBoolean(videoEnabled) ||
 		!optionalBoolean(isGuest)
-	) return null;
+	)
+		return null;
 	return {
 		name,
 		avatar,
@@ -132,7 +149,9 @@ export const parseParticipantMessage = (
 	}
 	const userDataValue = "userData" in value ? value.userData : undefined;
 	const userData =
-		userDataValue === undefined ? undefined : parseParticipantUserData(userDataValue);
+		userDataValue === undefined
+			? undefined
+			: parseParticipantUserData(userDataValue);
 	if (userDataValue !== undefined && !userData) return null;
 	return { type, value: { participantId, ...(userData ? { userData } : {}) } };
 };
@@ -152,7 +171,8 @@ export const parseProducerMessage = (
 		typeof participantId !== "string" ||
 		!participantId ||
 		typeof isScreen !== "boolean"
-	) return null;
+	)
+		return null;
 	return { type, value: { producerId, participantId, isScreen } };
 };
 
@@ -169,7 +189,8 @@ export const parseParticipantSnapshot = (
 		!optionalString(userId) ||
 		typeof infoValue !== "object" ||
 		infoValue === null
-	) return null;
+	)
+		return null;
 	const info = parseParticipantUserData(infoValue);
 	const userName = "user_name" in infoValue ? infoValue.user_name : undefined;
 	if (!info || !optionalString(userName)) return null;
@@ -181,13 +202,14 @@ export const parseProducerSnapshot = (
 ): ProducerSnapshot | null => {
 	if (typeof value !== "object" || value === null) return null;
 	const id = "id" in value ? value.id : undefined;
-	const participantId = "participantId" in value
-		? value.participantId
-		: "user_id" in value
-			? value.user_id
-			: "userId" in value
-				? value.userId
-				: undefined;
+	const participantId =
+		"participantId" in value
+			? value.participantId
+			: "user_id" in value
+				? value.user_id
+				: "userId" in value
+					? value.userId
+					: undefined;
 	const isScreen = "isScreen" in value ? value.isScreen : false;
 	if (
 		typeof id !== "string" ||
@@ -195,7 +217,8 @@ export const parseProducerSnapshot = (
 		typeof participantId !== "string" ||
 		!participantId ||
 		typeof isScreen !== "boolean"
-	) return null;
+	)
+		return null;
 	return { id, participantId, isScreen };
 };
 
@@ -212,14 +235,16 @@ export const parseMediaControlMessage = (
 		action === "unmute" ||
 		action === "video_off" ||
 		action === "video_on"
-	) return { participantId, action };
+	)
+		return { participantId, action };
 	if (typeof action !== "object" || action === null) return null;
 	const actionType = "type" in action ? action.type : undefined;
 	const enabled = "enabled" in action ? action.enabled : undefined;
 	if (
 		(actionType !== "audio" && actionType !== "video") ||
 		typeof enabled !== "boolean"
-	) return null;
+	)
+		return null;
 	return { participantId, action: { type: actionType, enabled } };
 };
 
@@ -254,8 +279,10 @@ export const parseReaction = (
 	if (typeof value !== "object" || value === null) return null;
 	const fromUser = "fromUser" in value ? value.fromUser : undefined;
 	const reaction = "reaction" in value ? value.reaction : undefined;
-	return typeof fromUser === "string" && fromUser &&
-		typeof reaction === "string" && reaction
+	return typeof fromUser === "string" &&
+		fromUser &&
+		typeof reaction === "string" &&
+		reaction
 		? { fromUser, reaction }
 		: null;
 };
@@ -273,7 +300,8 @@ export const parseHandChange = (
 		!participantId ||
 		typeof raised !== "boolean" ||
 		!optionalString(timestamp)
-	) return null;
+	)
+		return null;
 	return {
 		participantId,
 		raised,
@@ -290,7 +318,8 @@ export const parseRaisedHands = (
 	if (typeof hands !== "object" || hands === null || Array.isArray(hands))
 		return null;
 	const entries = Object.entries(hands);
-	if (entries.some(([, timestamp]) => typeof timestamp !== "string")) return null;
+	if (entries.some(([, timestamp]) => typeof timestamp !== "string"))
+		return null;
 	return Object.fromEntries(entries);
 };
 
@@ -306,7 +335,8 @@ export const parseChatMessage = (value: unknown): ChatMessage | null => {
 		typeof message !== "string" ||
 		!message ||
 		!optionalString(timestamp)
-	) return null;
+	)
+		return null;
 	return { fromUser, fromName, message, timestamp };
 };
 
@@ -326,9 +356,10 @@ export const parseParticipantUpdate = (
 		"video_enabled" in value ? value.video_enabled : undefined;
 	const isGuest = "is_guest" in value ? value.is_guest : undefined;
 	const userDataValue = "userData" in value ? value.userData : undefined;
-	const userData = userDataValue === undefined
-		? undefined
-		: parseParticipantUserData(userDataValue);
+	const userData =
+		userDataValue === undefined
+			? undefined
+			: parseParticipantUserData(userDataValue);
 	if (
 		!optionalString(participantId) ||
 		!optionalString(userId) ||
@@ -339,7 +370,8 @@ export const parseParticipantUpdate = (
 		!optionalBoolean(videoEnabled) ||
 		!optionalBoolean(isGuest) ||
 		(userDataValue !== undefined && !userData)
-	) return null;
+	)
+		return null;
 	return {
 		...("participantId" in value ? { participantId } : {}),
 		...("user_id" in value ? { user_id: userId } : {}),
@@ -356,22 +388,90 @@ export const parseParticipantUpdate = (
 export const parseRecordingChallenge = (
 	value: unknown,
 ): RecordingChallengeMessage | null => {
-	if (typeof value !== "object" || value === null) return null;
-	const version = "version" in value ? value.version : undefined;
+	if (
+		typeof value !== "object" ||
+		value === null ||
+		Array.isArray(value) ||
+		!exactKeys(value, [
+			"protocol_version",
+			"jti",
+			"socket_id",
+			"nonce",
+			"issued_at",
+			"expires_at",
+		])
+	)
+		return null;
+	const protocolVersion =
+		"protocol_version" in value ? value.protocol_version : undefined;
 	const jti = "jti" in value ? value.jti : undefined;
 	const socketId = "socket_id" in value ? value.socket_id : undefined;
 	const nonce = "nonce" in value ? value.nonce : undefined;
 	const issuedAt = "issued_at" in value ? value.issued_at : undefined;
 	const expiresAt = "expires_at" in value ? value.expires_at : undefined;
 	if (
-		version !== 1 ||
-		typeof jti !== "string" || !jti ||
-		typeof socketId !== "string" || !socketId ||
-		typeof nonce !== "string" || !nonce ||
-		typeof issuedAt !== "number" || !Number.isFinite(issuedAt) ||
-		typeof expiresAt !== "number" || !Number.isFinite(expiresAt)
-	) return null;
-	return { version, jti, socket_id: socketId, nonce, issued_at: issuedAt, expires_at: expiresAt };
+		protocolVersion !== 1 ||
+		typeof jti !== "string" ||
+		!jti ||
+		typeof socketId !== "string" ||
+		!socketId ||
+		typeof nonce !== "string" ||
+		!/^[A-Za-z0-9_-]{43}$/.test(nonce) ||
+		typeof issuedAt !== "number" ||
+		!Number.isSafeInteger(issuedAt) ||
+		typeof expiresAt !== "number" ||
+		!Number.isSafeInteger(expiresAt) ||
+		expiresAt - issuedAt !== 10
+	)
+		return null;
+	return {
+		protocol_version: protocolVersion,
+		jti,
+		socket_id: socketId,
+		nonce,
+		issued_at: issuedAt,
+		expires_at: expiresAt,
+	};
+};
+
+export const parseRecordingProofResponse = (
+	value: unknown,
+): RecordingProofResponse | null => {
+	if (typeof value !== "object" || value === null || Array.isArray(value))
+		return null;
+	if (
+		!("protocol_version" in value) ||
+		value.protocol_version !== 1 ||
+		!("success" in value)
+	)
+		return null;
+	if (
+		value.success === true &&
+		exactKeys(value, ["protocol_version", "success"])
+	) {
+		return { protocol_version: 1, success: true };
+	}
+	if (
+		value.success === false &&
+		exactKeys(
+			value,
+			["protocol_version", "success", "reason_code"],
+			["diagnostic"],
+		) &&
+		"reason_code" in value &&
+		value.reason_code === "invalid_proof" &&
+		(!("diagnostic" in value) ||
+			(typeof value.diagnostic === "string" && value.diagnostic.length <= 256))
+	)
+		return {
+			protocol_version: 1,
+			success: false,
+			reason_code: "invalid_proof",
+			...("diagnostic" in value
+				? { diagnostic: value.diagnostic as string }
+				: {}),
+		};
+	return null;
 };
 
 export const parseRequestResponse = (
@@ -393,18 +493,25 @@ export const parseScreenShareStarted = (
 	stream: MediaStream;
 } | null => {
 	if (typeof value !== "object" || value === null) return null;
-	const participantId = "participantId" in value ? value.participantId : undefined;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
 	const stream = "stream" in value ? value.stream : undefined;
 	const consumer = "consumer" in value ? value.consumer : undefined;
 	if (
-		typeof participantId !== "string" || !participantId ||
-		(typeof MediaStream === "undefined" || !(stream instanceof MediaStream)) ||
-		typeof consumer !== "object" || consumer === null ||
-		!("id" in consumer) || typeof consumer.id !== "string" || !consumer.id ||
+		typeof participantId !== "string" ||
+		!participantId ||
+		typeof MediaStream === "undefined" ||
+		!(stream instanceof MediaStream) ||
+		typeof consumer !== "object" ||
+		consumer === null ||
+		!("id" in consumer) ||
+		typeof consumer.id !== "string" ||
+		!consumer.id ||
 		!("producerId" in consumer) ||
 		typeof consumer.producerId !== "string" ||
 		!consumer.producerId
-	) return null;
+	)
+		return null;
 	return {
 		participantId,
 		consumerId: consumer.id,
@@ -417,13 +524,15 @@ export const parseScreenShareStopped = (
 	value: unknown,
 ): { participantId: string; producerId: string } | null => {
 	if (typeof value !== "object" || value === null) return null;
-	const participantId = "participantId" in value ? value.participantId : undefined;
+	const participantId =
+		"participantId" in value ? value.participantId : undefined;
 	const producerId = "producerId" in value ? value.producerId : undefined;
 	if (
 		typeof participantId !== "string" ||
 		!participantId ||
 		typeof producerId !== "string" ||
 		!producerId
-	) return null;
+	)
+		return null;
 	return { participantId, producerId };
 };

--- a/frontend/recorder/protocolContract.test.ts
+++ b/frontend/recorder/protocolContract.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	parseRecordingChallenge,
+	parseRecordingProofResponse,
+} from "./protocol";
+import { parseConfigureMessage } from "./rendererBridge";
+
+const contract = JSON.parse(
+	readFileSync(
+		resolve(process.cwd(), "../suite/meet/recording/contracts/v1.json"),
+		"utf8",
+	),
+) as {
+	vectors: {
+		proof_challenges: {
+			accepted: unknown[];
+			rejected: unknown[];
+		};
+		proof_responses: { accepted: unknown[]; rejected: unknown[] };
+		renderer_configure: { accepted: unknown[]; rejected: unknown[] };
+	};
+};
+
+describe("recording protocol contract v1", () => {
+	it("runs shared proof challenge vectors through the production parser", () => {
+		for (const value of contract.vectors.proof_challenges.accepted)
+			expect(parseRecordingChallenge(value)).toEqual(value);
+		for (const value of contract.vectors.proof_challenges.rejected)
+			expect(parseRecordingChallenge(value)).toBeNull();
+	});
+
+	it("runs shared configure vectors through the production parser", () => {
+		for (const value of contract.vectors.renderer_configure.accepted)
+			expect(parseConfigureMessage(value)).not.toBeNull();
+		for (const value of contract.vectors.renderer_configure.rejected)
+			expect(parseConfigureMessage(value)).toBeNull();
+	});
+
+	it("runs shared proof response vectors through the production parser", () => {
+		for (const value of contract.vectors.proof_responses.accepted)
+			expect(parseRecordingProofResponse(value)).toEqual(value);
+		for (const value of contract.vectors.proof_responses.rejected)
+			expect(parseRecordingProofResponse(value)).toBeNull();
+	});
+});

--- a/frontend/recorder/rendererBridge.test.ts
+++ b/frontend/recorder/rendererBridge.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
-import { canonicalChallenge, RecorderRendererBridge, type RecorderConfig } from "./rendererBridge";
+import {
+	canonicalChallenge,
+	type RecorderConfig,
+	RecorderRendererBridge,
+} from "./rendererBridge";
 
 const challenge = {
-	version: 1 as const,
+	protocol_version: 1 as const,
 	jti: "jti-vector",
 	socket_id: "socket-vector",
 	nonce: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
@@ -15,31 +19,164 @@ describe("RecorderRendererBridge", () => {
 		expect(new TextDecoder().decode(canonicalChallenge(challenge))).toBe(
 			"meet-recording-proof-v1\njti-vector\nsocket-vector\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n1700000000\n1700000010",
 		);
+		const postMessage = vi.fn();
 		const bridge = new RecorderRendererBridge();
-		const publicJwk = await bridge.initialize({ postMessage: vi.fn() });
+		const publicJwk = await bridge.initialize({ postMessage });
+		expect(postMessage).toHaveBeenCalledWith(
+			{
+				type: "suite-recorder:public-key-ready",
+				protocol_version: 1,
+				occurred_at: expect.stringMatching(
+					/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+				),
+				publicKey: publicJwk,
+			},
+			window.location.origin,
+		);
+		expect(Object.keys(publicJwk).sort()).toEqual(["crv", "kty", "x", "y"]);
 		const signature = await bridge.sign(challenge);
-		const bytes = Uint8Array.from(atob(signature.replace(/-/g, "+").replace(/_/g, "/")), (char) => char.charCodeAt(0));
-		const publicKey = await crypto.subtle.importKey("jwk", publicJwk, { name: "ECDSA", namedCurve: "P-256" }, false, ["verify"]);
+		const bytes = Uint8Array.from(
+			atob(signature.replace(/-/g, "+").replace(/_/g, "/")),
+			(char) => char.charCodeAt(0),
+		);
+		const publicKey = await crypto.subtle.importKey(
+			"jwk",
+			publicJwk,
+			{ name: "ECDSA", namedCurve: "P-256" },
+			false,
+			["verify"],
+		);
 
 		expect(bytes).toHaveLength(64);
-		expect(await crypto.subtle.verify({ name: "ECDSA", hash: "SHA-256" }, publicKey, bytes, canonicalChallenge(challenge))).toBe(true);
+		expect(
+			await crypto.subtle.verify(
+				{ name: "ECDSA", hash: "SHA-256" },
+				publicKey,
+				bytes,
+				canonicalChallenge(challenge),
+			),
+		).toBe(true);
 	});
 
 	it("accepts internal configuration only once", async () => {
 		const listeners: EventListener[] = [];
 		const source = {
-			addEventListener: vi.fn((_name: string, listener: EventListener) => listeners.push(listener)),
-			removeEventListener: vi.fn((_name: string, listener: EventListener) => listeners.splice(listeners.indexOf(listener), 1)),
+			addEventListener: vi.fn((_name: string, listener: EventListener) =>
+				listeners.push(listener),
+			),
+			removeEventListener: vi.fn((_name: string, listener: EventListener) =>
+				listeners.splice(listeners.indexOf(listener), 1),
+			),
 		};
-		const config: RecorderConfig = { job: "job", grant: "grant", meetingId: "room", sfuOrigin: "https://sfu.test", frappeOrigin: "https://frappe.test", socketPath: "/socket.io", startedAt: 1 };
+		const config: RecorderConfig = {
+			job: "job",
+			grant: "grant",
+			meetingId: "room",
+			sfuOrigin: "https://sfu.test",
+			frappeOrigin: "https://frappe.test",
+			socketPath: "/socket.io",
+			acceptedAt: "2026-08-30T12:00:00.000Z",
+		};
 		const bridge = new RecorderRendererBridge();
 		const pending = bridge.waitForConfig(source);
-		listeners[0](new MessageEvent("message", { data: { type: "suite-recorder:configure", config: { ...config, startedAt: "now" } }, origin: window.location.origin, source: window }));
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:configure",
+					protocol_version: 1,
+					config: { ...config, acceptedAt: "now" },
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
 		expect(source.removeEventListener).not.toHaveBeenCalled();
-		listeners[0](new MessageEvent("message", { data: { type: "suite-recorder:configure", config }, origin: window.location.origin, source: window }));
+		for (const data of [
+			{ type: "suite-recorder:configure", config },
+			{ type: "suite-recorder:configure", protocol_version: 2, config },
+			{
+				type: "suite-recorder:configure",
+				protocol_version: 1,
+				config,
+				extra: true,
+			},
+			{
+				type: "suite-recorder:configure",
+				protocol_version: 1,
+				config: { ...config, extra: true },
+			},
+		])
+			listeners[0](
+				new MessageEvent("message", {
+					data,
+					origin: window.location.origin,
+					source: window,
+				}),
+			);
+		expect(source.removeEventListener).not.toHaveBeenCalled();
+		listeners[0](
+			new MessageEvent("message", {
+				data: { type: "suite-recorder:configure", protocol_version: 1, config },
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
 
 		expect(await pending).toEqual(config);
 		expect(source.removeEventListener).toHaveBeenCalledOnce();
 		expect(listeners).toHaveLength(0);
+	});
+
+	it("emits exact versioned lifecycle messages with finite bounded reasons", async () => {
+		const postMessage = vi
+			.spyOn(window, "postMessage")
+			.mockImplementation(() => undefined);
+		const listeners: EventListener[] = [];
+		const source = {
+			addEventListener: (_name: string, listener: EventListener) =>
+				listeners.push(listener),
+			removeEventListener: () => undefined,
+		};
+		const config: RecorderConfig = {
+			job: "job",
+			grant: "grant",
+			meetingId: "room",
+			sfuOrigin: "https://sfu.test",
+			frappeOrigin: "https://frappe.test",
+			socketPath: "/socket.io",
+			acceptedAt: "2026-08-30T12:00:00.000Z",
+		};
+		const bridge = new RecorderRendererBridge();
+		const pending = bridge.waitForConfig(source);
+		listeners[0](
+			new MessageEvent("message", {
+				data: { type: "suite-recorder:configure", protocol_version: 1, config },
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await pending;
+		postMessage.mockClear();
+
+		bridge.reportCaptureReady();
+		bridge.reportInterruption("media_attachment_failed", "x".repeat(300));
+
+		expect(postMessage.mock.calls.map(([message]) => message)).toEqual([
+			{
+				type: "suite-recorder:capture-ready",
+				protocol_version: 1,
+				occurred_at: expect.any(String),
+				job: "job",
+			},
+			{
+				type: "suite-recorder:interruption",
+				protocol_version: 1,
+				occurred_at: expect.any(String),
+				job: "job",
+				reason_code: "media_attachment_failed",
+				diagnostic: "x".repeat(256),
+			},
+		]);
+		postMessage.mockRestore();
 	});
 });

--- a/frontend/recorder/rendererBridge.ts
+++ b/frontend/recorder/rendererBridge.ts
@@ -1,3 +1,5 @@
+import type { RecordingProofChallenge } from "../../suite/meet/types";
+
 export interface RecorderConfig {
 	job: string;
 	grant: string;
@@ -5,39 +7,72 @@ export interface RecorderConfig {
 	sfuOrigin: string;
 	frappeOrigin: string;
 	socketPath: string;
-	startedAt: number;
+	acceptedAt: string;
 	publicChat?: boolean;
 }
 
-export interface RecordingChallenge {
-	version: 1;
-	jti: string;
-	socket_id: string;
-	nonce: string;
-	issued_at: number;
-	expires_at: number;
-}
+export type RecordingChallenge = RecordingProofChallenge;
+
+export const RECORDER_PROTOCOL_VERSION = 1 as const;
+
+export type RendererReasonCode =
+	| "sfu_disconnected"
+	| "media_attachment_failed"
+	| "media_subscription_failed"
+	| "receive_transport_failed"
+	| "configuration_failed"
+	| "browser_disconnected"
+	| "page_crashed";
 
 type RendererReport =
 	| { type: "suite-recorder:capture-ready" }
-	| { type: "suite-recorder:interruption"; reason: string }
+	| {
+			type: "suite-recorder:interruption";
+			reason_code: RendererReasonCode;
+			diagnostic?: string;
+	  }
 	| { type: "suite-recorder:proof-complete" }
 	| { type: "suite-recorder:join-complete" }
 	| { type: "suite-recorder:room-empty" }
-	| { type: "suite-recorder:failure"; reason: string };
+	| {
+			type: "suite-recorder:failure";
+			reason_code: RendererReasonCode;
+			diagnostic?: string;
+	  };
 
 export type OutboundRendererMessage =
-	| { type: "suite-recorder:public-key-ready"; publicKey: JsonWebKey }
-	| { type: "suite-recorder:configuration-accepted"; job: string }
-	| (RendererReport & { job: string });
+	| {
+			type: "suite-recorder:public-key-ready";
+			protocol_version: 1;
+			occurred_at: string;
+			publicKey: JsonWebKey;
+	  }
+	| {
+			type: "suite-recorder:configuration-accepted";
+			protocol_version: 1;
+			occurred_at: string;
+			job: string;
+	  }
+	| (RendererReport & {
+			protocol_version: 1;
+			occurred_at: string;
+			job: string;
+	  });
 
-export const canonicalChallenge = (challenge: RecordingChallenge): Uint8Array<ArrayBuffer> =>
-	new TextEncoder().encode(`meet-recording-proof-v1\n${challenge.jti}\n${challenge.socket_id}\n${challenge.nonce}\n${challenge.issued_at}\n${challenge.expires_at}`);
+export const canonicalChallenge = (
+	challenge: RecordingChallenge,
+): Uint8Array<ArrayBuffer> =>
+	new TextEncoder().encode(
+		`meet-recording-proof-v1\n${challenge.jti}\n${challenge.socket_id}\n${challenge.nonce}\n${challenge.issued_at}\n${challenge.expires_at}`,
+	);
 
 const base64url = (bytes: ArrayBuffer): string => {
 	let binary = "";
 	for (const byte of new Uint8Array(bytes)) binary += String.fromCharCode(byte);
-	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+	return btoa(binary)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/, "");
 };
 
 export class RecorderRendererBridge {
@@ -45,32 +80,63 @@ export class RecorderRendererBridge {
 	private configured = false;
 	private job?: string;
 
-	private post(message: OutboundRendererMessage, target: Pick<Window, "postMessage"> = window): void {
+	private post(
+		message: OutboundRendererMessage,
+		target: Pick<Window, "postMessage"> = window,
+	): void {
 		target.postMessage(message, window.location.origin);
 	}
 
-	async initialize(target: Pick<Window, "postMessage"> = window): Promise<JsonWebKey> {
-		const pair = await crypto.subtle.generateKey(
+	async initialize(
+		target: Pick<Window, "postMessage"> = window,
+	): Promise<JsonWebKey> {
+		const pair = (await crypto.subtle.generateKey(
 			{ name: "ECDSA", namedCurve: "P-256" },
 			false,
 			["sign", "verify"],
-		) as CryptoKeyPair;
+		)) as CryptoKeyPair;
 		this.privateKey = pair.privateKey;
-		const publicKey = await crypto.subtle.exportKey("jwk", pair.publicKey);
-		this.post({ type: "suite-recorder:public-key-ready", publicKey }, target);
+		const exported = await crypto.subtle.exportKey("jwk", pair.publicKey);
+		const publicKey = {
+			kty: exported.kty,
+			crv: exported.crv,
+			x: exported.x,
+			y: exported.y,
+		};
+		this.post(
+			{
+				type: "suite-recorder:public-key-ready",
+				protocol_version: RECORDER_PROTOCOL_VERSION,
+				occurred_at: new Date().toISOString(),
+				publicKey,
+			},
+			target,
+		);
 		return publicKey;
 	}
 
-	waitForConfig(source: Pick<Window, "addEventListener" | "removeEventListener"> = window): Promise<RecorderConfig> {
+	waitForConfig(
+		source: Pick<Window, "addEventListener" | "removeEventListener"> = window,
+	): Promise<RecorderConfig> {
 		return new Promise((resolve) => {
 			const receive = (event: MessageEvent) => {
-				if (this.configured || event.source !== window || event.origin !== window.location.origin) return;
+				if (
+					this.configured ||
+					event.source !== window ||
+					event.origin !== window.location.origin
+				)
+					return;
 				const message = parseConfigureMessage(event.data);
 				if (!message) return;
 				this.configured = true;
 				this.job = message.config.job;
 				source.removeEventListener("message", receive as EventListener);
-				this.post({ type: "suite-recorder:configuration-accepted", job: this.job });
+				this.post({
+					type: "suite-recorder:configuration-accepted",
+					protocol_version: RECORDER_PROTOCOL_VERSION,
+					occurred_at: new Date().toISOString(),
+					job: this.job,
+				});
 				resolve(Object.freeze({ ...message.config }));
 			};
 			source.addEventListener("message", receive as EventListener);
@@ -91,8 +157,19 @@ export class RecorderRendererBridge {
 		this.report({ type: "suite-recorder:capture-ready" }, target);
 	}
 
-	reportInterruption(reason: string, target: Pick<Window, "postMessage"> = window): void {
-		this.report({ type: "suite-recorder:interruption", reason }, target);
+	reportInterruption(
+		reasonCode: RendererReasonCode,
+		diagnostic?: string,
+		target: Pick<Window, "postMessage"> = window,
+	): void {
+		this.report(
+			{
+				type: "suite-recorder:interruption",
+				reason_code: reasonCode,
+				...boundedDiagnostic(diagnostic),
+			},
+			target,
+		);
 	}
 
 	reportProofComplete(target: Pick<Window, "postMessage"> = window): void {
@@ -107,15 +184,52 @@ export class RecorderRendererBridge {
 		this.report({ type: "suite-recorder:room-empty" }, target);
 	}
 
-	reportFailure(reason: string, target: Pick<Window, "postMessage"> = window): void {
-		this.report({ type: "suite-recorder:failure", reason }, target);
+	reportFailure(
+		reasonCode: RendererReasonCode,
+		diagnostic?: string,
+		target: Pick<Window, "postMessage"> = window,
+	): void {
+		this.report(
+			{
+				type: "suite-recorder:failure",
+				reason_code: reasonCode,
+				...boundedDiagnostic(diagnostic),
+			},
+			target,
+		);
 	}
 
-	private report(message: RendererReport, target: Pick<Window, "postMessage">): void {
+	private report(
+		message: RendererReport,
+		target: Pick<Window, "postMessage">,
+	): void {
 		if (!this.job) return;
-		this.post({ ...message, job: this.job }, target);
+		this.post(
+			{
+				...message,
+				protocol_version: RECORDER_PROTOCOL_VERSION,
+				occurred_at: new Date().toISOString(),
+				job: this.job,
+			},
+			target,
+		);
 	}
 }
+
+const boundedDiagnostic = (diagnostic?: string): { diagnostic?: string } =>
+	diagnostic ? { diagnostic: diagnostic.slice(0, 256) } : {};
+
+const hasExactKeys = (
+	value: object,
+	required: string[],
+	optional: string[] = [],
+): boolean => {
+	const keys = Object.keys(value);
+	return (
+		required.every((key) => keys.includes(key)) &&
+		keys.every((key) => required.includes(key) || optional.includes(key))
+	);
+};
 
 const isHttpUrl = (value: string): boolean => {
 	try {
@@ -125,17 +239,55 @@ const isHttpUrl = (value: string): boolean => {
 	}
 };
 
+const isUtcTimestamp = (value: unknown): value is string =>
+	typeof value === "string" &&
+	/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value) &&
+	new Date(value).toISOString() === value;
+
 const parseConfig = (value: unknown): RecorderConfig | null => {
-	if (!value || typeof value !== "object") return null;
-	if (!("job" in value) || typeof value.job !== "string" || !value.job ||
-		!("grant" in value) || typeof value.grant !== "string" || !value.grant ||
-		!("meetingId" in value) || typeof value.meetingId !== "string" || !value.meetingId ||
-		!("sfuOrigin" in value) || typeof value.sfuOrigin !== "string" || !isHttpUrl(value.sfuOrigin) ||
-		!("frappeOrigin" in value) || typeof value.frappeOrigin !== "string" || !isHttpUrl(value.frappeOrigin) ||
-		!("socketPath" in value) || typeof value.socketPath !== "string" || !value.socketPath ||
-		!("startedAt" in value) || typeof value.startedAt !== "number" || !Number.isFinite(value.startedAt) ||
-		("publicChat" in value && value.publicChat !== undefined && typeof value.publicChat !== "boolean")
-	) return null;
+	if (
+		!value ||
+		typeof value !== "object" ||
+		Array.isArray(value) ||
+		!hasExactKeys(
+			value,
+			[
+				"job",
+				"grant",
+				"meetingId",
+				"sfuOrigin",
+				"frappeOrigin",
+				"socketPath",
+				"acceptedAt",
+			],
+			["publicChat"],
+		)
+	)
+		return null;
+	if (
+		!("job" in value) ||
+		typeof value.job !== "string" ||
+		!value.job ||
+		!("grant" in value) ||
+		typeof value.grant !== "string" ||
+		!value.grant ||
+		!("meetingId" in value) ||
+		typeof value.meetingId !== "string" ||
+		!value.meetingId ||
+		!("sfuOrigin" in value) ||
+		typeof value.sfuOrigin !== "string" ||
+		!isHttpUrl(value.sfuOrigin) ||
+		!("frappeOrigin" in value) ||
+		typeof value.frappeOrigin !== "string" ||
+		!isHttpUrl(value.frappeOrigin) ||
+		!("socketPath" in value) ||
+		typeof value.socketPath !== "string" ||
+		!value.socketPath ||
+		!("acceptedAt" in value) ||
+		!isUtcTimestamp(value.acceptedAt) ||
+		("publicChat" in value && typeof value.publicChat !== "boolean")
+	)
+		return null;
 	return {
 		job: value.job,
 		grant: value.grant,
@@ -143,23 +295,28 @@ const parseConfig = (value: unknown): RecorderConfig | null => {
 		sfuOrigin: value.sfuOrigin,
 		frappeOrigin: value.frappeOrigin,
 		socketPath: value.socketPath,
-		startedAt: value.startedAt,
+		acceptedAt: value.acceptedAt,
 		...("publicChat" in value && typeof value.publicChat === "boolean"
 			? { publicChat: value.publicChat }
 			: {}),
 	};
 };
 
-const parseConfigureMessage = (
+export const parseConfigureMessage = (
 	value: unknown,
 ): { type: "suite-recorder:configure"; config: RecorderConfig } | null => {
 	if (
 		typeof value !== "object" ||
 		value === null ||
+		Array.isArray(value) ||
+		!hasExactKeys(value, ["type", "protocol_version", "config"]) ||
 		!("type" in value) ||
 		value.type !== "suite-recorder:configure" ||
+		!("protocol_version" in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
 		!("config" in value)
-	) return null;
+	)
+		return null;
 	const config = parseConfig(value.config);
 	return config ? { type: value.type, config } : null;
 };

--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
+from re import fullmatch
 from zoneinfo import ZoneInfo
 
 import frappe
@@ -24,7 +25,7 @@ from suite.meet.doctype.meet_recording.meet_recording import (
     ACTIVE_RECORDING_STATUSES,
     recording_storage_reservation_key,
 )
-from suite.meet.recording.callback_auth import authenticate_callback
+from suite.meet.recording.callback_auth import PROTOCOL_VERSION, authenticate_callback
 from suite.meet.recording.grants import (
     mint_recording_grant,
     normalize_public_jwk,
@@ -56,6 +57,35 @@ STARTUP_MILESTONES = {
     "joined": "joined_at",
     "capture_started": "capture_started_at",
 }
+INTERRUPTION_REASON_CODES = {
+    "browser_disconnected",
+    "capture_interrupted",
+    "configuration_failed",
+    "ffmpeg_exited",
+    "media_attachment_failed",
+    "media_subscription_failed",
+    "page_crashed",
+    "receive_transport_failed",
+    "sfu_disconnected",
+}
+END_REASON_CODES = {
+    "duration_limit",
+    "host_stop",
+    "interruption_timeout",
+    "quota_limit",
+    "room_empty",
+    "service_shutdown",
+}
+GAP_REASON_CODES = {"capture_interrupted", "ffmpeg_exited", "renderer_interrupted"}
+
+
+def _validate_callback_protocol(protocol_version: int):
+    if isinstance(protocol_version, bool) or protocol_version != PROTOCOL_VERSION:
+        frappe.throw(_("Unsupported recording callback protocol version"))
+
+
+def _callback_response(result: dict) -> dict:
+    return {"protocol_version": PROTOCOL_VERSION, **result}
 
 
 def _get_room(meeting_id: str):
@@ -632,8 +662,8 @@ def _stop_operation_id(recording) -> str:
 
 
 def _startup_timestamp(value: str) -> datetime:
-    if not isinstance(value, str) or not value.endswith("Z"):
-        frappe.throw(_("Recording startup timestamp must be UTC"))
+    if not isinstance(value, str) or not fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", value):
+        frappe.throw(_("Recording startup timestamp must use canonical UTC milliseconds"))
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
@@ -702,15 +732,18 @@ def recorder_startup_progress(
     event_sequence: int,
     milestone: str,
     occurred_at: str,
+    protocol_version: int,
 ) -> dict:
     """Apply one authenticated, strictly ordered Recorder Startup milestone."""
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="startup_progress",
         operation_id=str(event_sequence),
     )
-    return _apply_startup_milestone(recording_id, event_sequence, milestone, occurred_at)
+    return _callback_response(_apply_startup_milestone(recording_id, event_sequence, milestone, occurred_at))
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -718,39 +751,50 @@ def recorder_interrupted(
     recording_id: str,
     job: str,
     event_sequence: int,
-    reason: str,
+    reason_code: str,
     interruption_id: str,
     interrupted_at: str,
     interruption_deadline: str,
     omission_started_at: str,
+    protocol_version: int,
 ) -> dict:
+    if not isinstance(reason_code, str) or reason_code not in INTERRUPTION_REASON_CODES:
+        frappe.throw(_("Invalid recording interruption reason code"))
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="interrupted",
         operation_id=str(event_sequence),
     )
-    return _apply_interruption(
-        recording_id,
-        event_sequence,
-        reason,
-        interruption_id,
-        interrupted_at,
-        interruption_deadline,
-        omission_started_at,
+    return _callback_response(
+        _apply_interruption(
+            recording_id,
+            event_sequence,
+            reason_code,
+            interruption_id,
+            interrupted_at,
+            interruption_deadline,
+            omission_started_at,
+        )
     )
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
-def recorder_segment_progress(recording_id: str, job: str, captured_bytes: int) -> dict:
+def recorder_segment_progress(
+    recording_id: str, job: str, captured_bytes: int, protocol_version: int
+) -> dict:
     """Grow one active Recording Session's budget after a durable segment."""
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="segment_progress",
         operation_id=str(captured_bytes),
     )
-    return _apply_segment_progress(recording_id, captured_bytes)
+    return _callback_response(_apply_segment_progress(recording_id, captured_bytes))
 
 
 def _apply_segment_progress(recording_id: str, captured_bytes: int, *, grow_budget: bool = True) -> dict:
@@ -878,22 +922,27 @@ def recorder_replacement_ready(
     endpoint_generation: int,
     public_jwk: str | dict,
     ready_at: str,
+    protocol_version: int,
 ) -> dict:
     """Authorize one strictly ordered replacement Recorder Endpoint."""
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="replacement_ready",
         operation_id=str(event_sequence),
     )
-    return _apply_replacement_ready(
-        recording_id,
-        event_sequence,
-        interruption_id,
-        endpoint_generation,
-        public_jwk,
-        ready_at,
-        _client(),
+    return _callback_response(
+        _apply_replacement_ready(
+            recording_id,
+            event_sequence,
+            interruption_id,
+            endpoint_generation,
+            public_jwk,
+            ready_at,
+            _client(),
+        )
     )
 
 
@@ -1040,19 +1089,24 @@ def recorder_recovered(
     interruption_id: str,
     resumed_capture_started_at: str,
     recovered_at: str,
+    protocol_version: int,
 ) -> dict:
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="recovered",
         operation_id=str(event_sequence),
     )
-    return _apply_recovery(
-        recording_id,
-        event_sequence,
-        interruption_id,
-        resumed_capture_started_at,
-        recovered_at,
+    return _callback_response(
+        _apply_recovery(
+            recording_id,
+            event_sequence,
+            interruption_id,
+            resumed_capture_started_at,
+            recovered_at,
+        )
     )
 
 
@@ -1115,10 +1169,13 @@ def recorder_stopped(
     sha256: str,
     duration_ms: int,
     ended_at: str,
-    end_reason: str,
+    end_reason_code: str,
+    protocol_version: int,
     gaps: str | list | None = None,
 ) -> dict:
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="stopped",
@@ -1126,6 +1183,17 @@ def recorder_stopped(
     )
     if not ended_at:
         frappe.throw(_("Recording stop callback requires an end time"))
+    if not isinstance(end_reason_code, str) or end_reason_code not in END_REASON_CODES:
+        frappe.throw(_("Invalid recording end reason code"))
+    gaps = frappe.parse_json(gaps) if isinstance(gaps, str) else gaps
+    if not isinstance(gaps, list) or any(
+        not isinstance(gap, dict)
+        or set(gap) != {"started_at", "ended_at", "reason_code"}
+        or not isinstance(gap["reason_code"], str)
+        or gap["reason_code"] not in GAP_REASON_CODES
+        for gap in gaps
+    ):
+        frappe.throw(_("Invalid recording gap reason code"))
     _apply_segment_progress(recording_id, captured_bytes, grow_budget=False)
     result = begin_upload(
         recording_id,
@@ -1133,18 +1201,29 @@ def recorder_stopped(
         size=size,
         sha256=sha256,
         duration_ms=duration_ms,
-        gaps=frappe.parse_json(gaps) if isinstance(gaps, str) else gaps,
+        gaps=[
+            {
+                "started_at": gap["started_at"],
+                "ended_at": gap["ended_at"],
+                "reason": gap["reason_code"],
+            }
+            for gap in gaps
+        ],
         ended_at=ended_at,
-        end_reason=end_reason,
+        end_reason=end_reason_code,
     )
     recording = frappe.get_doc("Meet Recording", recording_id)
     _publish_state(frappe.get_doc("Meet Room", recording.meet_room), recording)
-    return result
+    return _callback_response({"offset": result["offset"], "complete": result["complete"]})
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
-def recorder_upload_chunk(recording_id: str, job: str, offset: int, chunk_sha256: str) -> dict:
+def recorder_upload_chunk(
+    recording_id: str, job: str, offset: int, chunk_sha256: str, protocol_version: int
+) -> dict:
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="upload_chunk",
@@ -1154,17 +1233,21 @@ def recorder_upload_chunk(recording_id: str, job: str, offset: int, chunk_sha256
         frappe.throw(_("Recording upload chunks must be binary data"))
     if frappe.request.content_length is not None and frappe.request.content_length > CHUNK_SIZE:
         frappe.throw(_("Recording upload chunk is too large"))
-    return append_chunk(
-        recording_id,
-        offset=offset,
-        chunk=frappe.request.get_data(cache=True),
-        chunk_sha256=chunk_sha256,
+    return _callback_response(
+        append_chunk(
+            recording_id,
+            offset=offset,
+            chunk=frappe.request.get_data(cache=True),
+            chunk_sha256=chunk_sha256,
+        )
     )
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
-def recorder_complete_upload(recording_id: str, job: str, event_sequence: int) -> dict:
+def recorder_complete_upload(recording_id: str, job: str, event_sequence: int, protocol_version: int) -> dict:
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="complete_upload",
@@ -1173,7 +1256,7 @@ def recorder_complete_upload(recording_id: str, job: str, event_sequence: int) -
     result = complete_upload(recording_id, event_sequence=event_sequence)
     recording = frappe.get_doc("Meet Recording", recording_id)
     _publish_state(frappe.get_doc("Meet Room", recording.meet_room), recording)
-    return result
+    return _callback_response(result)
 
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
@@ -1181,9 +1264,12 @@ def recorder_failed(
     recording_id: str,
     job: str,
     event_sequence: int,
-    failure_code: str = "capture_failed",
+    protocol_version: int,
+    reason_code: str = "capture_failed",
 ) -> dict:
+    _validate_callback_protocol(protocol_version)
     authenticate_callback(
+        protocol_version=protocol_version,
         recording=recording_id,
         job=job,
         operation="failed",
@@ -1191,20 +1277,25 @@ def recorder_failed(
     )
     recording = _locked_recording(recording_id)
     if recording.status == "Failed":
-        return {"status": "Failed"}
+        return _callback_response({"status": "Failed"})
     if recording.status == "Cancelled":
-        return {"status": "Cancelled"}
+        return _callback_response({"status": "Cancelled"})
     if recording.status not in ("Starting", "Recording", "Interrupted", "Stopping", "Processing"):
         frappe.throw(_("Recording cannot accept a failure callback"))
     if cint(event_sequence) <= recording.recorder_event_sequence:
         frappe.throw(_("Recorder event is out of order"))
-    if failure_code not in ("capture_failed", "processing_failed", "storage_unavailable", "quota_exhausted"):
+    if not isinstance(reason_code, str) or reason_code not in (
+        "capture_failed",
+        "processing_failed",
+        "storage_unavailable",
+        "quota_exhausted",
+    ):
         frappe.throw(_("Invalid recording failure code"))
     startup_failure = recording.status == "Starting"
     recording.status = "Failed"
     recording.state_revision += 1
     recording.recorder_event_sequence = cint(event_sequence)
-    recording.failure_code = failure_code
+    recording.failure_code = reason_code
     if recording.started_at:
         recording.ended_at = recording.ended_at or _bounded_end(recording)
     if startup_failure:
@@ -1215,7 +1306,7 @@ def recorder_failed(
         None if startup_failure else recording,
         hosts_only=startup_failure,
     )
-    return {"status": "Failed"}
+    return _callback_response({"status": "Failed"})
 
 
 def reconcile_pending_recordings():
@@ -1394,7 +1485,7 @@ def _reconcile_recording(name: str):
     _apply_interruption(
         recording.name,
         interruption_sequence,
-        outcome.health_reason or "capture_interrupted",
+        outcome.reason_code or "capture_interrupted",
         interruption["id"],
         _callback_timestamp(interruption["interrupted_at"]),
         _callback_timestamp(interruption["deadline"]),

--- a/suite/meet/api/test/test_callback_security.py
+++ b/suite/meet/api/test/test_callback_security.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import hashlib
+import json
 import time
 import uuid
 from unittest.mock import Mock, patch
@@ -90,6 +91,7 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
             "future-issued": {"iat": now + 6, "exp": now + 36},
             "too-old": {"iat": now - 36, "exp": now - 6},
             "wrong-lifetime": {"exp": now + 31},
+            "protocol-version": {"protocol_version": 2},
         }
         for label, changes in cases.items():
             with self.subTest(label=label):
@@ -143,6 +145,83 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
         with self.assertRaises(frappe.AuthenticationError):
             self._authenticate(now)
 
+    def test_callback_rejects_unknown_json_fields_before_binding_lookup(self):
+        now = int(time.time())
+        body = json.loads(self._body())
+        body["unknown"] = True
+        encoded = json.dumps(body, separators=(",", ":")).encode()
+        claims = {**self._claims(now), "body_sha256": hashlib.sha256(encoded).hexdigest()}
+        self._set_token(claims, body=encoded)
+
+        with (
+            patch("suite.meet.recording.callback_auth.frappe.db.get_value") as get_value,
+            self.assertRaises(frappe.AuthenticationError),
+        ):
+            self._authenticate(now)
+        get_value.assert_not_called()
+
+    def test_invalid_callback_semantics_do_not_consume_replay_token(self):
+        now = int(time.time())
+        claims = self._claims(now)
+        invalid = json.loads(self._body())
+        invalid["size"] = 0
+        encoded = json.dumps(invalid, separators=(",", ":")).encode()
+        self._set_token({**claims, "body_sha256": hashlib.sha256(encoded).hexdigest()}, body=encoded)
+
+        with self.assertRaises(frappe.AuthenticationError):
+            self._authenticate(now)
+
+        self._set_token(claims)
+        self.assertEqual(self._authenticate(now)["jti"], claims["jti"])
+
+    def test_invalid_upload_bytes_do_not_consume_replay_token(self):
+        now = int(time.time())
+        body = b"chunk"
+        digest = hashlib.sha256(body).hexdigest()
+        query = {
+            "protocol_version": "1",
+            "recording_id": self.recording.name,
+            "job": self.recording.recorder_job_id,
+            "offset": "0",
+            "chunk_sha256": digest,
+        }
+        claims = {
+            **self._claims(now),
+            "operation": "upload_chunk",
+            "operation_id": f"0:{digest}",
+        }
+
+        invalid = b"bad"
+        self._set_token({**claims, "body_sha256": hashlib.sha256(invalid).hexdigest()}, body=invalid)
+        frappe.local.request.args.to_dict.return_value = query
+        frappe.local.request.content_type = "application/octet-stream"
+        frappe.local.request.content_length = len(invalid)
+        with self.assertRaises(frappe.AuthenticationError):
+            authenticate_callback(
+                protocol_version=1,
+                recording=self.recording.name,
+                job=self.recording.recorder_job_id,
+                operation="upload_chunk",
+                operation_id=f"0:{digest}",
+                now=now,
+            )
+
+        self._set_token({**claims, "body_sha256": hashlib.sha256(body).hexdigest()}, body=body)
+        frappe.local.request.args.to_dict.return_value = query
+        frappe.local.request.content_type = "application/octet-stream"
+        frappe.local.request.content_length = len(body)
+        self.assertEqual(
+            authenticate_callback(
+                protocol_version=1,
+                recording=self.recording.name,
+                job=self.recording.recorder_job_id,
+                operation="upload_chunk",
+                operation_id=f"0:{digest}",
+                now=now,
+            )["jti"],
+            claims["jti"],
+        )
+
     def test_mutating_callbacks_are_post_only(self):
         for callback in (
             recorder_interrupted,
@@ -167,12 +246,14 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
                 with self.subTest(content_type=content_type):
                     frappe.local.request = Mock(content_type=content_type, content_length=5)
                     with self.assertRaises(frappe.ValidationError):
-                        recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest)
+                        recorder_upload_chunk(
+                            self.recording.name, self.recording.recorder_job_id, 0, digest, 1
+                        )
 
             request = Mock(content_type="application/octet-stream", content_length=CHUNK_SIZE + 1)
             frappe.local.request = request
             with self.assertRaises(frappe.ValidationError):
-                recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest)
+                recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest, 1)
             request.get_data.assert_not_called()
 
             request = Mock(content_type="application/octet-stream", content_length=5)
@@ -180,8 +261,8 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
             frappe.local.request = request
             with patch("suite.meet.api.recording.append_chunk", return_value={"offset": 5}) as append:
                 self.assertEqual(
-                    recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest),
-                    {"offset": 5},
+                    recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest, 1),
+                    {"protocol_version": 1, "offset": 5},
                 )
             append.assert_called_once_with(
                 self.recording.name,
@@ -203,7 +284,19 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
                     1000,
                     "",
                     "host_stop",
+                    1,
                 )
+
+    def test_wrong_callback_protocol_is_rejected_before_authentication(self):
+        with patch("suite.meet.api.recording.authenticate_callback") as authenticate:
+            with self.assertRaisesRegex(frappe.ValidationError, "protocol version"):
+                recorder_segment_progress(
+                    self.recording.name,
+                    self.recording.recorder_job_id,
+                    0,
+                    2,
+                )
+        authenticate.assert_not_called()
 
     def test_upload_chunk_boundary_failures_do_not_mutate_state(self):
         stop(self.room.name)
@@ -241,6 +334,7 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
 
     def _claims(self, now: int) -> dict:
         return {
+            "protocol_version": 1,
             "iss": f"meet-recorder:{frappe.local.site}",
             "aud": CALLBACK_AUDIENCE,
             "site": frappe.local.site,
@@ -248,13 +342,14 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
             "job": self.recording.recorder_job_id,
             "operation": "stopped",
             "operation_id": "2",
-            "body_sha256": hashlib.sha256(b"{}").hexdigest(),
+            "body_sha256": hashlib.sha256(self._body()).hexdigest(),
             "jti": str(uuid.uuid4()),
             "iat": now,
             "exp": now + 30,
         }
 
-    def _set_token(self, claims: dict, headers: dict | None = None, body: bytes = b"{}"):
+    def _set_token(self, claims: dict, headers: dict | None = None, body: bytes | None = None):
+        body = self._body() if body is None else body
         token = jwt.encode(
             claims,
             frappe.conf.recorder_secret,
@@ -268,9 +363,28 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
 
     def _authenticate(self, now: int):
         return authenticate_callback(
+            protocol_version=1,
             recording=self.recording.name,
             job=self.recording.recorder_job_id,
             operation="stopped",
             operation_id="2",
             now=now,
         )
+
+    def _body(self) -> bytes:
+        return json.dumps(
+            {
+                "protocol_version": 1,
+                "recording_id": self.recording.name,
+                "job": self.recording.recorder_job_id,
+                "event_sequence": 2,
+                "captured_bytes": 0,
+                "size": 1,
+                "sha256": "a" * 64,
+                "duration_ms": 1000,
+                "ended_at": "2026-01-01T00:00:00.000Z",
+                "end_reason_code": "host_stop",
+                "gaps": [],
+            },
+            separators=(",", ":"),
+        ).encode()

--- a/suite/meet/api/test/test_recording.py
+++ b/suite/meet/api/test/test_recording.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import hashlib
+import json
 import time
 import uuid
 from datetime import UTC, datetime, timedelta
@@ -351,7 +352,24 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         started = start(self.room.name, str(uuid.uuid4()))
         recording = frappe.get_doc("Meet Recording", started["name"])
         now = int(time.time())
+        body = json.dumps(
+            {
+                "protocol_version": 1,
+                "recording_id": recording.name,
+                "job": recording.recorder_job_id,
+                "event_sequence": 2,
+                "captured_bytes": 0,
+                "size": 1,
+                "sha256": "a" * 64,
+                "duration_ms": 1000,
+                "ended_at": "2026-01-01T00:00:00.000Z",
+                "end_reason_code": "host_stop",
+                "gaps": [],
+            },
+            separators=(",", ":"),
+        ).encode()
         claims = {
+            "protocol_version": 1,
             "iss": f"meet-recorder:{frappe.local.site}",
             "aud": CALLBACK_AUDIENCE,
             "site": frappe.local.site,
@@ -359,7 +377,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             "job": recording.recorder_job_id,
             "operation": "stopped",
             "operation_id": "2",
-            "body_sha256": hashlib.sha256(b"{}").hexdigest(),
+            "body_sha256": hashlib.sha256(body).hexdigest(),
             "jti": str(uuid.uuid4()),
             "iat": now,
             "exp": now + 30,
@@ -373,11 +391,12 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         original_request = getattr(frappe.local, "request", None)
         frappe.local.request = Mock(
             headers={"X-Meet-Recorder-Authorization": f"Bearer {token}"},
-            get_data=Mock(return_value=b"{}"),
+            get_data=Mock(return_value=body),
         )
         try:
             self.assertEqual(
                 authenticate_callback(
+                    protocol_version=1,
                     recording=recording.name,
                     job=recording.recorder_job_id,
                     operation="stopped",
@@ -388,6 +407,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             )
             with self.assertRaises(frappe.AuthenticationError):
                 authenticate_callback(
+                    protocol_version=1,
                     recording=recording.name,
                     job=recording.recorder_job_id,
                     operation="complete_upload",
@@ -580,6 +600,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             1,
             REPLACEMENT_JWK,
             (interrupted + timedelta(seconds=1)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            1,
         )
 
         with (
@@ -590,7 +611,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             retried = recorder_replacement_ready(*arguments)
 
         recording.reload()
-        self.assertEqual(first, {"status": "Interrupted", "grant_delivered": True})
+        self.assertEqual(first, {"protocol_version": 1, "status": "Interrupted", "grant_delivered": True})
         self.assertEqual(retried, first)
         self.assertEqual(recording.endpoint_generation, 1)
         self.assertEqual(recording.replacement_event_sequence, 7)
@@ -600,7 +621,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         client.deliver_grant.assert_called_once()
         self.assertEqual(client.deliver_grant.call_args.kwargs["endpoint_generation"], 1)
 
-        conflicting = (*arguments[:5], PUBLIC_JWK, arguments[6])
+        conflicting = (*arguments[:5], PUBLIC_JWK, arguments[6], 1)
         with (
             patch("suite.meet.api.recording.authenticate_callback"),
             patch("suite.meet.api.recording._client", return_value=client),
@@ -612,7 +633,9 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             patch("suite.meet.api.recording._client", return_value=client),
             self.assertRaises(frappe.ValidationError),
         ):
-            recorder_replacement_ready(*arguments[:2], 8, interruption_id, 1, REPLACEMENT_JWK, arguments[6])
+            recorder_replacement_ready(
+                *arguments[:2], 8, interruption_id, 1, REPLACEMENT_JWK, arguments[6], 1
+            )
 
         resumed = interrupted + timedelta(seconds=2)
         recovered = interrupted + timedelta(seconds=3)
@@ -627,9 +650,13 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 interruption_id,
                 resumed.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
                 recovered.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+                1,
             )
             after_recovery = recorder_replacement_ready(*arguments)
-        self.assertEqual(after_recovery, {"status": "Recording", "grant_delivered": True})
+        self.assertEqual(
+            after_recovery,
+            {"protocol_version": 1, "status": "Recording", "grant_delivered": True},
+        )
         client.deliver_grant.assert_called_once()
 
     def test_reconciliation_adopts_lost_replacement_callback_and_retries_grant(self):
@@ -702,6 +729,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             1,
             REPLACEMENT_JWK,
             (interrupted + timedelta(seconds=1)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            1,
         )
 
         with (
@@ -752,6 +780,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 (interrupted + timedelta(seconds=1))
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
 
         frappe.db.set_value(
@@ -776,6 +805,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 (interrupted + timedelta(seconds=1))
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
 
     def _interrupted_recording(self):
@@ -788,7 +818,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 recording.name,
                 recording.recorder_job_id,
                 6,
-                "connection_lost",
+                "sfu_disconnected",
                 interruption_id,
                 interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
                 (interrupted + timedelta(seconds=60))
@@ -797,6 +827,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 recording.started_at.replace(tzinfo=UTC)
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
         recording.reload()
         return recording, interrupted, interruption_id
@@ -821,10 +852,11 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 recording.started_at.replace(tzinfo=UTC)
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
 
         recording.reload()
-        self.assertEqual(result, {"status": "Interrupted"})
+        self.assertEqual(result, {"protocol_version": 1, "status": "Interrupted"})
         self.assertEqual(recording.status, "Interrupted")
         self.assertEqual(recording.recorder_event_sequence, 6)
 
@@ -838,10 +870,11 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 interruption_id,
                 resumed.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
                 recovered.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+                1,
             )
 
         recording.reload()
-        self.assertEqual(result, {"status": "Recording"})
+        self.assertEqual(result, {"protocol_version": 1, "status": "Recording"})
         self.assertEqual(recording.recorder_event_sequence, 7)
         self.assertEqual(
             frappe.parse_json(recording.capture_gaps),
@@ -869,7 +902,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             public_jwk=REPLACEMENT_JWK,
             endpoint_generation=2,
             state="capture_ready",
-            health_reason=None,
+            reason_code=None,
             event_sequence=9,
             interruption={
                 "id": interruption_id,
@@ -921,6 +954,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 recording.started_at.replace(tzinfo=UTC)
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
         frappe.db.set_value(
             "Meet Recording",
@@ -960,6 +994,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 recording.started_at.replace(tzinfo=UTC)
                 .isoformat(timespec="milliseconds")
                 .replace("+00:00", "Z"),
+                1,
             )
         client = Mock()
         client.query.return_value = RecorderOutcome(
@@ -1012,10 +1047,11 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                     sequence,
                     milestone,
                     timestamp,
+                    1,
                 )
 
         recording = frappe.get_doc("Meet Recording", result["name"])
-        self.assertEqual(state, {"status": "Recording"})
+        self.assertEqual(state, {"protocol_version": 1, "status": "Recording"})
         self.assertEqual(recording.status, "Recording")
         self.assertEqual(
             recording.started_at,
@@ -1033,13 +1069,14 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             recording.name,
             recording.recorder_job_id,
             6,
-            "connection_lost",
+            "sfu_disconnected",
             interruption_id,
             interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             (interrupted + timedelta(seconds=60)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             recording.started_at.replace(tzinfo=UTC)
             .isoformat(timespec="milliseconds")
             .replace("+00:00", "Z"),
+            1,
         )
 
         with patch("suite.meet.api.recording.authenticate_callback"):
@@ -1060,7 +1097,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         )
 
         with patch("suite.meet.api.recording.authenticate_callback"):
-            recorder_failed(recording.name, recording.recorder_job_id, 6, "capture_failed")
+            recorder_failed(recording.name, recording.recorder_job_id, 6, 1, "capture_failed")
 
         self.assertEqual(get_storage_usage(self.owner)["reserved_size"], usage_before.get("reserved_size", 0))
 
@@ -1119,13 +1156,13 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         path = _upload_path(recording.upload_id)
         append_chunk(recording.name, offset=0, chunk=content, chunk_sha256=digest)
         with patch("suite.meet.api.recording.authenticate_callback"):
-            recorder_failed(recording.name, recording.recorder_job_id, 7, "processing_failed")
+            recorder_failed(recording.name, recording.recorder_job_id, 7, 1, "processing_failed")
         frappe.db.set_value("Meet Recording", recording.name, "modified", "2000-01-01", update_modified=False)
 
         recent = start(self.room.name, str(uuid.uuid4()))
         recent_recording = frappe.get_doc("Meet Recording", recent["name"])
         with patch("suite.meet.api.recording.authenticate_callback"):
-            recorder_failed(recent_recording.name, recent_recording.recorder_job_id, 6, "capture_failed")
+            recorder_failed(recent_recording.name, recent_recording.recorder_job_id, 6, 1, "capture_failed")
 
         cleanup_failed_recordings()
 
@@ -1137,7 +1174,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
     def test_explicit_rejection_and_startup_timeout_are_retained(self):
         frappe.conf.recording_fixture_mode = False
         client = Mock()
-        client.reserve.return_value = RecorderOutcome("rejected", reason="capacity")
+        client.reserve.return_value = RecorderOutcome("rejected", reason_code="capacity")
         with (
             patch("suite.meet.api.recording._client", return_value=client),
             patch("suite.meet.api.recording.frappe.publish_realtime") as publish,
@@ -1225,7 +1262,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         frappe.conf.recording_fixture_mode = False
         outcomes = [
             RecorderOutcome("accepted", _system_datetime_as_utc(now_datetime()), PUBLIC_JWK),
-            RecorderOutcome("rejected", reason="capacity"),
+            RecorderOutcome("rejected", reason_code="capacity"),
             RecorderOutcome("indeterminate"),
         ]
         client = Mock()

--- a/suite/meet/api/test/test_recording_reliability.py
+++ b/suite/meet/api/test/test_recording_reliability.py
@@ -308,7 +308,7 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
             recording.name,
             recording.recorder_job_id,
             6,
-            "connection_lost",
+            "sfu_disconnected",
             first_id,
             first_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             (first_interrupted + timedelta(seconds=60))
@@ -317,6 +317,7 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
             recording.started_at.replace(tzinfo=UTC)
             .isoformat(timespec="milliseconds")
             .replace("+00:00", "Z"),
+            1,
         )
         first_recovery = (
             recording.name,
@@ -325,6 +326,7 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
             first_id,
             first_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             first_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            1,
         )
         second_id = str(uuid.uuid4())
         second_interrupted = first_interrupted
@@ -332,13 +334,14 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
             recording.name,
             recording.recorder_job_id,
             8,
-            "connection_lost",
+            "sfu_disconnected",
             second_id,
             second_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             (second_interrupted + timedelta(seconds=60))
             .isoformat(timespec="milliseconds")
             .replace("+00:00", "Z"),
             first_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            1,
         )
         second_recovery = (
             recording.name,
@@ -347,6 +350,7 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
             second_id,
             second_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
             second_interrupted.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            1,
         )
         with (
             patch("suite.meet.api.recording.authenticate_callback"),
@@ -354,36 +358,36 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
         ):
             self.assertEqual(
                 recorder_interrupted(*first_interruption),
-                {"status": "Interrupted"},
+                {"protocol_version": 1, "status": "Interrupted"},
             )
             interruption_publish_count = publish.call_count
             self.assertEqual(
                 recorder_interrupted(*first_interruption),
-                {"status": "Interrupted"},
+                {"protocol_version": 1, "status": "Interrupted"},
             )
             self.assertEqual(publish.call_count, interruption_publish_count)
             self.assertEqual(
                 recorder_recovered(*first_recovery),
-                {"status": "Recording"},
+                {"protocol_version": 1, "status": "Recording"},
             )
             recovery_publish_count = publish.call_count
             self.assertEqual(
                 recorder_recovered(*first_recovery),
-                {"status": "Recording"},
+                {"protocol_version": 1, "status": "Recording"},
             )
             self.assertEqual(publish.call_count, recovery_publish_count)
             self.assertEqual(
                 recorder_interrupted(*second_interruption),
-                {"status": "Interrupted"},
+                {"protocol_version": 1, "status": "Interrupted"},
             )
             self.assertEqual(
                 recorder_recovered(*second_recovery),
-                {"status": "Recording"},
+                {"protocol_version": 1, "status": "Recording"},
             )
             second_recovery_publish_count = publish.call_count
             self.assertEqual(
-                recorder_failed(recording.name, recording.recorder_job_id, 10, "capture_failed"),
-                {"status": "Failed"},
+                recorder_failed(recording.name, recording.recorder_job_id, 10, 1, "capture_failed"),
+                {"protocol_version": 1, "status": "Failed"},
             )
             self.assertGreater(publish.call_count, second_recovery_publish_count)
 
@@ -406,8 +410,10 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
 
         invalid_ends = (
             "2026-08-10 12:00:00",
-            (_system_datetime_as_utc(recording.max_ends_at) + timedelta(seconds=1)).isoformat(),
-            (started_at - timedelta(seconds=1)).isoformat(),
+            (_system_datetime_as_utc(recording.max_ends_at) + timedelta(seconds=1))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            (started_at - timedelta(seconds=1)).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
         )
         for ended_at in invalid_ends:
             with self.subTest(ended_at=ended_at), self.assertRaises(frappe.ValidationError):
@@ -422,10 +428,16 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
                 )
             recording.reload()
 
-        valid_end = (started_at + timedelta(seconds=60)).isoformat()
+        valid_end = (
+            (started_at + timedelta(seconds=60)).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+        )
         gap = {
-            "started_at": (started_at - timedelta(seconds=1)).isoformat(),
-            "ended_at": (started_at + timedelta(seconds=1)).isoformat(),
+            "started_at": (started_at - timedelta(seconds=1))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
+            "ended_at": (started_at + timedelta(seconds=1))
+            .isoformat(timespec="milliseconds")
+            .replace("+00:00", "Z"),
             "reason": "capture_interrupted",
         }
         with self.assertRaisesRegex(frappe.ValidationError, "within the recording interval"):

--- a/suite/meet/docs/adr/0009-version-recording-contracts.md
+++ b/suite/meet/docs/adr/0009-version-recording-contracts.md
@@ -1,0 +1,14 @@
+# Version recording contracts with shared semantic vectors
+
+Recording-specific messages crossing process Seams use immutable, language-neutral JSON contract files containing finite vocabularies, exact message shapes, and accepted and rejected vectors. Python and TypeScript Adapters retain independent fail-closed validators and run the same vectors against their production parsers; generated validators and new runtime schema dependencies were rejected because shared behavior can be enforced without coupling security validation to one implementation toolchain.
+
+## Consequences
+
+- The contract covers Frappe-recorder commands and callbacks, recorder-browser lifecycle messages, and Recording Grant proof messages. General participant, media, chat, and signaling messages remain outside its scope.
+- Every message carries an integer `protocol_version`. An Adapter emits its current version and accepts only the current and immediately previous versions during rolling deployment.
+- A shipped version is immutable. Any changed field, meaning, state, reason, ordering rule, or error mode creates a new version.
+- Authenticated commands, callbacks, Recording Grants, and lifecycle messages reject unknown fields before side effects.
+- Frappe domain states and recorder implementation milestones use separate finite vocabularies with explicit tested mappings.
+- Behavioral reasons use a finite `reason_code`; an optional bounded `diagnostic` may aid operations but never drives domain behavior.
+- Lifecycle event timestamps use canonical UTC RFC 3339 with exactly millisecond precision and `Z`. JWT `iat` and `exp` remain integer epoch seconds.
+- Every production Adapter parses the same vectors. Accepted vectors normalize to the same semantic JSON; rejected vectors fail with a contract-version or validation category before side effects; coverage verifies every finite state and reason appears in a vector.

--- a/suite/meet/recorder-server/src/AuthManager.ts
+++ b/suite/meet/recorder-server/src/AuthManager.ts
@@ -5,6 +5,7 @@ import {
 	COMMAND_AUDIENCE,
 	COMMAND_TYPE,
 	type CommandClaims,
+	PROTOCOL_VERSION,
 	type RecordingLimits,
 } from './types.js';
 
@@ -18,6 +19,7 @@ const CLAIM_KEYS = [
 	'limits',
 	'operation',
 	'origin',
+	'protocol_version',
 	'recording',
 	'room',
 	'site',
@@ -38,18 +40,12 @@ function nonempty(value: unknown): value is string {
 export function validUtcTimestamp(value: unknown): value is string {
 	if (
 		typeof value !== 'string' ||
-		!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d(?:\.\d{1,3})?Z$/.test(value)
+		!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value)
 	)
 		return false;
 	const parsed = Date.parse(value);
 	if (Number.isNaN(parsed)) return false;
-	const normalized = value.includes('.')
-		? value.replace(
-				/\.(\d{1,2})Z$/,
-				(_match, digits: string) => `.${digits.padEnd(3, '0')}Z`,
-			)
-		: value.replace('Z', '.000Z');
-	return new Date(parsed).toISOString() === normalized;
+	return new Date(parsed).toISOString() === value;
 }
 
 export function validLimits(value: unknown): value is RecordingLimits {
@@ -160,7 +156,8 @@ export class AuthManager {
 			claims.operation !== expectedOperation ||
 			claims.site !== this.site ||
 			claims.origin !== this.origin ||
-			claims.iss !== `frappe-site:${claims.site}`
+			claims.iss !== `frappe-site:${claims.site}` ||
+			claims.protocol_version !== PROTOCOL_VERSION
 		)
 			throw new AuthError('wrong command scope');
 		if (
@@ -191,7 +188,7 @@ export class AuthManager {
 	}
 }
 
-function parseCommandClaims(value: unknown): CommandClaims {
+export function parseCommandClaims(value: unknown): CommandClaims {
 	if (
 		!value ||
 		typeof value !== 'object' ||
@@ -201,6 +198,8 @@ function parseCommandClaims(value: unknown): CommandClaims {
 		throw new AuthError('invalid claims');
 	}
 	if (
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
 		!('aud' in value) ||
 		value.aud !== COMMAND_AUDIENCE ||
 		!('operation' in value) ||
@@ -221,6 +220,7 @@ function parseCommandClaims(value: unknown): CommandClaims {
 	const limits = parseLimits(value.limits);
 	if (!limits) throw new AuthError('invalid limits');
 	return {
+		protocol_version: PROTOCOL_VERSION,
 		iss: claimString(value, 'iss'),
 		aud: COMMAND_AUDIENCE,
 		site: claimString(value, 'site'),

--- a/suite/meet/recorder-server/src/CallbackClient.test.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.test.ts
@@ -22,9 +22,14 @@ describe('CallbackClient', () => {
 	it('reports segment progress with the captured byte operation ID', async () => {
 		const fetch = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ message: { budget_bytes: 2_000_000 } }), {
-					status: 200,
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, budget_bytes: 2_000_000 },
+					}),
+					{
+						status: 200,
+					},
+				),
 		);
 		vi.stubGlobal('fetch', fetch);
 		const secret = 's'.repeat(32);
@@ -50,6 +55,7 @@ describe('CallbackClient', () => {
 		);
 		const body = String(fetch.mock.calls[0]?.[1]?.body);
 		expect(JSON.parse(body)).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			captured_bytes: 1_234_567,
@@ -60,6 +66,7 @@ describe('CallbackClient', () => {
 		expect(
 			jwt.verify(String(authorization).replace('Bearer ', ''), secret),
 		).toMatchObject({
+			protocol_version: 1,
 			operation: 'segment_progress',
 			operation_id: '1234567',
 			body_sha256: createHash('sha256').update(body).digest('hex'),
@@ -67,10 +74,12 @@ describe('CallbackClient', () => {
 	});
 
 	it.each([
-		{ budget_bytes: -1 },
-		{ budget_bytes: 1.5 },
-		{ budget_bytes: '2000000' },
-		{ budget_bytes: 2_000_000, extra: true },
+		{ protocol_version: 1, budget_bytes: -1 },
+		{ protocol_version: 1, budget_bytes: 1.5 },
+		{ protocol_version: 1, budget_bytes: '2000000' },
+		{ protocol_version: 1, budget_bytes: 2_000_000, extra: true },
+		{ protocol_version: 2, budget_bytes: 2_000_000 },
+		{ budget_bytes: 2_000_000 },
 	])('rejects an invalid segment progress response %#', async (message) => {
 		vi.stubGlobal(
 			'fetch',
@@ -97,13 +106,44 @@ describe('CallbackClient', () => {
 		).rejects.toThrow('invalid Frappe callback response');
 	});
 
+	it('requires the exact Frappe response wrapper', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							message: { protocol_version: 1, budget_bytes: 2_000_000 },
+							extra: true,
+						}),
+					),
+			),
+		);
+		await expect(
+			new CallbackClient({
+				origin: 'https://site.test',
+				site: 'site.test',
+				secret: 's'.repeat(32),
+				dataRoot: '/tmp',
+			}).segmentProgress(
+				{ job: 'job', recording: 'recording' } as JobRecord,
+				1,
+			),
+		).rejects.toThrow('invalid Frappe callback response');
+	});
+
 	it('publishes an ordered startup milestone with its durable timestamp', async () => {
 		const fetch = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ message: { status: 'Starting' } }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Starting' },
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
 		);
 		vi.stubGlobal('fetch', fetch);
 		const job = {
@@ -130,6 +170,7 @@ describe('CallbackClient', () => {
 		);
 		expect(fetch).toHaveBeenCalledTimes(2);
 		expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			event_sequence: 2,
@@ -137,6 +178,7 @@ describe('CallbackClient', () => {
 			occurred_at: '2026-08-30T11:59:59.000Z',
 		});
 		expect(JSON.parse(String(fetch.mock.calls[1]?.[1]?.body))).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			event_sequence: 3,
@@ -151,10 +193,15 @@ describe('CallbackClient', () => {
 			.mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
 			.mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
 			.mockResolvedValue(
-				new Response(JSON.stringify({ message: { status: 'Recording' } }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Recording' },
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
 			);
 		vi.stubGlobal('fetch', fetch);
 		const job = {
@@ -182,10 +229,15 @@ describe('CallbackClient', () => {
 	it('publishes recorder interruption with the next lifecycle sequence', async () => {
 		const fetch = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ message: { status: 'Interrupted' } }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Interrupted' },
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
 		);
 		vi.stubGlobal('fetch', fetch);
 		const job = {
@@ -211,10 +263,11 @@ describe('CallbackClient', () => {
 
 		expect(String(fetch.mock.calls[0]?.[0])).toContain('recorder_interrupted');
 		expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			event_sequence: 2,
-			reason: 'connection_lost',
+			reason_code: 'capture_interrupted',
 			interruption_id: '11111111-1111-4111-8111-111111111111',
 			interrupted_at: '2026-08-30T12:00:00.000Z',
 			interruption_deadline: '2026-08-30T12:01:00.000Z',
@@ -225,10 +278,15 @@ describe('CallbackClient', () => {
 	it('publishes recovery for the active interruption sequence', async () => {
 		const fetch = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ message: { status: 'Recording' } }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Recording' },
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
 		);
 		vi.stubGlobal('fetch', fetch);
 		const job = {
@@ -252,6 +310,7 @@ describe('CallbackClient', () => {
 
 		expect(String(fetch.mock.calls[0]?.[0])).toContain('recorder_recovered');
 		expect(JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			event_sequence: 2,
@@ -266,9 +325,14 @@ describe('CallbackClient', () => {
 			.fn()
 			.mockResolvedValueOnce(new Response('unavailable', { status: 503 }))
 			.mockResolvedValue(
-				new Response(JSON.stringify({ message: { status: 'Interrupted' } }), {
-					status: 200,
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Interrupted' },
+					}),
+					{
+						status: 200,
+					},
+				),
 			);
 		vi.stubGlobal('fetch', fetch);
 		const publicJwk = {
@@ -305,6 +369,7 @@ describe('CallbackClient', () => {
 		);
 		const body = String(fetch.mock.calls[1]?.[1]?.body);
 		expect(JSON.parse(body)).toEqual({
+			protocol_version: 1,
 			recording_id: 'recording',
 			job: 'job',
 			event_sequence: 7,
@@ -321,6 +386,7 @@ describe('CallbackClient', () => {
 			's'.repeat(32),
 		) as jwt.JwtPayload;
 		expect(claims).toMatchObject({
+			protocol_version: 1,
 			operation: 'replacement_ready',
 			operation_id: '7',
 			body_sha256: createHash('sha256').update(body).digest('hex'),
@@ -364,10 +430,15 @@ describe('CallbackClient', () => {
 	it('publishes later interruption cycles with their persisted sequence', async () => {
 		const fetch = vi.fn(
 			async () =>
-				new Response(JSON.stringify({ message: { status: 'Interrupted' } }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+				new Response(
+					JSON.stringify({
+						message: { protocol_version: 1, status: 'Interrupted' },
+					}),
+					{
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					},
+				),
 		);
 		vi.stubGlobal('fetch', fetch);
 		const job = {
@@ -459,10 +530,13 @@ describe('CallbackClient', () => {
 							: requests.length === 4
 								? { status: 'Processing' }
 								: { offset: content.length, complete: true };
-			return new Response(JSON.stringify({ message }), {
-				status: 200,
-				headers: { 'Content-Type': 'application/json' },
-			});
+			return new Response(
+				JSON.stringify({ message: { protocol_version: 1, ...message } }),
+				{
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				},
+			);
 		});
 		vi.stubGlobal('fetch', fetch);
 		const secret = 's'.repeat(32);
@@ -485,7 +559,7 @@ describe('CallbackClient', () => {
 				{
 					started_at: '2026-01-01T00:00:59.000Z',
 					ended_at: '2026-01-01T00:01:00.000Z',
-					reason: 'ffmpeg_exited',
+					reason_code: 'ffmpeg_exited',
 				},
 			],
 		});
@@ -498,6 +572,7 @@ describe('CallbackClient', () => {
 		);
 		const token = authorization?.slice('Bearer '.length) ?? '';
 		expect(jwt.verify(token, secret, { algorithms: ['HS256'] })).toMatchObject({
+			protocol_version: 1,
 			aud: 'meet-recording-callback',
 			site: 'site.test',
 			recording: 'recording',
@@ -505,6 +580,7 @@ describe('CallbackClient', () => {
 			operation: 'upload_chunk',
 			body_sha256: createHash('sha256').update(content).digest('hex'),
 		});
+		expect(requests[2]?.url).toContain('protocol_version=1');
 		expect(jwt.decode(token, { complete: true })?.header.typ).toBe(
 			'meet-recording-callback+jwt',
 		);

--- a/suite/meet/recorder-server/src/CallbackClient.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.ts
@@ -7,7 +7,20 @@ import type { JobRecord } from './types.js';
 
 const AUDIENCE = 'meet-recording-callback';
 const TYPE = 'meet-recording-callback+jwt';
+const PROTOCOL_VERSION = 1;
 const CHUNK_SIZE = 8 * 1024 * 1024;
+const FRAPPE_RECORDING_STATES = new Set([
+	'Pending',
+	'Starting',
+	'Recording',
+	'Interrupted',
+	'Stopping',
+	'Processing',
+	'Ready',
+	'Partial',
+	'Failed',
+	'Cancelled',
+]);
 
 interface CallbackClientOptions {
 	origin: string;
@@ -19,10 +32,11 @@ interface CallbackClientOptions {
 }
 
 interface InterruptedRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
-	reason: string;
+	reason_code: string;
 	interruption_id: string;
 	interrupted_at: string;
 	interruption_deadline: string;
@@ -30,6 +44,7 @@ interface InterruptedRequest {
 }
 
 interface RecoveredRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
@@ -39,6 +54,7 @@ interface RecoveredRequest {
 }
 
 interface ReplacementReadyRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
@@ -49,6 +65,7 @@ interface ReplacementReadyRequest {
 }
 
 interface StartupProgressRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
@@ -57,13 +74,15 @@ interface StartupProgressRequest {
 }
 
 interface FailedRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
-	failure_code: 'capture_failed';
+	reason_code: 'capture_failed';
 }
 
 interface StoppedRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
@@ -72,17 +91,19 @@ interface StoppedRequest {
 	sha256: string;
 	duration_ms: number;
 	ended_at: string;
-	end_reason: string;
-	gaps: Array<{ started_at: string; ended_at: string; reason: string }>;
+	end_reason_code: string;
+	gaps: Array<{ started_at: string; ended_at: string; reason_code: string }>;
 }
 
 interface CompleteUploadRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	event_sequence: number;
 }
 
 interface SegmentProgressRequest {
+	protocol_version: typeof PROTOCOL_VERSION;
 	recording_id: string;
 	job: string;
 	captured_bytes: number;
@@ -120,19 +141,23 @@ type CallbackOperation =
 	| 'complete_upload';
 
 interface StatusResponse {
+	protocol_version: typeof PROTOCOL_VERSION;
 	status: string;
 }
 
 interface UploadStartResponse {
+	protocol_version: typeof PROTOCOL_VERSION;
 	offset: number;
 	complete: boolean;
 }
 
 interface UploadChunkResponse {
+	protocol_version: typeof PROTOCOL_VERSION;
 	offset: number;
 }
 
 interface SegmentProgressResponse {
+	protocol_version: typeof PROTOCOL_VERSION;
 	budget_bytes: number;
 }
 
@@ -169,6 +194,7 @@ export class CallbackClient {
 						'startup_progress',
 						String(sequence),
 						{
+							protocol_version: PROTOCOL_VERSION,
 							recording_id: job.recording,
 							job: job.job,
 							event_sequence: sequence,
@@ -198,10 +224,11 @@ export class CallbackClient {
 				'interrupted',
 				String(sequence),
 				{
+					protocol_version: PROTOCOL_VERSION,
 					recording_id: job.recording,
 					job: job.job,
 					event_sequence: sequence,
-					reason: job.health_reason ?? 'capture_interrupted',
+					reason_code: this.healthReason(job.health_reason),
 					interruption_id: job.interruption_id,
 					interrupted_at: job.interrupted_at,
 					interruption_deadline: job.interruption_deadline,
@@ -227,6 +254,7 @@ export class CallbackClient {
 				'recovered',
 				String(sequence),
 				{
+					protocol_version: PROTOCOL_VERSION,
 					recording_id: job.recording,
 					job: job.job,
 					event_sequence: sequence,
@@ -250,6 +278,7 @@ export class CallbackClient {
 				'replacement_ready',
 				String(sequence),
 				{
+					protocol_version: PROTOCOL_VERSION,
 					recording_id: job.recording,
 					job: job.job,
 					event_sequence: sequence,
@@ -275,6 +304,7 @@ export class CallbackClient {
 			'segment_progress',
 			String(capturedBytes),
 			{
+				protocol_version: PROTOCOL_VERSION,
 				recording_id: job.recording,
 				job: job.job,
 				captured_bytes: capturedBytes,
@@ -311,10 +341,11 @@ export class CallbackClient {
 				'failed',
 				String(terminalSequence),
 				{
+					protocol_version: PROTOCOL_VERSION,
 					recording_id: job.recording,
 					job: job.job,
 					event_sequence: terminalSequence,
-					failure_code: 'capture_failed',
+					reason_code: 'capture_failed',
 				},
 				parseStatusResponse,
 			);
@@ -335,6 +366,7 @@ export class CallbackClient {
 			'stopped',
 			String(stoppedSequence),
 			{
+				protocol_version: PROTOCOL_VERSION,
 				recording_id: job.recording,
 				job: job.job,
 				event_sequence: stoppedSequence,
@@ -343,11 +375,11 @@ export class CallbackClient {
 				sha256: artifact.sha256,
 				duration_ms: artifact.duration_ms,
 				ended_at: job.terminal_at ?? new Date().toISOString(),
-				end_reason: this.endReason(job),
+				end_reason_code: this.endReason(job),
 				gaps: (artifact.gaps ?? []).map((gap) => ({
 					started_at: gap.started_at,
 					ended_at: gap.ended_at ?? job.terminal_at ?? new Date().toISOString(),
-					reason: this.gapReason(gap.reason),
+					reason_code: this.gapReason(gap.reason),
 				})),
 			},
 			parseUploadStartResponse,
@@ -385,6 +417,7 @@ export class CallbackClient {
 			'complete_upload',
 			String(stoppedSequence + 1),
 			{
+				protocol_version: PROTOCOL_VERSION,
 				recording_id: job.recording,
 				job: job.job,
 				event_sequence: stoppedSequence + 1,
@@ -425,6 +458,7 @@ export class CallbackClient {
 		);
 		url.searchParams.set('recording_id', job.recording);
 		url.searchParams.set('job', job.job);
+		url.searchParams.set('protocol_version', String(PROTOCOL_VERSION));
 		url.searchParams.set('offset', String(offset));
 		url.searchParams.set('chunk_sha256', hash);
 		const body = new Uint8Array(chunk.length);
@@ -497,7 +531,7 @@ export class CallbackClient {
 		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
 			throw new Error('invalid Frappe callback response');
 		}
-		if (!('message' in parsed)) {
+		if (!exactKeys(parsed, ['message']) || !('message' in parsed)) {
 			throw new Error('invalid Frappe callback response');
 		}
 		return parseResponse(parsed.message);
@@ -519,6 +553,7 @@ export class CallbackClient {
 		if (!bytes) throw new Error('unsupported callback request body');
 		return jwt.sign(
 			{
+				protocol_version: PROTOCOL_VERSION,
 				iss: `meet-recorder:${this.options.site}`,
 				aud: AUDIENCE,
 				site: this.options.site,
@@ -549,6 +584,21 @@ export class CallbackClient {
 		return 'host_stop';
 	}
 
+	private healthReason(reason?: string): string {
+		const finite = new Set([
+			'browser_disconnected',
+			'capture_interrupted',
+			'configuration_failed',
+			'ffmpeg_exited',
+			'media_attachment_failed',
+			'media_subscription_failed',
+			'page_crashed',
+			'receive_transport_failed',
+			'sfu_disconnected',
+		]);
+		return reason && finite.has(reason) ? reason : 'capture_interrupted';
+	}
+
 	private gapReason(reason: string): string {
 		if (reason.includes('ffmpeg') || reason.includes('segment'))
 			return 'ffmpeg_exited';
@@ -557,24 +607,25 @@ export class CallbackClient {
 	}
 }
 
-function parseStatusResponse(value: unknown): StatusResponse {
+export function parseStatusResponse(value: unknown): StatusResponse {
 	if (
-		!value ||
-		typeof value !== 'object' ||
-		Array.isArray(value) ||
+		!exactKeys(value, ['protocol_version', 'status']) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
 		!('status' in value) ||
-		typeof value.status !== 'string'
+		typeof value.status !== 'string' ||
+		!FRAPPE_RECORDING_STATES.has(value.status)
 	) {
 		throw new Error('invalid Frappe callback response');
 	}
-	return { status: value.status };
+	return { protocol_version: PROTOCOL_VERSION, status: value.status };
 }
 
 function parseUploadStartResponse(value: unknown): UploadStartResponse {
 	if (
-		!value ||
-		typeof value !== 'object' ||
-		Array.isArray(value) ||
+		!exactKeys(value, ['complete', 'offset', 'protocol_version']) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
 		!('complete' in value) ||
 		typeof value.complete !== 'boolean' ||
 		!('offset' in value) ||
@@ -583,30 +634,32 @@ function parseUploadStartResponse(value: unknown): UploadStartResponse {
 	) {
 		throw new Error('invalid Frappe callback response');
 	}
-	return { complete: value.complete, offset: value.offset };
+	return {
+		protocol_version: PROTOCOL_VERSION,
+		complete: value.complete,
+		offset: value.offset,
+	};
 }
 
 function parseUploadChunkResponse(value: unknown): UploadChunkResponse {
 	if (
-		!value ||
-		typeof value !== 'object' ||
-		Array.isArray(value) ||
+		!exactKeys(value, ['offset', 'protocol_version']) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
 		!('offset' in value) ||
 		typeof value.offset !== 'number' ||
 		!Number.isSafeInteger(value.offset)
 	) {
 		throw new Error('invalid Frappe callback response');
 	}
-	return { offset: value.offset };
+	return { protocol_version: PROTOCOL_VERSION, offset: value.offset };
 }
 
 function parseSegmentProgressResponse(value: unknown): SegmentProgressResponse {
 	if (
-		!value ||
-		typeof value !== 'object' ||
-		Array.isArray(value) ||
-		JSON.stringify(Object.keys(value).sort()) !==
-			JSON.stringify(['budget_bytes']) ||
+		!exactKeys(value, ['budget_bytes', 'protocol_version']) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
 		!('budget_bytes' in value) ||
 		typeof value.budget_bytes !== 'number' ||
 		!Number.isSafeInteger(value.budget_bytes) ||
@@ -614,5 +667,17 @@ function parseSegmentProgressResponse(value: unknown): SegmentProgressResponse {
 	) {
 		throw new Error('invalid Frappe callback response');
 	}
-	return { budget_bytes: value.budget_bytes };
+	return {
+		protocol_version: PROTOCOL_VERSION,
+		budget_bytes: value.budget_bytes,
+	};
+}
+
+function exactKeys(value: unknown, keys: string[]): value is object {
+	return (
+		!!value &&
+		typeof value === 'object' &&
+		!Array.isArray(value) &&
+		JSON.stringify(Object.keys(value).sort()) === JSON.stringify(keys)
+	);
 }

--- a/suite/meet/recorder-server/src/ProtocolContract.test.ts
+++ b/suite/meet/recorder-server/src/ProtocolContract.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parseCommandClaims, validUtcTimestamp } from './AuthManager.js';
+import { grantBody, reserveBody, stopBody } from './app.js';
+import { parseStatusResponse } from './CallbackClient.js';
+import {
+	parseRendererLifecycle,
+	parseRendererPublicKeyReady,
+} from './RendererBridge.js';
+
+type JsonValue = null | boolean | number | string | JsonValue[] | JsonObject;
+type JsonObject = { [key: string]: JsonValue };
+
+const contract = JSON.parse(
+	readFileSync(
+		resolve(process.cwd(), '../recording/contracts/v1.json'),
+		'utf8',
+	),
+) as {
+	protocol_version: number;
+	accepted_protocol_versions: number[];
+	vocabularies: {
+		frappe_recording_states: string[];
+		renderer_reason_codes: string[];
+		[key: string]: string[];
+	};
+	vectors: {
+		timestamps: { accepted: JsonValue[]; rejected: JsonValue[] };
+		renderer_lifecycle: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		renderer_public_key_ready: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		callback_status_responses: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		command_claims: { accepted: JsonObject[]; rejected: JsonObject[] };
+		command_requests: {
+			accepted: { operation: string; body: JsonObject }[];
+			rejected: { operation: string; body: JsonObject }[];
+		};
+		finite_values: { [key: string]: string[] };
+	};
+};
+
+const commandBodyParser = (operation: string) => {
+	if (operation === 'reserve') return reserveBody;
+	if (operation === 'grant') return grantBody;
+	if (operation === 'stop') return stopBody;
+	throw new Error(`unsupported command operation: ${operation}`);
+};
+
+describe('recording protocol contract v1', () => {
+	it('accepts only canonical lifecycle timestamps', () => {
+		for (const value of contract.vectors.timestamps.accepted)
+			expect(validUtcTimestamp(value)).toBe(true);
+		for (const value of contract.vectors.timestamps.rejected)
+			expect(validUtcTimestamp(value)).toBe(false);
+	});
+
+	it('runs shared lifecycle vectors through the production parser', () => {
+		for (const value of contract.vectors.renderer_lifecycle.accepted)
+			expect(parseRendererLifecycle(value)).toBeDefined();
+		for (const value of contract.vectors.renderer_lifecycle.rejected)
+			expect(parseRendererLifecycle(value)).toBeUndefined();
+	});
+
+	it('runs shared renderer public-key vectors through the production parser', () => {
+		for (const value of contract.vectors.renderer_public_key_ready.accepted)
+			expect(parseRendererPublicKeyReady(value)).not.toBeNull();
+		for (const value of contract.vectors.renderer_public_key_ready.rejected)
+			expect(parseRendererPublicKeyReady(value)).toBeNull();
+	});
+
+	it('covers every finite renderer reason code', () => {
+		const covered = contract.vectors.renderer_lifecycle.accepted
+			.map((value) => value.reason_code)
+			.filter((value): value is string => typeof value === 'string');
+		expect(new Set(covered)).toEqual(
+			new Set(contract.vocabularies.renderer_reason_codes),
+		);
+		expect(contract.accepted_protocol_versions).toEqual([
+			contract.protocol_version,
+		]);
+	});
+
+	it('runs every finite Frappe state through the callback response parser', () => {
+		for (const value of contract.vectors.callback_status_responses.accepted)
+			expect(parseStatusResponse(value)).toEqual(value);
+		for (const value of contract.vectors.callback_status_responses.rejected)
+			expect(() => parseStatusResponse(value)).toThrow();
+		expect(
+			contract.vectors.callback_status_responses.accepted.map(
+				(value) => value.status,
+			),
+		).toEqual(contract.vocabularies.frappe_recording_states);
+	});
+
+	it('runs shared command claims and request vectors through production parsers', () => {
+		for (const value of contract.vectors.command_claims.accepted)
+			expect(parseCommandClaims(value)).toBeDefined();
+		for (const value of contract.vectors.command_claims.rejected)
+			expect(() => parseCommandClaims(value)).toThrow();
+		for (const value of contract.vectors.command_requests.accepted)
+			expect(commandBodyParser(value.operation)(value.body)).toBe(true);
+		for (const value of contract.vectors.command_requests.rejected)
+			expect(commandBodyParser(value.operation)(value.body)).toBe(false);
+		const base = contract.vectors.command_claims.accepted[0];
+		for (const operation of contract.vectors.finite_values.command_operations)
+			expect(parseCommandClaims({ ...base, operation }).operation).toBe(
+				operation,
+			);
+	});
+
+	it('enumerates every finite vocabulary in executable vectors', () => {
+		expect(contract.vectors.finite_values).toEqual(contract.vocabularies);
+	});
+});

--- a/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
+++ b/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
@@ -89,31 +89,35 @@ describe('recorder vertical chain', () => {
 				});
 				const issuedAt = Math.floor(Date.now() / 1000);
 				const challenge = {
-					version: 1 as const,
+					protocol_version: 1 as const,
 					jti: 'grant-jti',
 					socket_id: socket.id,
-					nonce: randomBytes(24).toString('base64url'),
+					nonce: randomBytes(32).toString('base64url'),
 					issued_at: issuedAt,
-					expires_at: issuedAt + 30,
+					expires_at: issuedAt + 10,
 				};
-				socket.on('recording:proof', ({ signature }, callback) => {
-					const canonical = Buffer.from(
-						`meet-recording-proof-v1\n${challenge.jti}\n${challenge.socket_id}\n${challenge.nonce}\n${challenge.issued_at}\n${challenge.expires_at}`,
-					);
-					proofAccepted = Boolean(
-						publicJwk &&
-							verify(
-								'sha256',
-								canonical,
-								{
-									key: createPublicKey({ key: publicJwk, format: 'jwk' }),
-									dsaEncoding: 'ieee-p1363',
-								},
-								Buffer.from(signature, 'base64url'),
-							),
-					);
-					callback({ success: proofAccepted });
-				});
+				socket.on(
+					'recording:proof',
+					({ protocol_version, signature }, callback) => {
+						expect(protocol_version).toBe(1);
+						const canonical = Buffer.from(
+							`meet-recording-proof-v1\n${challenge.jti}\n${challenge.socket_id}\n${challenge.nonce}\n${challenge.issued_at}\n${challenge.expires_at}`,
+						);
+						proofAccepted = Boolean(
+							publicJwk &&
+								verify(
+									'sha256',
+									canonical,
+									{
+										key: createPublicKey({ key: publicJwk, format: 'jwk' }),
+										dsaEncoding: 'ieee-p1363',
+									},
+									Buffer.from(signature, 'base64url'),
+								),
+						);
+						callback({ protocol_version: 1, success: proofAccepted });
+					},
+				);
 				socket.on('recording:join', (data, callback) => {
 					expect(proofAccepted).toBe(true);
 					expect(data).toEqual({ roomId: command.room });
@@ -182,7 +186,7 @@ describe('recorder vertical chain', () => {
 				await bridge.deliverGrant(
 					command.job,
 					'recording-grant',
-					'2026-07-31T12:00:00Z',
+					'2026-07-31T12:00:00.000Z',
 				);
 				await expect
 					.poll(() => lifecycle.at(-1)?.type, { timeout: 15_000 })

--- a/suite/meet/recorder-server/src/RendererBridge.test.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.test.ts
@@ -36,6 +36,48 @@ const command: CommandClaims = {
 };
 
 describe('ChromiumRendererBridge', () => {
+	it.each([
+		{
+			type: 'suite-recorder:public-key-ready',
+			publicKey: TEST_PUBLIC_JWK,
+		},
+		{
+			type: 'suite-recorder:public-key-ready',
+			protocol_version: 2,
+			occurred_at: '2026-08-30T12:00:00.000Z',
+			publicKey: TEST_PUBLIC_JWK,
+		},
+		{
+			type: 'suite-recorder:public-key-ready',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:00.000Z',
+			publicKey: TEST_PUBLIC_JWK,
+			extra: true,
+		},
+		{
+			type: 'suite-recorder:public-key-ready',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:00.000Z',
+			publicKey: { ...TEST_PUBLIC_JWK, ext: true },
+		},
+	])('rejects malformed public-key message %#', (message) => {
+		const bridge = new ChromiumRendererBridge({} as never);
+		const resolveReady = vi.fn();
+		const rejectReady = vi.fn();
+		const receive = Reflect.get(bridge, 'receive') as (
+			job: string,
+			generation: number,
+			value: unknown,
+			resolve: typeof resolveReady,
+			reject: typeof rejectReady,
+		) => void;
+
+		receive.call(bridge, 'job-1', 0, message, resolveReady, rejectReady);
+
+		expect(resolveReady).not.toHaveBeenCalled();
+		expect(rejectReady).toHaveBeenCalledOnce();
+	});
+
 	it('cancels and awaits a Chromium launch during shutdown', async () => {
 		const assets = await mkdtemp(join(tmpdir(), 'renderer-assets-'));
 		await writeFile(join(assets, 'recorder.html'), '<!doctype html>');
@@ -85,6 +127,8 @@ describe('ChromiumRendererBridge', () => {
 		const evaluate = vi.fn(async () => {
 			exposed?.({
 				type: 'suite-recorder:configuration-accepted',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:01.000Z',
 				job: 'job-1',
 			});
 		});
@@ -99,7 +143,9 @@ describe('ChromiumRendererBridge', () => {
 			goto: vi.fn(async () => {
 				exposed?.({
 					type: 'suite-recorder:public-key-ready',
-					publicKey: { ...TEST_PUBLIC_JWK, ext: true, key_ops: ['verify'] },
+					protocol_version: 1,
+					occurred_at: '2026-08-30T12:00:00.000Z',
+					publicKey: TEST_PUBLIC_JWK,
 				});
 				return null;
 			}),
@@ -128,6 +174,8 @@ describe('ChromiumRendererBridge', () => {
 			},
 			adapter,
 		);
+		const lifecycle = vi.fn(async () => undefined);
+		bridge.onLifecycle(lifecycle);
 
 		await bridge.initialize();
 		expect(bridge.productionReady).toBe(true);
@@ -140,20 +188,85 @@ describe('ChromiumRendererBridge', () => {
 			page.goto as never,
 		);
 
-		await bridge.deliverGrant('job-1', 'private-grant', '2026-07-31T12:00:00Z');
+		await bridge.deliverGrant(
+			'job-1',
+			'private-grant',
+			'2026-07-31T12:00:00.000Z',
+		);
 		expect(evaluate.mock.calls[0]?.[1]).toEqual({
-			job: 'job-1',
-			grant: 'private-grant',
-			frappeOrigin: 'https://site.test',
-			meetingId: 'room-1',
-			sfuOrigin: 'https://sfu.test',
-			socketPath: '/socket.io',
-			startedAt: Date.parse('2026-07-31T12:00:00Z'),
+			type: 'suite-recorder:configure',
+			protocol_version: 1,
+			config: {
+				job: 'job-1',
+				grant: 'private-grant',
+				frappeOrigin: 'https://site.test',
+				meetingId: 'room-1',
+				sfuOrigin: 'https://sfu.test',
+				socketPath: '/socket.io',
+				acceptedAt: '2026-07-31T12:00:00.000Z',
+			},
 		});
-		await bridge.deliverGrant('job-1', 'private-grant', '2026-07-31T12:00:00Z');
+		expect(lifecycle).toHaveBeenCalledTimes(1);
+		for (const message of [
+			{ type: 'suite-recorder:capture-ready', job: 'job-1' },
+			{
+				type: 'suite-recorder:capture-ready',
+				protocol_version: 2,
+				occurred_at: '2026-08-30T12:00:02.000Z',
+				job: 'job-1',
+			},
+			{
+				type: 'suite-recorder:capture-ready',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:02.000Z',
+				job: 'job-1',
+				extra: true,
+			},
+			{
+				type: 'suite-recorder:interruption',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:02.000Z',
+				job: 'job-1',
+				reason_code: 'arbitrary_reason',
+			},
+			{
+				type: 'suite-recorder:interruption',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:02.000Z',
+				job: 'job-1',
+				reason_code: 'sfu_disconnected',
+				diagnostic: 'x'.repeat(257),
+			},
+		])
+			exposed?.(message);
+		expect(lifecycle).toHaveBeenCalledTimes(1);
+		exposed?.({
+			type: 'suite-recorder:interruption',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:02.000Z',
+			job: 'job-1',
+			reason_code: 'sfu_disconnected',
+			diagnostic: 'connection lost',
+		});
+		expect(lifecycle).toHaveBeenLastCalledWith({
+			job: 'job-1',
+			generation: 0,
+			type: 'interrupted',
+			reason: 'sfu_disconnected',
+			occurredAt: '2026-08-30T12:00:02.000Z',
+		});
+		await bridge.deliverGrant(
+			'job-1',
+			'private-grant',
+			'2026-07-31T12:00:00.000Z',
+		);
 		expect(evaluate).toHaveBeenCalledOnce();
 		await expect(
-			bridge.deliverGrant('job-1', 'different-grant', '2026-07-31T12:00:00Z'),
+			bridge.deliverGrant(
+				'job-1',
+				'different-grant',
+				'2026-07-31T12:00:00.000Z',
+			),
 		).rejects.toThrow('conflicting');
 
 		await bridge.stop('job-1');
@@ -185,6 +298,8 @@ describe('ChromiumRendererBridge', () => {
 			goto: vi.fn(async () => {
 				exposed?.({
 					type: 'suite-recorder:public-key-ready',
+					protocol_version: 1,
+					occurred_at: '2026-08-30T12:00:00.000Z',
 					publicKey: TEST_PUBLIC_JWK,
 				});
 				return null;

--- a/suite/meet/recorder-server/src/RendererBridge.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.ts
@@ -10,6 +10,7 @@ import puppeteer, {
 	type HTTPRequest,
 	type Page,
 } from 'puppeteer-core';
+import { validUtcTimestamp } from './AuthManager.js';
 import type {
 	CaptureArtifact,
 	CaptureGap,
@@ -117,6 +118,7 @@ const browserAdapter: BrowserAdapter = {
 function isPublicJwk(value: unknown): value is PublicJwk {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
 	return (
+		hasExactKeys(value, ['kty', 'crv', 'x', 'y']) &&
 		'kty' in value &&
 		value.kty === 'EC' &&
 		'crv' in value &&
@@ -127,6 +129,29 @@ function isPublicJwk(value: unknown): value is PublicJwk {
 		typeof value.y === 'string' &&
 		/^[A-Za-z0-9_-]{43}$/.test(value.x) &&
 		/^[A-Za-z0-9_-]{43}$/.test(value.y)
+	);
+}
+
+const RECORDER_PROTOCOL_VERSION = 1;
+const RENDERER_REASON_CODES = new Set([
+	'sfu_disconnected',
+	'media_attachment_failed',
+	'media_subscription_failed',
+	'receive_transport_failed',
+	'configuration_failed',
+	'browser_disconnected',
+	'page_crashed',
+]);
+
+function hasExactKeys(
+	value: object,
+	required: string[],
+	optional: string[] = [],
+): boolean {
+	const keys = Object.keys(value);
+	return (
+		required.every((key) => keys.includes(key)) &&
+		keys.every((key) => required.includes(key) || optional.includes(key))
 	);
 }
 
@@ -359,21 +384,22 @@ export class ChromiumRendererBridge implements RendererBridge {
 			renderer.resolveConfiguration = resolve;
 			renderer.rejectConfiguration = reject;
 		});
-		const config = {
-			job,
-			grant,
-			meetingId: renderer.command.room,
-			sfuOrigin: this.options.sfuOrigin,
-			frappeOrigin: renderer.command.origin,
-			socketPath: this.options.sfuSocketPath,
-			startedAt: Date.parse(acceptedAt),
+		const message = {
+			type: 'suite-recorder:configure' as const,
+			protocol_version: RECORDER_PROTOCOL_VERSION,
+			config: {
+				job,
+				grant,
+				meetingId: renderer.command.room,
+				sfuOrigin: this.options.sfuOrigin,
+				frappeOrigin: renderer.command.origin,
+				socketPath: this.options.sfuSocketPath,
+				acceptedAt,
+			},
 		};
 		await renderer.page.evaluate((value) => {
-			window.postMessage(
-				{ type: 'suite-recorder:configure', config: value },
-				window.location.origin,
-			);
-		}, config);
+			window.postMessage(value, window.location.origin);
+		}, message);
 		let timeout: NodeJS.Timeout | undefined;
 		try {
 			await Promise.race([
@@ -489,28 +515,22 @@ export class ChromiumRendererBridge implements RendererBridge {
 	): void {
 		if (!value || typeof value !== 'object' || Array.isArray(value)) return;
 		if ('type' in value && value.type === 'suite-recorder:public-key-ready') {
-			if ('publicKey' in value && isPublicJwk(value.publicKey)) {
-				const { kty, crv, x, y } = value.publicKey;
-				resolveReady({ kty, crv, x, y });
-			} else rejectReady(new Error('renderer returned an invalid public JWK'));
+			const publicKey = parseRendererPublicKeyReady(value);
+			if (publicKey) resolveReady(publicKey);
+			else rejectReady(new Error('renderer returned an invalid public JWK'));
 			return;
 		}
-		if (!('job' in value) || value.job !== job || !('type' in value)) return;
+		const lifecycle = parseRendererLifecycle(value);
+		if (!lifecycle || lifecycle.job !== job) return;
 		const renderer = this.jobs.get(job);
 		if (!renderer || renderer.generation !== generation) return;
-		const type = rendererLifecycleType(value.type);
-		if (!type) return;
-		if (type === 'configured') renderer?.resolveConfiguration?.();
-		const reason =
-			'reason' in value && typeof value.reason === 'string'
-				? value.reason.slice(0, 256)
-				: undefined;
+		if (lifecycle.type === 'configured') renderer.resolveConfiguration?.();
 		void this.lifecycleHandler({
 			job,
 			generation,
-			type,
-			occurredAt: new Date().toISOString(),
-			...(reason ? { reason } : {}),
+			type: lifecycle.type,
+			occurredAt: lifecycle.occurredAt,
+			...(lifecycle.reasonCode ? { reason: lifecycle.reasonCode } : {}),
 		});
 	}
 
@@ -526,27 +546,92 @@ export class ChromiumRendererBridge implements RendererBridge {
 	}
 }
 
-function rendererLifecycleType(
-	value: unknown,
-): RendererLifecycleEvent['type'] | undefined {
-	switch (value) {
-		case 'suite-recorder:configuration-accepted':
-			return 'configured';
-		case 'suite-recorder:proof-complete':
-			return 'proof_complete';
-		case 'suite-recorder:join-complete':
-			return 'joined';
-		case 'suite-recorder:capture-ready':
-			return 'capture_ready';
-		case 'suite-recorder:interruption':
-			return 'interrupted';
-		case 'suite-recorder:room-empty':
-			return 'room_empty';
-		case 'suite-recorder:failure':
-			return 'failed';
-		default:
+export function parseRendererPublicKeyReady(value: object): PublicJwk | null {
+	if (
+		!hasExactKeys(value, [
+			'type',
+			'protocol_version',
+			'occurred_at',
+			'publicKey',
+		]) ||
+		!('type' in value) ||
+		value.type !== 'suite-recorder:public-key-ready' ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!('occurred_at' in value) ||
+		!validUtcTimestamp(value.occurred_at) ||
+		!('publicKey' in value) ||
+		!isPublicJwk(value.publicKey)
+	)
+		return null;
+	const { kty, crv, x, y } = value.publicKey;
+	return { kty, crv, x, y };
+}
+
+export function parseRendererLifecycle(value: object):
+	| {
+			job: string;
+			type: RendererLifecycleEvent['type'];
+			occurredAt: string;
+			reasonCode?: string;
+	  }
+	| undefined {
+	if (
+		!('type' in value) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!('occurred_at' in value) ||
+		!validUtcTimestamp(value.occurred_at) ||
+		!('job' in value) ||
+		typeof value.job !== 'string' ||
+		!value.job
+	)
+		return undefined;
+	const types: Record<string, RendererLifecycleEvent['type']> = {
+		'suite-recorder:configuration-accepted': 'configured',
+		'suite-recorder:proof-complete': 'proof_complete',
+		'suite-recorder:join-complete': 'joined',
+		'suite-recorder:capture-ready': 'capture_ready',
+		'suite-recorder:room-empty': 'room_empty',
+	};
+	const lifecycleType =
+		typeof value.type === 'string' ? types[value.type] : undefined;
+	if (lifecycleType) {
+		if (
+			!hasExactKeys(value, ['type', 'protocol_version', 'occurred_at', 'job'])
+		)
 			return undefined;
+		return {
+			job: value.job,
+			type: lifecycleType,
+			occurredAt: value.occurred_at,
+		};
 	}
+	if (
+		value.type !== 'suite-recorder:interruption' &&
+		value.type !== 'suite-recorder:failure'
+	)
+		return undefined;
+	if (
+		!hasExactKeys(
+			value,
+			['type', 'protocol_version', 'occurred_at', 'job', 'reason_code'],
+			['diagnostic'],
+		) ||
+		!('reason_code' in value) ||
+		typeof value.reason_code !== 'string' ||
+		!RENDERER_REASON_CODES.has(value.reason_code) ||
+		('diagnostic' in value &&
+			(typeof value.diagnostic !== 'string' || value.diagnostic.length > 256))
+	)
+		return undefined;
+	return {
+		job: value.job,
+		occurredAt: value.occurred_at,
+		type:
+			value.type === 'suite-recorder:interruption' ? 'interrupted' : 'failed',
+		reasonCode: value.reason_code,
+	};
 }
 
 export const TEST_PUBLIC_JWK: PublicJwk = {

--- a/suite/meet/recorder-server/src/app.ts
+++ b/suite/meet/recorder-server/src/app.ts
@@ -8,18 +8,43 @@ import { AuthError, type AuthManager } from './AuthManager.js';
 import type { Config } from './config.js';
 import type { JobManager } from './JobManager.js';
 import type { Logger } from './logger.js';
-import type { CommandClaims, JobRecord } from './types.js';
+import {
+	type CommandClaims,
+	type JobRecord,
+	PROTOCOL_VERSION,
+} from './types.js';
+
+const HEALTH_REASON_CODES = new Set([
+	'browser_disconnected',
+	'capture_interrupted',
+	'configuration_failed',
+	'duration_limit',
+	'ffmpeg_exited',
+	'interruption_timeout',
+	'media_attachment_failed',
+	'media_subscription_failed',
+	'page_crashed',
+	'quota_limit',
+	'receive_transport_failed',
+	'room_empty',
+	'service_shutdown',
+	'sfu_disconnected',
+	'worker_missing_after_restart',
+]);
 
 interface ReserveBody {
+	protocol_version: typeof PROTOCOL_VERSION;
 	job: string;
 }
 
 interface GrantBody {
+	protocol_version: typeof PROTOCOL_VERSION;
 	grant: string;
 	endpoint_generation: number;
 }
 
 interface StopBody {
+	protocol_version: typeof PROTOCOL_VERSION;
 	job: string;
 	operation_id: string;
 }
@@ -33,15 +58,21 @@ function exactBody(value: unknown, keys: string[]): value is object {
 	);
 }
 
-function reserveBody(value: unknown): value is ReserveBody {
+export function reserveBody(value: unknown): value is ReserveBody {
 	return (
-		exactBody(value, ['job']) && 'job' in value && typeof value.job === 'string'
+		exactBody(value, ['job', 'protocol_version']) &&
+		'protocol_version' in value &&
+		value.protocol_version === PROTOCOL_VERSION &&
+		'job' in value &&
+		typeof value.job === 'string'
 	);
 }
 
-function grantBody(value: unknown): value is GrantBody {
+export function grantBody(value: unknown): value is GrantBody {
 	return (
-		exactBody(value, ['endpoint_generation', 'grant']) &&
+		exactBody(value, ['endpoint_generation', 'grant', 'protocol_version']) &&
+		'protocol_version' in value &&
+		value.protocol_version === PROTOCOL_VERSION &&
 		'grant' in value &&
 		typeof value.grant === 'string' &&
 		value.grant.length > 0 &&
@@ -52,9 +83,11 @@ function grantBody(value: unknown): value is GrantBody {
 	);
 }
 
-function stopBody(value: unknown): value is StopBody {
+export function stopBody(value: unknown): value is StopBody {
 	return (
-		exactBody(value, ['job', 'operation_id']) &&
+		exactBody(value, ['job', 'operation_id', 'protocol_version']) &&
+		'protocol_version' in value &&
+		value.protocol_version === PROTOCOL_VERSION &&
 		'job' in value &&
 		typeof value.job === 'string' &&
 		'operation_id' in value &&
@@ -77,6 +110,7 @@ function accepted(job: JobRecord) {
 		])[],
 	);
 	return {
+		protocol_version: PROTOCOL_VERSION,
 		status: 'accepted',
 		job: job.job,
 		accepted_at: job.accepted_at,
@@ -85,8 +119,9 @@ function accepted(job: JobRecord) {
 		state: job.state,
 		event_sequence: job.event_sequence ?? 1,
 		...(Object.keys(milestones).length ? { milestones } : {}),
-		...(job.artifact ? { artifact: job.artifact } : {}),
-		...(job.health_reason ? { health_reason: job.health_reason } : {}),
+		...(job.health_reason
+			? { reason_code: healthReasonCode(job.health_reason) }
+			: {}),
 		...(job.replacement_ready_at
 			? { replacement_ready_at: job.replacement_ready_at }
 			: {}),
@@ -103,6 +138,22 @@ function accepted(job: JobRecord) {
 				}
 			: {}),
 	};
+}
+
+function healthReasonCode(reason: string): string {
+	if (HEALTH_REASON_CODES.has(reason)) return reason;
+	if (reason.includes('budget') || reason.includes('quota'))
+		return 'quota_limit';
+	if (reason.includes('time_limit') || reason.includes('duration'))
+		return 'duration_limit';
+	if (reason.includes('recovery_timeout') || reason.includes('interruption'))
+		return 'interruption_timeout';
+	if (reason.includes('shutdown')) return 'service_shutdown';
+	if (reason.includes('room_empty')) return 'room_empty';
+	if (reason.includes('ffmpeg') || reason.includes('segment'))
+		return 'ffmpeg_exited';
+	if (reason.includes('worker_missing')) return 'worker_missing_after_restart';
+	return 'capture_interrupted';
 }
 
 export function createApp(
@@ -174,7 +225,9 @@ export function createApp(
 					event: 'authorization_rejected',
 					reason: error instanceof AuthError ? error.message : 'invalid',
 				});
-				res.status(401).json({ status: 'unauthorized' });
+				res
+					.status(401)
+					.json({ protocol_version: PROTOCOL_VERSION, status: 'unauthorized' });
 			}
 		};
 	}
@@ -189,9 +242,10 @@ export function createApp(
 				const body: unknown = req.body;
 				if (!reserveBody(body) || body.job !== claims.job)
 					return res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 				await auth.consume(claims);
 				const result = await jobs.reserve(claims);
@@ -209,7 +263,12 @@ export function createApp(
 								? 507
 								: 422,
 					)
-					.json({ status: 'rejected', job: claims.job, reason: result.reason });
+					.json({
+						protocol_version: PROTOCOL_VERSION,
+						status: 'rejected',
+						job: claims.job,
+						reason_code: result.reason,
+					});
 			} catch (error) {
 				next(error);
 			}
@@ -224,9 +283,10 @@ export function createApp(
 			return job
 				? res.json(accepted(job))
 				: res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 		} catch (error) {
 			next(error);
@@ -243,19 +303,24 @@ export function createApp(
 				const body: unknown = req.body;
 				if (!grantBody(body))
 					return res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 				await auth.consume(claims);
 				if (!(await jobs.grant(claims, body.grant, body.endpoint_generation)))
 					return res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 				log.info({ event: 'job_grant', status: 'accepted' });
-				return res.json({ status: 'accepted' });
+				return res.json({
+					protocol_version: PROTOCOL_VERSION,
+					status: 'accepted',
+				});
 			} catch (error) {
 				next(error);
 			}
@@ -272,19 +337,22 @@ export function createApp(
 				const body: unknown = req.body;
 				if (!stopBody(body) || body.job !== claims.job)
 					return res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 				await auth.consume(claims);
 				if (!(await jobs.stop(claims, body.operation_id)))
 					return res.status(422).json({
+						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason: 'invalid_job',
+						reason_code: 'invalid_job',
 					});
 				log.info({ event: 'job_stop', status: 'accepted' });
 				return res.status(202).json({
+					protocol_version: PROTOCOL_VERSION,
 					status: 'accepted',
 					job: claims.job,
 					operation_id: body.operation_id,
@@ -297,7 +365,9 @@ export function createApp(
 
 	app.use((error: Error, _req: Request, res: Response, _next: NextFunction) => {
 		if (error instanceof AuthError)
-			return res.status(401).json({ status: 'unauthorized' });
+			return res
+				.status(401)
+				.json({ protocol_version: PROTOCOL_VERSION, status: 'unauthorized' });
 		const status =
 			'status' in error && error.status === 413
 				? 413
@@ -313,7 +383,9 @@ export function createApp(
 						? 'invalid_json'
 						: 'unavailable',
 		});
-		res.status(status).json({ status: 'indeterminate' });
+		res
+			.status(status)
+			.json({ protocol_version: PROTOCOL_VERSION, status: 'indeterminate' });
 	});
 	return app;
 }

--- a/suite/meet/recorder-server/src/core.test.ts
+++ b/suite/meet/recorder-server/src/core.test.ts
@@ -13,11 +13,17 @@ import { JobManager } from './JobManager.js';
 import { JobStore } from './JobStore.js';
 import type { LogEntry, Logger } from './logger.js';
 import { FakeRendererBridge, TEST_PUBLIC_JWK } from './RendererBridge.js';
-import { COMMAND_AUDIENCE, COMMAND_TYPE, type CommandClaims } from './types.js';
+import {
+	COMMAND_AUDIENCE,
+	COMMAND_TYPE,
+	type CommandClaims,
+	PROTOCOL_VERSION,
+} from './types.js';
 
 const secret = 'a-long-enough-test-secret-for-hs256';
 const now = Math.floor(Date.now() / 1000);
 const baseClaims = {
+	protocol_version: PROTOCOL_VERSION,
 	iss: 'frappe-site:site.test',
 	aud: COMMAND_AUDIENCE,
 	site: 'site.test',
@@ -31,7 +37,7 @@ const baseClaims = {
 	exp: now + 30,
 	limits: {
 		budget_bytes: 1_000_000,
-		max_ends_at: '2026-07-31T12:00:00Z',
+		max_ends_at: '2026-07-31T12:00:00.000Z',
 		output: { width: 1920, height: 1080, fps: 30, video: 'h264', audio: 'aac' },
 	},
 } satisfies CommandClaims;
@@ -82,7 +88,11 @@ function authenticated(
 			Authorization: `Bearer ${signed}`,
 			...(body ? { 'Content-Type': 'application/json' } : {}),
 		},
-		...(body ? { body: JSON.stringify(body) } : {}),
+		...(body
+			? {
+					body: JSON.stringify({ protocol_version: PROTOCOL_VERSION, ...body }),
+				}
+			: {}),
 	};
 }
 
@@ -175,6 +185,22 @@ describe('AuthManager', () => {
 
 	it('accepts the exact Python RecorderClient command', () => {
 		expect(auth.authenticate(`Bearer ${token()}`, 'reserve').job).toBe('job');
+	});
+
+	it('rejects missing and unsupported command protocol versions', () => {
+		const { protocol_version: _version, ...missingVersion } = baseClaims;
+		for (const claims of [
+			missingVersion,
+			{ ...baseClaims, protocol_version: 2 },
+		]) {
+			const signed = jwt.sign(claims, secret, {
+				algorithm: 'HS256',
+				header: { alg: 'HS256', typ: COMMAND_TYPE },
+			});
+			expect(() => auth.authenticate(`Bearer ${signed}`, 'reserve')).toThrow(
+				AuthError,
+			);
+		}
 	});
 
 	it('atomically rejects replay', () => {
@@ -1351,6 +1377,7 @@ describe('HTTP contract', () => {
 		);
 		expect(reserve.status).toBe(202);
 		const reserveBody: {
+			protocol_version: 1;
 			status: 'accepted';
 			job: string;
 			accepted_at: string;
@@ -1364,6 +1391,7 @@ describe('HTTP contract', () => {
 			'endpoint_generation',
 			'event_sequence',
 			'job',
+			'protocol_version',
 			'public_jwk',
 			'state',
 			'status',
@@ -1389,7 +1417,7 @@ describe('HTTP contract', () => {
 		);
 		expect([grant.status, await grant.json()]).toEqual([
 			200,
-			{ status: 'accepted' },
+			{ protocol_version: 1, status: 'accepted' },
 		]);
 		const stop = await call(
 			app,
@@ -1402,7 +1430,12 @@ describe('HTTP contract', () => {
 		);
 		expect([stop.status, await stop.json()]).toEqual([
 			202,
-			{ status: 'accepted', job: 'job', operation_id: 'stop-1' },
+			{
+				protocol_version: 1,
+				status: 'accepted',
+				job: 'job',
+				operation_id: 'stop-1',
+			},
 		]);
 		expect(bridge.grants).toEqual([
 			{
@@ -1423,9 +1456,10 @@ describe('HTTP contract', () => {
 		);
 		expect(response.status).toBe(507);
 		expect(await response.json()).toEqual({
+			protocol_version: 1,
 			status: 'rejected',
 			job: 'job',
-			reason: 'storage',
+			reason_code: 'storage',
 		});
 	});
 
@@ -1443,7 +1477,10 @@ describe('HTTP contract', () => {
 			authenticated('POST', { job: 'job', padding: 'x'.repeat(17 * 1024) }),
 		);
 		expect(oversized.status).toBe(413);
-		expect(await oversized.json()).toEqual({ status: 'indeterminate' });
+		expect(await oversized.json()).toEqual({
+			protocol_version: 1,
+			status: 'indeterminate',
+		});
 	});
 
 	it('binds route and body to signed job and rejects extra fields', async () => {
@@ -1514,6 +1551,34 @@ describe('HTTP contract', () => {
 				)
 			).status,
 		).toBe(401);
+	});
+
+	it('rejects body protocol errors before consuming a command nonce', async () => {
+		const signed = token({ jti: 'protocol-retry', operation: 'reserve' });
+		for (const body of [
+			{ job: 'job' },
+			{ protocol_version: 2, job: 'job' },
+			{ protocol_version: 1, job: 'job', unknown: true },
+		]) {
+			const response = await call(app, '/v1/recordings', {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${signed}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(body),
+			});
+			expect(response.status).toBe(422);
+		}
+		expect(
+			(
+				await call(
+					app,
+					'/v1/recordings',
+					authenticated('POST', { job: 'job' }, signed),
+				)
+			).status,
+		).toBe(202);
 	});
 
 	it('protects metrics independently', async () => {

--- a/suite/meet/recorder-server/src/types.ts
+++ b/suite/meet/recorder-server/src/types.ts
@@ -1,5 +1,6 @@
 export const COMMAND_AUDIENCE = 'meet-recorder-control';
 export const COMMAND_TYPE = 'meet-recorder-command+jwt';
+export const PROTOCOL_VERSION = 1;
 export type CommandOperation = 'reserve' | 'query' | 'grant' | 'stop';
 
 export interface RecordingLimits {
@@ -9,6 +10,7 @@ export interface RecordingLimits {
 }
 
 export interface CommandClaims {
+	protocol_version: typeof PROTOCOL_VERSION;
 	iss: string;
 	aud: typeof COMMAND_AUDIENCE;
 	site: string;

--- a/suite/meet/recording/callback_auth.py
+++ b/suite/meet/recording/callback_auth.py
@@ -2,14 +2,21 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
+import re
 import time
+import uuid
+from datetime import datetime
 
 import frappe
 import jwt
 from frappe import _
 
+from suite.meet.recording.grants import normalize_public_jwk
+
 CALLBACK_AUDIENCE = "meet-recording-callback"
 CALLBACK_TYPE = "meet-recording-callback+jwt"
+PROTOCOL_VERSION = 1
 CLAIM_KEYS = {
     "aud",
     "body_sha256",
@@ -20,13 +27,301 @@ CLAIM_KEYS = {
     "jti",
     "operation",
     "operation_id",
+    "protocol_version",
     "recording",
     "site",
 }
 
+CALLBACK_BODY_KEYS = {
+    "startup_progress": {
+        "protocol_version",
+        "recording_id",
+        "job",
+        "event_sequence",
+        "milestone",
+        "occurred_at",
+    },
+    "interrupted": {
+        "protocol_version",
+        "recording_id",
+        "job",
+        "event_sequence",
+        "reason_code",
+        "interruption_id",
+        "interrupted_at",
+        "interruption_deadline",
+        "omission_started_at",
+    },
+    "recovered": {
+        "protocol_version",
+        "recording_id",
+        "job",
+        "event_sequence",
+        "interruption_id",
+        "resumed_capture_started_at",
+        "recovered_at",
+    },
+    "replacement_ready": {
+        "protocol_version",
+        "recording_id",
+        "job",
+        "event_sequence",
+        "interruption_id",
+        "endpoint_generation",
+        "public_jwk",
+        "ready_at",
+    },
+    "failed": {"protocol_version", "recording_id", "job", "event_sequence", "reason_code"},
+    "stopped": {
+        "protocol_version",
+        "recording_id",
+        "job",
+        "event_sequence",
+        "captured_bytes",
+        "size",
+        "sha256",
+        "duration_ms",
+        "ended_at",
+        "end_reason_code",
+        "gaps",
+    },
+    "segment_progress": {"protocol_version", "recording_id", "job", "captured_bytes"},
+    "complete_upload": {"protocol_version", "recording_id", "job", "event_sequence"},
+}
+UPLOAD_QUERY_KEYS = {"protocol_version", "recording_id", "job", "offset", "chunk_sha256"}
+STARTUP_MILESTONES = {"configured", "proof_complete", "joined", "capture_started"}
+INTERRUPTION_REASON_CODES = {
+    "browser_disconnected",
+    "capture_interrupted",
+    "configuration_failed",
+    "ffmpeg_exited",
+    "media_attachment_failed",
+    "media_subscription_failed",
+    "page_crashed",
+    "receive_transport_failed",
+    "sfu_disconnected",
+}
+END_REASON_CODES = {
+    "duration_limit",
+    "host_stop",
+    "interruption_timeout",
+    "quota_limit",
+    "room_empty",
+    "service_shutdown",
+}
+GAP_REASON_CODES = {"capture_interrupted", "ffmpeg_exited", "renderer_interrupted"}
+FAILURE_REASON_CODES = {"capture_failed", "processing_failed", "storage_unavailable", "quota_exhausted"}
+
+
+def _invalid_payload():
+    frappe.throw(_("Invalid recorder callback body"), frappe.AuthenticationError)
+
+
+def _is_integer(value, *, minimum: int = 0) -> bool:
+    return type(value) is int and value >= minimum
+
+
+def _is_canonical_timestamp(value) -> bool:
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", value):
+        return False
+    try:
+        datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return True
+
+
+def _timestamp(value):
+    if not _is_canonical_timestamp(value):
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _is_uuid(value) -> bool:
+    try:
+        return isinstance(value, str) and str(uuid.UUID(value)) == value.lower()
+    except (ValueError, AttributeError):
+        return False
+
+
+def _validate_callback_payload(operation: str, body: dict):
+    if (
+        type(body.get("protocol_version")) is not int
+        or body["protocol_version"] != PROTOCOL_VERSION
+        or not isinstance(body.get("recording_id"), str)
+        or not body["recording_id"]
+        or not isinstance(body.get("job"), str)
+        or not body["job"]
+    ):
+        _invalid_payload()
+
+    sequence = body.get("event_sequence")
+    if operation in {
+        "startup_progress",
+        "interrupted",
+        "recovered",
+        "replacement_ready",
+        "failed",
+        "stopped",
+        "complete_upload",
+    } and not _is_integer(sequence, minimum=1):
+        _invalid_payload()
+
+    valid = True
+    if operation == "startup_progress":
+        valid = (
+            isinstance(body.get("milestone"), str)
+            and body["milestone"] in STARTUP_MILESTONES
+            and _is_canonical_timestamp(body.get("occurred_at"))
+        )
+    elif operation == "interrupted":
+        interrupted = _timestamp(body.get("interrupted_at"))
+        deadline = _timestamp(body.get("interruption_deadline"))
+        omission_started = _timestamp(body.get("omission_started_at"))
+        valid = (
+            isinstance(body.get("reason_code"), str)
+            and body["reason_code"] in INTERRUPTION_REASON_CODES
+            and _is_uuid(body.get("interruption_id"))
+            and interrupted is not None
+            and deadline is not None
+            and omission_started is not None
+            and deadline.timestamp() - interrupted.timestamp() == 60
+            and omission_started <= interrupted
+        )
+    elif operation == "recovered":
+        resumed = _timestamp(body.get("resumed_capture_started_at"))
+        recovered = _timestamp(body.get("recovered_at"))
+        valid = (
+            _is_uuid(body.get("interruption_id"))
+            and resumed is not None
+            and recovered is not None
+            and resumed <= recovered
+        )
+    elif operation == "replacement_ready":
+        try:
+            normalize_public_jwk(body.get("public_jwk"))
+        except (TypeError, ValueError):
+            valid = False
+        valid = (
+            valid
+            and _is_uuid(body.get("interruption_id"))
+            and _is_integer(body.get("endpoint_generation"))
+            and _is_canonical_timestamp(body.get("ready_at"))
+        )
+    elif operation == "failed":
+        valid = isinstance(body.get("reason_code"), str) and body["reason_code"] in FAILURE_REASON_CODES
+    elif operation == "segment_progress":
+        valid = _is_integer(body.get("captured_bytes"))
+    elif operation == "stopped":
+        gaps = body.get("gaps")
+        valid = (
+            _is_integer(body.get("captured_bytes"))
+            and _is_integer(body.get("size"), minimum=1)
+            and _is_integer(body.get("duration_ms"), minimum=1)
+            and isinstance(body.get("sha256"), str)
+            and re.fullmatch(r"[0-9a-f]{64}", body["sha256"]) is not None
+            and _is_canonical_timestamp(body.get("ended_at"))
+            and isinstance(body.get("end_reason_code"), str)
+            and body["end_reason_code"] in END_REASON_CODES
+            and isinstance(gaps, list)
+            and all(
+                isinstance(gap, dict)
+                and set(gap) == {"started_at", "ended_at", "reason_code"}
+                and _is_canonical_timestamp(gap["started_at"])
+                and _is_canonical_timestamp(gap["ended_at"])
+                and _timestamp(gap["started_at"]) <= _timestamp(gap["ended_at"])
+                and isinstance(gap["reason_code"], str)
+                and gap["reason_code"] in GAP_REASON_CODES
+                for gap in gaps
+            )
+        )
+    if not valid:
+        _invalid_payload()
+
+
+def valid_upload_query(args, *, content_type, content_length, body) -> bool:
+    return (
+        isinstance(args, dict)
+        and set(args) == UPLOAD_QUERY_KEYS
+        and args.get("protocol_version") == str(PROTOCOL_VERSION)
+        and bool(args.get("recording_id"))
+        and bool(args.get("job"))
+        and isinstance(args.get("offset"), str)
+        and re.fullmatch(r"0|[1-9]\d*", args["offset"]) is not None
+        and isinstance(args.get("chunk_sha256"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", args["chunk_sha256"]) is not None
+        and content_type == "application/octet-stream"
+        and type(content_length) is int
+        and 0 < content_length <= 8 * 1024 * 1024
+        and isinstance(body, bytes)
+        and len(body) == content_length
+        and hmac.compare_digest(hashlib.sha256(body).hexdigest(), args["chunk_sha256"])
+    )
+
+
+def _validate_upload_query():
+    content_length = frappe.request.content_length
+    if (
+        frappe.request.content_type != "application/octet-stream"
+        or type(content_length) is not int
+        or not 0 < content_length <= 8 * 1024 * 1024
+    ):
+        frappe.throw(_("Invalid recorder callback query"), frappe.AuthenticationError)
+    body = frappe.request.get_data(cache=True)
+    if not valid_upload_query(
+        frappe.request.args.to_dict(),
+        content_type=frappe.request.content_type,
+        content_length=content_length,
+        body=body,
+    ):
+        frappe.throw(_("Invalid recorder callback query"), frappe.AuthenticationError)
+    return body
+
+
+def valid_callback_claims(
+    claims,
+    *,
+    site: str,
+    recording: str,
+    job: str,
+    operation: str,
+    operation_id: str,
+    protocol_version: int,
+    now: int,
+) -> bool:
+    return (
+        isinstance(claims, dict)
+        and set(claims) == CLAIM_KEYS
+        and claims.get("aud") == CALLBACK_AUDIENCE
+        and claims.get("site") == site
+        and claims.get("iss") == f"meet-recorder:{site}"
+        and claims.get("recording") == recording
+        and claims.get("job") == job
+        and claims.get("operation") == operation
+        and claims.get("operation_id") == operation_id
+        and type(claims.get("protocol_version")) is int
+        and claims.get("protocol_version") == PROTOCOL_VERSION
+        and claims.get("protocol_version") == protocol_version
+        and isinstance(claims.get("jti"), str)
+        and bool(claims["jti"])
+        and type(claims.get("iat")) is int
+        and type(claims.get("exp")) is int
+        and claims["exp"] - claims["iat"] == 30
+        and claims["iat"] <= now + 5
+        and claims["iat"] >= now - 35
+        and isinstance(claims.get("body_sha256"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", claims["body_sha256"]) is not None
+    )
+
 
 def authenticate_callback(
-    *, recording: str, job: str, operation: str, operation_id: str, now: int | None = None
+    *,
+    protocol_version: int,
+    recording: str,
+    job: str,
+    operation: str,
+    operation_id: str,
+    now: int | None = None,
 ):
     authorization = frappe.request.headers.get("X-Meet-Recorder-Authorization", "")
     if not authorization.startswith("Bearer ") or len(authorization) == 7:
@@ -51,30 +346,33 @@ def authenticate_callback(
         )
     except jwt.PyJWTError:
         frappe.throw(_("Invalid recorder callback authorization"), frappe.AuthenticationError)
-    if (
-        set(claims) != CLAIM_KEYS
-        or claims.get("aud") != CALLBACK_AUDIENCE
-        or claims.get("site") != frappe.local.site
-        or claims.get("iss") != f"meet-recorder:{claims.get('site')}"
-        or claims.get("recording") != recording
-        or claims.get("job") != job
-        or claims.get("operation") != operation
-        or claims.get("operation_id") != operation_id
-        or not isinstance(claims.get("jti"), str)
-        or not claims["jti"]
-        or not isinstance(claims.get("iat"), int)
-        or not isinstance(claims.get("exp"), int)
-        or claims["exp"] - claims["iat"] != 30
-        or claims["iat"] > now + 5
-        or claims["iat"] < now - 35
-        or not isinstance(claims.get("body_sha256"), str)
-        or len(claims["body_sha256"]) != 64
+    if not valid_callback_claims(
+        claims,
+        site=frappe.local.site,
+        recording=recording,
+        job=job,
+        operation=operation,
+        operation_id=operation_id,
+        protocol_version=protocol_version,
+        now=now,
     ):
         frappe.throw(_("Invalid recorder callback scope"), frappe.AuthenticationError)
 
-    body_sha256 = hashlib.sha256(frappe.request.get_data(cache=True)).hexdigest()
+    body_data = (
+        _validate_upload_query() if operation == "upload_chunk" else frappe.request.get_data(cache=True)
+    )
+    body_sha256 = hashlib.sha256(body_data).hexdigest()
     if not hmac.compare_digest(claims["body_sha256"], body_sha256):
         frappe.throw(_("Invalid recorder callback body"), frappe.AuthenticationError)
+
+    if operation != "upload_chunk":
+        try:
+            body = json.loads(body_data)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            frappe.throw(_("Invalid recorder callback body"), frappe.AuthenticationError)
+        if not isinstance(body, dict) or set(body) != CALLBACK_BODY_KEYS.get(operation):
+            frappe.throw(_("Invalid recorder callback body"), frappe.AuthenticationError)
+        _validate_callback_payload(operation, body)
 
     expected_job = frappe.db.get_value("Meet Recording", recording, "recorder_job_id")
     if expected_job != job:

--- a/suite/meet/recording/contracts/v1.json
+++ b/suite/meet/recording/contracts/v1.json
@@ -1,0 +1,693 @@
+{
+  "name": "meet-recording-contracts",
+  "protocol_version": 1,
+  "accepted_protocol_versions": [1],
+  "timestamp_format": "UTC RFC 3339 with exactly millisecond precision and Z",
+  "vocabularies": {
+    "command_operations": ["reserve", "query", "grant", "stop"],
+    "command_states": [
+      "reserved",
+      "configured",
+      "proof_complete",
+      "joined",
+      "capture_ready",
+      "interrupted",
+      "failed",
+      "recovery_required",
+      "stopping",
+      "complete",
+      "partial"
+    ],
+    "command_rejection_reason_codes": ["capacity", "storage", "policy", "invalid_job"],
+    "health_reason_codes": [
+      "browser_disconnected",
+      "capture_interrupted",
+      "configuration_failed",
+      "duration_limit",
+      "ffmpeg_exited",
+      "interruption_timeout",
+      "media_attachment_failed",
+      "media_subscription_failed",
+      "page_crashed",
+      "quota_limit",
+      "receive_transport_failed",
+      "room_empty",
+      "service_shutdown",
+      "sfu_disconnected",
+      "worker_missing_after_restart"
+    ],
+    "startup_milestones": ["configured", "proof_complete", "joined", "capture_started"],
+    "interruption_reason_codes": [
+      "browser_disconnected",
+      "capture_interrupted",
+      "configuration_failed",
+      "ffmpeg_exited",
+      "media_attachment_failed",
+      "media_subscription_failed",
+      "page_crashed",
+      "receive_transport_failed",
+      "sfu_disconnected"
+    ],
+    "renderer_reason_codes": [
+      "sfu_disconnected",
+      "media_attachment_failed",
+      "media_subscription_failed",
+      "receive_transport_failed",
+      "configuration_failed",
+      "browser_disconnected",
+      "page_crashed"
+    ],
+    "callback_failure_reason_codes": [
+      "capture_failed",
+      "processing_failed",
+      "storage_unavailable",
+      "quota_exhausted"
+    ],
+    "end_reason_codes": [
+      "duration_limit",
+      "host_stop",
+      "interruption_timeout",
+      "quota_limit",
+      "room_empty",
+      "service_shutdown"
+    ],
+    "gap_reason_codes": ["capture_interrupted", "ffmpeg_exited", "renderer_interrupted"],
+    "frappe_recording_states": [
+      "Pending",
+      "Starting",
+      "Recording",
+      "Interrupted",
+      "Stopping",
+      "Processing",
+      "Ready",
+      "Partial",
+      "Failed",
+      "Cancelled"
+    ],
+    "proof_reason_codes": ["invalid_proof"]
+  },
+  "message_shapes": {
+    "command_claims": {
+      "required": [
+        "aud",
+        "exp",
+        "iat",
+        "iss",
+        "job",
+        "jti",
+        "limits",
+        "operation",
+        "origin",
+        "protocol_version",
+        "recording",
+        "room",
+        "site"
+      ],
+      "optional": []
+    },
+    "reserve_request": { "required": ["job", "protocol_version"], "optional": [] },
+    "grant_request": {
+      "required": ["endpoint_generation", "grant", "protocol_version"],
+      "optional": []
+    },
+    "stop_request": {
+      "required": ["job", "operation_id", "protocol_version"],
+      "optional": []
+    },
+    "command_accepted_response": {
+      "required": [
+        "accepted_at",
+        "endpoint_generation",
+        "event_sequence",
+        "job",
+        "protocol_version",
+        "public_jwk",
+        "state",
+        "status"
+      ],
+      "optional": ["interruption", "milestones", "reason_code", "replacement_ready_at"]
+    },
+    "command_rejected_response": {
+      "required": ["job", "protocol_version", "reason_code", "status"],
+      "optional": []
+    },
+    "grant_success_response": {
+      "required": ["protocol_version", "status"],
+      "optional": []
+    },
+    "stop_success_response": {
+      "required": ["job", "operation_id", "protocol_version", "status"],
+      "optional": []
+    },
+    "callback_claims": {
+      "required": [
+        "aud",
+        "body_sha256",
+        "exp",
+        "iat",
+        "iss",
+        "job",
+        "jti",
+        "operation",
+        "operation_id",
+        "protocol_version",
+        "recording",
+        "site"
+      ],
+      "optional": []
+    },
+    "callback_startup_progress": {
+      "required": [
+        "event_sequence",
+        "job",
+        "milestone",
+        "occurred_at",
+        "protocol_version",
+        "recording_id"
+      ],
+      "optional": []
+    },
+    "callback_interrupted": {
+      "required": [
+        "event_sequence",
+        "interrupted_at",
+        "interruption_deadline",
+        "interruption_id",
+        "job",
+        "omission_started_at",
+        "protocol_version",
+        "reason_code",
+        "recording_id"
+      ],
+      "optional": []
+    },
+    "callback_recovered": {
+      "required": [
+        "event_sequence",
+        "interruption_id",
+        "job",
+        "protocol_version",
+        "recovered_at",
+        "recording_id",
+        "resumed_capture_started_at"
+      ],
+      "optional": []
+    },
+    "callback_replacement_ready": {
+      "required": [
+        "endpoint_generation",
+        "event_sequence",
+        "interruption_id",
+        "job",
+        "protocol_version",
+        "public_jwk",
+        "ready_at",
+        "recording_id"
+      ],
+      "optional": []
+    },
+    "callback_failed": {
+      "required": ["event_sequence", "job", "protocol_version", "reason_code", "recording_id"],
+      "optional": []
+    },
+    "callback_stopped": {
+      "required": [
+        "captured_bytes",
+        "duration_ms",
+        "ended_at",
+        "end_reason_code",
+        "event_sequence",
+        "gaps",
+        "job",
+        "protocol_version",
+        "recording_id",
+        "sha256",
+        "size"
+      ],
+      "optional": []
+    },
+    "callback_segment_progress": {
+      "required": ["captured_bytes", "job", "protocol_version", "recording_id"],
+      "optional": []
+    },
+    "callback_complete_upload": {
+      "required": ["event_sequence", "job", "protocol_version", "recording_id"],
+      "optional": []
+    },
+    "callback_upload_query": {
+      "required": ["chunk_sha256", "job", "offset", "protocol_version", "recording_id"],
+      "optional": []
+    },
+    "renderer_configure": {
+      "required": ["config", "protocol_version", "type"],
+      "optional": []
+    },
+    "renderer_lifecycle": {
+      "required": ["job", "occurred_at", "protocol_version", "type"],
+      "optional": []
+    },
+    "renderer_reason_lifecycle": {
+      "required": ["job", "occurred_at", "protocol_version", "reason_code", "type"],
+      "optional": ["diagnostic"]
+    },
+    "renderer_public_key_ready": {
+      "required": ["occurred_at", "protocol_version", "publicKey", "type"],
+      "optional": []
+    },
+    "recording_grant_claims": {
+      "required": [
+        "aud",
+        "authorization_expires_at",
+        "cnf",
+        "exp",
+        "iat",
+        "iss",
+        "jti",
+        "meeting_id",
+        "protocol_version",
+        "recorder_job_id",
+        "recording_id",
+        "scope",
+        "site"
+      ],
+      "optional": []
+    },
+    "proof_challenge": {
+      "required": ["expires_at", "issued_at", "jti", "nonce", "protocol_version", "socket_id"],
+      "optional": []
+    },
+    "proof_request": { "required": ["protocol_version", "signature"], "optional": [] },
+    "proof_success": { "required": ["protocol_version", "success"], "optional": [] },
+    "proof_failure": {
+      "required": ["protocol_version", "reason_code", "success"],
+      "optional": ["diagnostic"]
+    }
+  },
+  "mappings": {
+    "startup_milestone_to_frappe_state": {
+      "configured": "Starting",
+      "proof_complete": "Starting",
+      "joined": "Starting",
+      "capture_started": "Recording"
+    },
+    "callback_event_to_frappe_state": {
+      "interrupted": ["Interrupted"],
+      "recovered": ["Recording"],
+      "replacement_ready": ["Interrupted"],
+      "failed": ["Failed", "Cancelled"],
+      "stopped": ["Processing", "Ready", "Partial"],
+      "segment_progress": ["Recording", "Interrupted", "Stopping"],
+      "complete_upload": ["Processing", "Ready", "Partial"]
+    }
+  },
+  "vectors": {
+    "protocol_versions": {
+      "accepted": [1],
+      "rejected": [0, 2, 1.5, true, "1", null]
+    },
+    "timestamps": {
+      "accepted": [
+        "2026-08-30T12:00:00.000Z",
+        "2026-08-30T12:00:00.999Z"
+      ],
+      "rejected": [
+        "2026-08-30T12:00:00Z",
+        "2026-08-30T12:00:00.00Z",
+        "2026-08-30T12:00:00.000+00:00",
+        "2026-02-30T12:00:00.000Z",
+        1788091200000,
+        null
+      ]
+    },
+    "renderer_lifecycle": {
+      "accepted": [
+        {
+          "type": "suite-recorder:configuration-accepted",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:proof-complete",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:join-complete",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:capture-ready",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:room-empty",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:interruption",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "sfu_disconnected"
+        },
+        {
+          "type": "suite-recorder:interruption",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "media_attachment_failed"
+        },
+        {
+          "type": "suite-recorder:interruption",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "media_subscription_failed"
+        },
+        {
+          "type": "suite-recorder:interruption",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "receive_transport_failed"
+        },
+        {
+          "type": "suite-recorder:failure",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "configuration_failed"
+        },
+        {
+          "type": "suite-recorder:failure",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "browser_disconnected"
+        },
+        {
+          "type": "suite-recorder:failure",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "page_crashed",
+          "diagnostic": "renderer page crashed"
+        }
+      ],
+      "rejected": [
+        {
+          "type": "suite-recorder:capture-ready",
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:capture-ready",
+          "protocol_version": 2,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z"
+        },
+        {
+          "type": "suite-recorder:capture-ready",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00Z"
+        },
+        {
+          "type": "suite-recorder:failure",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "unknown"
+        },
+        {
+          "type": "suite-recorder:capture-ready",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "unknown": true
+        }
+      ]
+    },
+    "proof_challenges": {
+      "accepted": [
+        {
+          "protocol_version": 1,
+          "jti": "jti-vector",
+          "socket_id": "socket-vector",
+          "nonce": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "issued_at": 1700000000,
+          "expires_at": 1700000010
+        }
+      ],
+      "rejected": [
+        {
+          "protocol_version": 2,
+          "jti": "jti-vector",
+          "socket_id": "socket-vector",
+          "nonce": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "issued_at": 1700000000,
+          "expires_at": 1700000010
+        },
+        {
+          "protocol_version": 1,
+          "jti": "jti-vector",
+          "socket_id": "socket-vector",
+          "nonce": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          "issued_at": 1700000000,
+          "expires_at": 1700000010,
+          "unknown": true
+        }
+      ]
+    },
+    "command_claims": {
+      "accepted": [{
+        "protocol_version": 1,
+        "iss": "frappe-site:site.test",
+        "aud": "meet-recorder-control",
+        "site": "site.test",
+        "origin": "https://site.test",
+        "room": "room-vector",
+        "recording": "recording-vector",
+        "job": "job-vector",
+        "operation": "reserve",
+        "limits": {
+          "budget_bytes": 1000000,
+          "max_ends_at": "2026-08-30T12:00:00.000Z",
+          "output": { "width": 1920, "height": 1080, "fps": 30, "video": "h264", "audio": "aac" }
+        },
+        "jti": "jti-vector",
+        "iat": 1700000000,
+        "exp": 1700000030
+      }],
+      "rejected": [
+        { "protocol_version": 2 },
+        { "protocol_version": 1, "unknown": true }
+      ]
+    },
+    "command_requests": {
+      "accepted": [
+        { "operation": "reserve", "body": { "protocol_version": 1, "job": "job-vector" } },
+        { "operation": "grant", "body": { "protocol_version": 1, "grant": "grant-vector", "endpoint_generation": 0 } },
+        { "operation": "stop", "body": { "protocol_version": 1, "job": "job-vector", "operation_id": "stop-vector" } }
+      ],
+      "rejected": [
+        { "operation": "reserve", "body": { "job": "job-vector" } },
+        { "operation": "grant", "body": { "protocol_version": 2, "grant": "grant-vector", "endpoint_generation": 0 } },
+        { "operation": "stop", "body": { "protocol_version": 1, "job": "job-vector", "operation_id": "stop-vector", "unknown": true } }
+      ]
+    },
+    "command_responses": {
+      "accepted": [{
+        "protocol_version": 1,
+        "status": "accepted",
+        "job": "job-vector",
+        "accepted_at": "2026-08-30T12:00:00.000Z",
+        "public_jwk": {
+          "kty": "EC",
+          "crv": "P-256",
+          "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY",
+          "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU"
+        },
+        "endpoint_generation": 0,
+        "state": "reserved",
+        "event_sequence": 1
+      }],
+      "rejected": [
+        { "status": "accepted", "job": "job-vector" },
+        { "protocol_version": 2, "status": "rejected", "job": "job-vector", "reason_code": "capacity" }
+      ]
+    },
+    "command_rejected_responses": {
+      "accepted": [
+        { "http_status": 429, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "capacity" } },
+        { "http_status": 507, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "storage" } },
+        { "http_status": 422, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "policy" } },
+        { "http_status": 422, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "invalid_job" } }
+      ],
+      "rejected": [
+        { "http_status": 429, "body": { "protocol_version": 2, "status": "rejected", "job": "job-vector", "reason_code": "capacity" } },
+        { "http_status": 429, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "unknown" } },
+        { "http_status": 507, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "capacity" } },
+        { "http_status": 409, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "invalid_job" } }
+      ]
+    },
+    "grant_responses": {
+      "accepted": [{ "http_status": 200, "body": { "protocol_version": 1, "status": "accepted" } }],
+      "rejected": [
+        { "http_status": 200, "body": { "status": "accepted" } },
+        { "http_status": 200, "body": { "protocol_version": 1, "status": "accepted", "unknown": true } }
+      ]
+    },
+    "stop_responses": {
+      "accepted": [{ "http_status": 202, "body": { "protocol_version": 1, "status": "accepted", "job": "job-vector", "operation_id": "stop-vector" } }],
+      "rejected": [
+        { "http_status": 202, "body": { "status": "accepted", "job": "job-vector", "operation_id": "stop-vector" } },
+        { "http_status": 202, "body": { "protocol_version": 1, "status": "accepted", "job": "job-vector", "operation_id": "stop-vector", "unknown": true } }
+      ]
+    },
+    "callback_claims": {
+      "accepted": [{
+        "protocol_version": 1,
+        "iss": "meet-recorder:site.test",
+        "aud": "meet-recording-callback",
+        "site": "site.test",
+        "recording": "recording-vector",
+        "job": "job-vector",
+        "operation": "stopped",
+        "operation_id": "2",
+        "body_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "jti": "jti-vector",
+        "iat": 1700000000,
+        "exp": 1700000030
+      }],
+      "rejected": [
+        { "protocol_version": 2 },
+        { "protocol_version": 1, "unknown": true }
+      ]
+    },
+    "callback_requests": {
+      "accepted": [
+        { "operation": "startup_progress", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "milestone": "configured", "occurred_at": "2026-08-30T12:00:00.000Z" } },
+        { "operation": "interrupted", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "reason_code": "capture_interrupted", "interruption_id": "4cad3218-a956-4dec-a522-18f0dd3b75a2", "interrupted_at": "2026-08-30T12:00:00.000Z", "interruption_deadline": "2026-08-30T12:01:00.000Z", "omission_started_at": "2026-08-30T11:59:30.000Z" } },
+        { "operation": "recovered", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 3, "interruption_id": "4cad3218-a956-4dec-a522-18f0dd3b75a2", "resumed_capture_started_at": "2026-08-30T12:00:30.000Z", "recovered_at": "2026-08-30T12:00:31.000Z" } },
+        { "operation": "replacement_ready", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 3, "interruption_id": "4cad3218-a956-4dec-a522-18f0dd3b75a2", "endpoint_generation": 1, "public_jwk": { "kty": "EC", "crv": "P-256", "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY", "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU" }, "ready_at": "2026-08-30T12:00:10.000Z" } },
+        { "operation": "failed", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "reason_code": "capture_failed" } },
+        { "operation": "stopped", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "captured_bytes": 10, "size": 10, "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "duration_ms": 1000, "ended_at": "2026-08-30T12:00:00.000Z", "end_reason_code": "host_stop", "gaps": [] } },
+        { "operation": "segment_progress", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "captured_bytes": 10 } },
+        { "operation": "complete_upload", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 3 } }
+      ],
+      "rejected": [
+        { "operation": "startup_progress", "body": { "protocol_version": 2, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "milestone": "configured", "occurred_at": "2026-08-30T12:00:00.000Z" } },
+        { "operation": "interrupted", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "reason_code": "capture_interrupted", "interruption_id": "4cad3218-a956-4dec-a522-18f0dd3b75a2", "interrupted_at": "2026-08-30T12:00:00.000Z", "interruption_deadline": "2026-08-30T12:00:59.000Z", "omission_started_at": "2026-08-30T11:59:30.000Z" } },
+        { "operation": "recovered", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 3, "interruption_id": "4cad3218-a956-4dec-a522-18f0dd3b75a2", "resumed_capture_started_at": "2026-08-30T12:00:31.000Z", "recovered_at": "2026-08-30T12:00:30.000Z" } },
+        { "operation": "stopped", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "captured_bytes": 10, "size": 0, "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "duration_ms": 1000, "ended_at": "2026-08-30T12:00:00.000Z", "end_reason_code": "host_stop", "gaps": [] } },
+        { "operation": "stopped", "body": { "protocol_version": 1, "recording_id": "recording-vector", "job": "job-vector", "event_sequence": 2, "captured_bytes": 10, "size": 10, "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "duration_ms": 1000, "ended_at": "2026-08-30T12:00:00Z", "end_reason_code": "host_stop", "gaps": [] } }
+      ]
+    },
+    "callback_upload_queries": {
+      "accepted": [{ "protocol_version": "1", "recording_id": "recording-vector", "job": "job-vector", "offset": "0", "chunk_sha256": "6c87f68371b28954707ebb92afee7ccffb74c6f71ec8fea8a98cf6104289585b" }],
+      "rejected": [
+        { "recording_id": "recording-vector", "job": "job-vector", "offset": "0", "chunk_sha256": "6c87f68371b28954707ebb92afee7ccffb74c6f71ec8fea8a98cf6104289585b" },
+        { "protocol_version": "1", "recording_id": "recording-vector", "job": "job-vector", "offset": "-1", "chunk_sha256": "6c87f68371b28954707ebb92afee7ccffb74c6f71ec8fea8a98cf6104289585b" },
+        { "protocol_version": "1", "recording_id": "recording-vector", "job": "job-vector", "offset": "0", "chunk_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+      ]
+    },
+    "renderer_configure": {
+      "accepted": [{ "type": "suite-recorder:configure", "protocol_version": 1, "config": { "job": "job-vector", "grant": "grant-vector", "meetingId": "room-vector", "sfuOrigin": "https://sfu.test", "frappeOrigin": "https://site.test", "socketPath": "/socket.io", "acceptedAt": "2026-08-30T12:00:00.000Z" } }],
+      "rejected": [
+        { "type": "suite-recorder:configure", "protocol_version": 2, "config": {} },
+        { "type": "suite-recorder:configure", "protocol_version": 1, "config": { "job": "job-vector" }, "unknown": true }
+      ]
+    },
+    "renderer_public_key_ready": {
+      "accepted": [{ "type": "suite-recorder:public-key-ready", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.000Z", "publicKey": { "kty": "EC", "crv": "P-256", "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY", "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU" } }],
+      "rejected": [
+        { "type": "suite-recorder:public-key-ready", "protocol_version": 2, "occurred_at": "2026-08-30T12:00:00.000Z", "publicKey": { "kty": "EC", "crv": "P-256", "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY", "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU" } },
+        { "type": "suite-recorder:public-key-ready", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00Z", "publicKey": {} }
+      ]
+    },
+    "recording_grant_claims": {
+      "accepted": [{
+        "protocol_version": 1,
+        "iss": "frappe-site:site.test",
+        "aud": "meet-sfu-recorder",
+        "scope": "recording",
+        "jti": "jti-vector",
+        "site": "site.test",
+        "meeting_id": "room-vector",
+        "recording_id": "recording-vector",
+        "recorder_job_id": "job-vector",
+        "cnf": {
+          "jwk": { "kty": "EC", "crv": "P-256", "x": "dekZC7nsWz9JfUnSQDU0HAyC2rFohnQ1xG1oiGPCASs", "y": "uQYwl6W7tkTphKATetD73cCx6_QObRdD9VqsCTA0mlE" },
+          "jkt": "5_dTnFp8YLZgTpIYA00V-_KwFyfTvqnxBPQECGyfOlU"
+        },
+        "iat": 1700000000,
+        "exp": 1700000060,
+        "authorization_expires_at": 1700003600
+      }],
+      "rejected": [
+        { "protocol_version": 2 },
+        { "protocol_version": 1, "unknown": true }
+      ]
+    },
+    "proof_requests": {
+      "accepted": [{ "protocol_version": 1, "signature": "signature-vector" }],
+      "rejected": [
+        { "signature": "signature-vector" },
+        { "protocol_version": 1, "signature": "signature-vector", "unknown": true }
+      ]
+    },
+    "proof_responses": {
+      "accepted": [
+        { "protocol_version": 1, "success": true },
+        { "protocol_version": 1, "success": false, "reason_code": "invalid_proof" }
+      ],
+      "rejected": [
+        { "success": true },
+        { "protocol_version": 1, "success": false, "reason_code": "unknown" }
+      ]
+    },
+    "finite_values": {
+      "command_operations": ["reserve", "query", "grant", "stop"],
+      "command_states": ["reserved", "configured", "proof_complete", "joined", "capture_ready", "interrupted", "failed", "recovery_required", "stopping", "complete", "partial"],
+      "command_rejection_reason_codes": ["capacity", "storage", "policy", "invalid_job"],
+      "health_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "duration_limit", "ffmpeg_exited", "interruption_timeout", "media_attachment_failed", "media_subscription_failed", "page_crashed", "quota_limit", "receive_transport_failed", "room_empty", "service_shutdown", "sfu_disconnected", "worker_missing_after_restart"],
+      "startup_milestones": ["configured", "proof_complete", "joined", "capture_started"],
+      "interruption_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "ffmpeg_exited", "media_attachment_failed", "media_subscription_failed", "page_crashed", "receive_transport_failed", "sfu_disconnected"],
+      "renderer_reason_codes": ["sfu_disconnected", "media_attachment_failed", "media_subscription_failed", "receive_transport_failed", "configuration_failed", "browser_disconnected", "page_crashed"],
+      "callback_failure_reason_codes": ["capture_failed", "processing_failed", "storage_unavailable", "quota_exhausted"],
+      "end_reason_codes": ["duration_limit", "host_stop", "interruption_timeout", "quota_limit", "room_empty", "service_shutdown"],
+      "gap_reason_codes": ["capture_interrupted", "ffmpeg_exited", "renderer_interrupted"],
+      "frappe_recording_states": ["Pending", "Starting", "Recording", "Interrupted", "Stopping", "Processing", "Ready", "Partial", "Failed", "Cancelled"],
+      "proof_reason_codes": ["invalid_proof"]
+    },
+    "callback_status_responses": {
+      "accepted": [
+        { "protocol_version": 1, "status": "Pending" },
+        { "protocol_version": 1, "status": "Starting" },
+        { "protocol_version": 1, "status": "Recording" },
+        { "protocol_version": 1, "status": "Interrupted" },
+        { "protocol_version": 1, "status": "Stopping" },
+        { "protocol_version": 1, "status": "Processing" },
+        { "protocol_version": 1, "status": "Ready" },
+        { "protocol_version": 1, "status": "Partial" },
+        { "protocol_version": 1, "status": "Failed" },
+        { "protocol_version": 1, "status": "Cancelled" }
+      ],
+      "rejected": [
+        { "status": "Recording" },
+        { "protocol_version": 2, "status": "Recording" },
+        { "protocol_version": 1, "status": "Unknown" },
+        { "protocol_version": 1, "status": "Recording", "unknown": true }
+      ]
+    }
+  }
+}

--- a/suite/meet/recording/grants.py
+++ b/suite/meet/recording/grants.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 
 GRANT_AUDIENCE = "meet-sfu-recorder"
 GRANT_TYPE = "meet-recording-grant+jwt"
+PROTOCOL_VERSION = 1
 MAX_CONNECTION_LIFETIME_SECONDS = 60
 
 
@@ -104,6 +105,7 @@ def mint_recording_grant(
 
     normalized_jwk = normalize_public_jwk(public_jwk)
     payload = {
+        "protocol_version": PROTOCOL_VERSION,
         "iss": f"frappe-site:{site}",
         "aud": GRANT_AUDIENCE,
         "scope": "recording",

--- a/suite/meet/recording/ingest.py
+++ b/suite/meet/recording/ingest.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import math
 import os
+import re
 import shutil
 import subprocess
 from contextlib import suppress
@@ -377,7 +378,12 @@ def _validate_media(path: Path) -> dict:
 
 
 def _callback_datetime(value):
-    parsed = get_datetime(value)
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", value):
+        frappe.throw(_("Recording callback timestamps must use canonical UTC milliseconds"))
+    try:
+        parsed = get_datetime(value)
+    except (TypeError, ValueError, OverflowError):
+        frappe.throw(_("Recording callback timestamp is invalid"))
     if parsed.tzinfo is None:
         frappe.throw(_("Recording callback timestamps must include a timezone"))
     return parsed.astimezone(UTC).replace(tzinfo=None)

--- a/suite/meet/recording/recorder_client.py
+++ b/suite/meet/recording/recorder_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -16,9 +17,41 @@ from suite.meet.recording.grants import normalize_public_jwk
 
 COMMAND_AUDIENCE = "meet-recorder-control"
 COMMAND_TYPE = "meet-recorder-command+jwt"
+PROTOCOL_VERSION = 1
 MAX_RESPONSE_BYTES = 16 * 1024
 TIMEOUT = (2, 5)
 REJECTION_REASONS = {"capacity", "storage", "policy", "invalid_job"}
+REJECTION_STATUSES = {"capacity": 429, "storage": 507, "policy": 422, "invalid_job": 422}
+HEALTH_REASON_CODES = {
+    "browser_disconnected",
+    "capture_interrupted",
+    "configuration_failed",
+    "duration_limit",
+    "ffmpeg_exited",
+    "interruption_timeout",
+    "media_attachment_failed",
+    "media_subscription_failed",
+    "page_crashed",
+    "quota_limit",
+    "receive_transport_failed",
+    "room_empty",
+    "service_shutdown",
+    "sfu_disconnected",
+    "worker_missing_after_restart",
+}
+COMMAND_STATES = {
+    "reserved",
+    "configured",
+    "proof_complete",
+    "joined",
+    "capture_ready",
+    "interrupted",
+    "failed",
+    "recovery_required",
+    "stopping",
+    "complete",
+    "partial",
+}
 
 
 @dataclass(frozen=True)
@@ -26,9 +59,8 @@ class RecorderOutcome:
     outcome: Literal["accepted", "rejected", "indeterminate"]
     accepted_at: datetime | None = None
     public_jwk: dict[str, str] | None = None
-    reason: str | None = None
+    reason_code: str | None = None
     state: str | None = None
-    health_reason: str | None = None
     event_sequence: int | None = None
     milestones: dict[str, datetime] | None = None
     interruption: dict[str, Any] | None = None
@@ -74,12 +106,13 @@ class RecorderClient:
             recording,
             job,
             limits,
-            {"job": job, "operation_id": operation_id},
+            {"protocol_version": PROTOCOL_VERSION, "job": job, "operation_id": operation_id},
         )
         if result is None:
             return False
         response, body = result
         return response.status_code in (200, 202) and body == {
+            "protocol_version": PROTOCOL_VERSION,
             "status": "accepted",
             "job": job,
             "operation_id": operation_id,
@@ -103,12 +136,19 @@ class RecorderClient:
             recording,
             job,
             limits,
-            {"grant": grant, "endpoint_generation": endpoint_generation},
+            {
+                "protocol_version": PROTOCOL_VERSION,
+                "grant": grant,
+                "endpoint_generation": endpoint_generation,
+            },
         )
         if outcome is None:
             return False
         response, body = outcome
-        return response.status_code in (200, 204) and (body is None or body == {"status": "accepted"})
+        return response.status_code == 200 and body == {
+            "protocol_version": PROTOCOL_VERSION,
+            "status": "accepted",
+        }
 
     def _request(
         self,
@@ -120,13 +160,23 @@ class RecorderClient:
         job: str,
         limits: dict[str, Any],
     ) -> RecorderOutcome:
-        result = self._raw_request(operation, method, path, room, recording, job, limits, {"job": job})
+        result = self._raw_request(
+            operation,
+            method,
+            path,
+            room,
+            recording,
+            job,
+            limits,
+            {"protocol_version": PROTOCOL_VERSION, "job": job},
+        )
         if result is None:
             return RecorderOutcome("indeterminate")
         response, body = result
         if not isinstance(body, dict) or body.get("job") != job:
             return RecorderOutcome("indeterminate")
         accepted_keys = {
+            "protocol_version",
             "status",
             "job",
             "accepted_at",
@@ -136,9 +186,8 @@ class RecorderClient:
             "event_sequence",
         }
         optional_keys = {
-            "health_reason",
+            "reason_code",
             "milestones",
-            "artifact",
             "interruption",
             "replacement_ready_at",
         }
@@ -147,29 +196,26 @@ class RecorderClient:
             and accepted_keys.issubset(body)
             and set(body).issubset(accepted_keys | optional_keys)
         ):
-            if body["status"] != "accepted":
-                return RecorderOutcome("indeterminate")
-            states = {
-                "reserved",
-                "configured",
-                "proof_complete",
-                "joined",
-                "capture_ready",
-                "interrupted",
-                "failed",
-                "recovery_required",
-                "stopping",
-            }
             if (
-                body["state"] not in states
-                or not isinstance(body["event_sequence"], int)
+                type(body["protocol_version"]) is not int
+                or body["protocol_version"] != PROTOCOL_VERSION
+                or body["status"] != "accepted"
+            ):
+                return RecorderOutcome("indeterminate")
+            if (
+                not isinstance(body["state"], str)
+                or body["state"] not in COMMAND_STATES
+                or type(body["event_sequence"]) is not int
                 or body["event_sequence"] < 1
                 or isinstance(body["endpoint_generation"], bool)
                 or not isinstance(body["endpoint_generation"], int)
                 or body["endpoint_generation"] < 0
                 or (
-                    "health_reason" in body
-                    and (not isinstance(body["health_reason"], str) or len(body["health_reason"]) > 256)
+                    "reason_code" in body
+                    and (
+                        not isinstance(body["reason_code"], str)
+                        or body["reason_code"] not in HEALTH_REASON_CODES
+                    )
                 )
             ):
                 return RecorderOutcome("indeterminate")
@@ -212,16 +258,28 @@ class RecorderClient:
                 public_jwk=public_jwk,
                 endpoint_generation=body["endpoint_generation"],
                 state=body["state"],
-                health_reason=body.get("health_reason"),
+                reason_code=body.get("reason_code"),
                 event_sequence=body["event_sequence"],
                 milestones=milestones,
                 interruption=interruption,
                 replacement_ready_at=replacement_ready_at,
             )
-        if response.status_code in (409, 422, 429, 507) and set(body) == {"status", "job", "reason"}:
-            reason = body["reason"]
-            if body["status"] == "rejected" and reason in REJECTION_REASONS:
-                return RecorderOutcome("rejected", reason=reason)
+        if response.status_code in (409, 422, 429, 507) and set(body) == {
+            "protocol_version",
+            "status",
+            "job",
+            "reason_code",
+        }:
+            reason_code = body["reason_code"]
+            if (
+                type(body["protocol_version"]) is int
+                and body["protocol_version"] == PROTOCOL_VERSION
+                and body["status"] == "rejected"
+                and isinstance(reason_code, str)
+                and reason_code in REJECTION_REASONS
+                and response.status_code == REJECTION_STATUSES[reason_code]
+            ):
+                return RecorderOutcome("rejected", reason_code=reason_code)
         return RecorderOutcome("indeterminate")
 
     def _raw_request(
@@ -268,6 +326,7 @@ class RecorderClient:
     ) -> str:
         now = int(time.time())
         payload = {
+            "protocol_version": PROTOCOL_VERSION,
             "iss": f"frappe-site:{self.site}",
             "aud": COMMAND_AUDIENCE,
             "site": self.site,
@@ -306,7 +365,7 @@ def _validate_url(value: str, *, allow_http: bool, allow_loopback_http: bool = F
 
 
 def _utc_datetime(value: Any) -> datetime:
-    if not isinstance(value, str) or not value.endswith("Z"):
+    if not isinstance(value, str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", value):
         raise ValueError("accepted_at must be UTC RFC 3339")
     parsed = datetime.fromisoformat(value[:-1] + "+00:00")
     if parsed.tzinfo != UTC:

--- a/suite/meet/recording/test_grants.py
+++ b/suite/meet/recording/test_grants.py
@@ -64,6 +64,7 @@ class TestRecordingGrants(unittest.TestCase):
         self.assertEqual(
             claims,
             {
+                "protocol_version": 1,
                 "iss": "frappe-site:meet.example.test",
                 "aud": "meet-sfu-recorder",
                 "scope": "recording",

--- a/suite/meet/recording/test_protocol_contract.py
+++ b/suite/meet/recording/test_protocol_contract.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import Mock
+
+import frappe
+import requests
+
+from suite.meet.api.recording import (
+    END_REASON_CODES,
+    GAP_REASON_CODES,
+    INTERRUPTION_REASON_CODES,
+    STARTUP_MILESTONES,
+    _startup_timestamp,
+)
+from suite.meet.recording.callback_auth import (
+    CALLBACK_BODY_KEYS,
+    FAILURE_REASON_CODES,
+    _validate_callback_payload,
+    valid_callback_claims,
+    valid_upload_query,
+)
+from suite.meet.recording.ingest import _callback_datetime
+from suite.meet.recording.recorder_client import (
+    COMMAND_STATES,
+    HEALTH_REASON_CODES,
+    REJECTION_REASONS,
+    RecorderClient,
+    _utc_datetime,
+)
+
+CONTRACT = json.loads((Path(__file__).parent / "contracts" / "v1.json").read_text())
+
+
+class TestRecordingProtocolContract(TestCase):
+    def test_shared_timestamp_vectors_use_the_production_parser(self):
+        for value in CONTRACT["vectors"]["timestamps"]["accepted"]:
+            self.assertEqual(_utc_datetime(value).isoformat(timespec="milliseconds"), value[:-1] + "+00:00")
+            self.assertEqual(
+                _startup_timestamp(value).isoformat(timespec="milliseconds"), value[:-1] + "+00:00"
+            )
+            self.assertEqual(_callback_datetime(value).isoformat(timespec="milliseconds"), value[:-1])
+        for value in CONTRACT["vectors"]["timestamps"]["rejected"]:
+            with self.assertRaises((TypeError, ValueError)):
+                _utc_datetime(value)
+            with self.assertRaises(frappe.ValidationError):
+                _startup_timestamp(value)
+            with self.assertRaises(frappe.ValidationError):
+                _callback_datetime(value)
+
+    def test_finite_command_vocabularies_match_production(self):
+        self.assertEqual(set(CONTRACT["vocabularies"]["command_states"]), COMMAND_STATES)
+        self.assertEqual(set(CONTRACT["vocabularies"]["health_reason_codes"]), HEALTH_REASON_CODES)
+        self.assertEqual(set(CONTRACT["vocabularies"]["command_rejection_reason_codes"]), REJECTION_REASONS)
+        self.assertEqual(set(CONTRACT["vocabularies"]["startup_milestones"]), set(STARTUP_MILESTONES))
+        self.assertEqual(
+            set(CONTRACT["vocabularies"]["interruption_reason_codes"]), INTERRUPTION_REASON_CODES
+        )
+        self.assertEqual(set(CONTRACT["vocabularies"]["callback_failure_reason_codes"]), FAILURE_REASON_CODES)
+        self.assertEqual(set(CONTRACT["vocabularies"]["end_reason_codes"]), END_REASON_CODES)
+        self.assertEqual(set(CONTRACT["vocabularies"]["gap_reason_codes"]), GAP_REASON_CODES)
+        self.assertEqual(CONTRACT["vectors"]["finite_values"], CONTRACT["vocabularies"])
+
+    def test_shared_callback_claim_and_request_vectors_use_production_validators(self):
+        claims = CONTRACT["vectors"]["callback_claims"]
+        expected = {
+            "site": "site.test",
+            "recording": "recording-vector",
+            "job": "job-vector",
+            "operation": "stopped",
+            "operation_id": "2",
+            "protocol_version": 1,
+            "now": 1700000000,
+        }
+        for value in claims["accepted"]:
+            self.assertTrue(valid_callback_claims(value, **expected))
+        for value in claims["rejected"]:
+            self.assertFalse(valid_callback_claims(value, **expected))
+
+        request_vectors = CONTRACT["vectors"]["callback_requests"]
+        for value in request_vectors["accepted"]:
+            self.assertEqual(set(value["body"]), CALLBACK_BODY_KEYS[value["operation"]])
+            _validate_callback_payload(value["operation"], value["body"])
+        for value in request_vectors["rejected"]:
+            with self.assertRaises((frappe.AuthenticationError, ValueError)):
+                if set(value["body"]) != CALLBACK_BODY_KEYS[value["operation"]]:
+                    raise ValueError
+                _validate_callback_payload(value["operation"], value["body"])
+
+        accepted_by_operation = {value["operation"]: value["body"] for value in request_vectors["accepted"]}
+        finite = CONTRACT["vectors"]["finite_values"]
+        for milestone in finite["startup_milestones"]:
+            _validate_callback_payload(
+                "startup_progress",
+                {**accepted_by_operation["startup_progress"], "milestone": milestone},
+            )
+        for reason_code in finite["interruption_reason_codes"]:
+            _validate_callback_payload(
+                "interrupted",
+                {**accepted_by_operation["interrupted"], "reason_code": reason_code},
+            )
+        for reason_code in finite["callback_failure_reason_codes"]:
+            _validate_callback_payload(
+                "failed",
+                {**accepted_by_operation["failed"], "reason_code": reason_code},
+            )
+        for reason_code in finite["end_reason_codes"]:
+            _validate_callback_payload(
+                "stopped",
+                {**accepted_by_operation["stopped"], "end_reason_code": reason_code},
+            )
+        for reason_code in finite["gap_reason_codes"]:
+            _validate_callback_payload(
+                "stopped",
+                {
+                    **accepted_by_operation["stopped"],
+                    "gaps": [
+                        {
+                            "started_at": "2026-08-30T11:59:00.000Z",
+                            "ended_at": "2026-08-30T11:59:30.000Z",
+                            "reason_code": reason_code,
+                        }
+                    ],
+                },
+            )
+
+        upload_vectors = CONTRACT["vectors"]["callback_upload_queries"]
+        for value in upload_vectors["accepted"]:
+            self.assertTrue(
+                valid_upload_query(
+                    value,
+                    content_type="application/octet-stream",
+                    content_length=5,
+                    body=b"chunk",
+                )
+            )
+        for value in upload_vectors["rejected"]:
+            self.assertFalse(
+                valid_upload_query(
+                    value,
+                    content_type="application/octet-stream",
+                    content_length=5,
+                    body=b"chunk",
+                )
+            )
+
+    def test_shared_command_response_vectors_use_the_production_parser(self):
+        session = Mock(spec=requests.Session)
+        client = RecorderClient(
+            base_url="http://recorder.test",
+            secret="a-long-enough-test-secret-for-hs256",
+            site="site.test",
+            origin="http://site.test",
+            allow_http=True,
+            session=session,
+        )
+        arguments = {
+            "room": "room-vector",
+            "recording": "recording-vector",
+            "job": "job-vector",
+            "limits": {"x": 1},
+        }
+        for value in CONTRACT["vectors"]["command_responses"]["accepted"]:
+            session.request.return_value = _response(202, value)
+            self.assertEqual(client.reserve(**arguments).outcome, "accepted")
+        for value in CONTRACT["vectors"]["command_responses"]["rejected"]:
+            session.request.return_value = _response(202, value)
+            self.assertEqual(client.reserve(**arguments).outcome, "indeterminate")
+
+        base = CONTRACT["vectors"]["command_responses"]["accepted"][0]
+        for state in CONTRACT["vectors"]["finite_values"]["command_states"]:
+            session.request.return_value = _response(202, {**base, "state": state})
+            self.assertEqual(client.reserve(**arguments).state, state)
+        for reason_code in CONTRACT["vectors"]["finite_values"]["health_reason_codes"]:
+            session.request.return_value = _response(202, {**base, "reason_code": reason_code})
+            self.assertEqual(client.reserve(**arguments).reason_code, reason_code)
+
+        for value in CONTRACT["vectors"]["command_rejected_responses"]["accepted"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertEqual(client.reserve(**arguments).outcome, "rejected")
+        for value in CONTRACT["vectors"]["command_rejected_responses"]["rejected"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertEqual(client.reserve(**arguments).outcome, "indeterminate")
+
+        for value in CONTRACT["vectors"]["grant_responses"]["accepted"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertTrue(client.deliver_grant(**arguments, grant="grant", endpoint_generation=0))
+        for value in CONTRACT["vectors"]["grant_responses"]["rejected"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertFalse(client.deliver_grant(**arguments, grant="grant", endpoint_generation=0))
+
+        for value in CONTRACT["vectors"]["stop_responses"]["accepted"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertTrue(client.stop(**arguments, operation_id="stop-vector"))
+        for value in CONTRACT["vectors"]["stop_responses"]["rejected"]:
+            session.request.return_value = _response(value["http_status"], value["body"])
+            self.assertFalse(client.stop(**arguments, operation_id="stop-vector"))
+
+    def test_startup_mapping_covers_every_recorder_milestone(self):
+        mapping = CONTRACT["mappings"]["startup_milestone_to_frappe_state"]
+        self.assertEqual(set(mapping), set(CONTRACT["vocabularies"]["startup_milestones"]))
+        self.assertEqual(set(mapping.values()), {"Starting", "Recording"})
+
+    def test_first_version_accepts_no_unversioned_predecessor(self):
+        self.assertEqual(CONTRACT["protocol_version"], 1)
+        self.assertEqual(CONTRACT["accepted_protocol_versions"], [1])
+        self.assertEqual(CONTRACT["vectors"]["protocol_versions"]["accepted"], [1])
+
+
+def _response(status: int, body) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status
+    response.headers["Content-Type"] = "application/json"
+    response._content = json.dumps(body).encode()
+    response.raw = BytesIO(response._content)
+    return response

--- a/suite/meet/recording/test_recorder_client.py
+++ b/suite/meet/recording/test_recorder_client.py
@@ -43,6 +43,7 @@ class TestRecorderClient(unittest.TestCase):
         self.session.request.return_value = response(
             202,
             {
+                "protocol_version": 1,
                 "status": "accepted",
                 "job": "job",
                 "accepted_at": "2026-07-31T10:11:12.123Z",
@@ -83,27 +84,30 @@ class TestRecorderClient(unittest.TestCase):
                 "jti",
                 "iat",
                 "exp",
+                "protocol_version",
             },
         )
+        self.assertEqual(claims["protocol_version"], 1)
+        self.assertEqual(call.kwargs["json"], {"protocol_version": 1, "job": "job"})
         self.assertEqual(claims["operation"], "reserve")
         self.assertEqual(call.kwargs["timeout"], (2, 5))
         self.assertFalse(call.kwargs["allow_redirects"])
 
     def test_explicit_rejection_is_bounded(self):
         self.session.request.return_value = response(
-            429, {"status": "rejected", "job": "job", "reason": "capacity"}
+            429, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "capacity"}
         )
         self.assertEqual(self.client.reserve(**self.arguments).outcome, "rejected")
 
         self.session.request.return_value = response(
-            507, {"status": "rejected", "job": "job", "reason": "storage"}
+            507, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "storage"}
         )
         outcome = self.client.reserve(**self.arguments)
         self.assertEqual(outcome.outcome, "rejected")
-        self.assertEqual(outcome.reason, "storage")
+        self.assertEqual(outcome.reason_code, "storage")
 
         self.session.request.return_value = response(
-            429, {"status": "rejected", "job": "job", "reason": "anything"}
+            429, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "anything"}
         )
         self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
 
@@ -111,6 +115,7 @@ class TestRecorderClient(unittest.TestCase):
         self.session.request.return_value = response(
             200,
             {
+                "protocol_version": 1,
                 "status": "accepted",
                 "job": "job",
                 "accepted_at": "2026-07-31T10:11:12.123Z",
@@ -140,6 +145,7 @@ class TestRecorderClient(unittest.TestCase):
 
     def test_endpoint_generation_must_be_a_nonnegative_integer(self):
         body = {
+            "protocol_version": 1,
             "status": "accepted",
             "job": "job",
             "accepted_at": "2026-07-31T10:11:12.123Z",
@@ -163,6 +169,62 @@ class TestRecorderClient(unittest.TestCase):
             with self.subTest(result=result):
                 self.session.request.side_effect = result if isinstance(result, Exception) else None
                 self.session.request.return_value = None if isinstance(result, Exception) else result
+                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+
+    def test_rejects_missing_wrong_and_unknown_response_protocol_fields(self):
+        accepted = {
+            "protocol_version": 1,
+            "status": "accepted",
+            "job": "job",
+            "accepted_at": "2026-07-31T10:11:12.123Z",
+            "public_jwk": PUBLIC_JWK,
+            "endpoint_generation": 0,
+            "state": "reserved",
+            "event_sequence": 1,
+        }
+        for body in (
+            {key: value for key, value in accepted.items() if key != "protocol_version"},
+            {**accepted, "protocol_version": 2},
+            {**accepted, "extra": True},
+        ):
+            with self.subTest(body=body):
+                self.session.request.return_value = response(202, body)
+                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+
+    def test_unhashable_state_and_reason_values_are_indeterminate(self):
+        accepted = {
+            "protocol_version": 1,
+            "status": "accepted",
+            "job": "job",
+            "accepted_at": "2026-07-31T10:11:12.123Z",
+            "public_jwk": PUBLIC_JWK,
+            "endpoint_generation": 0,
+            "state": "reserved",
+            "event_sequence": 1,
+        }
+        for body in ({**accepted, "state": []}, {**accepted, "reason_code": {}}):
+            with self.subTest(body=body):
+                self.session.request.return_value = response(202, body)
+                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+
+    def test_timestamp_requires_exact_millisecond_precision(self):
+        base = {
+            "protocol_version": 1,
+            "status": "accepted",
+            "job": "job",
+            "public_jwk": PUBLIC_JWK,
+            "endpoint_generation": 0,
+            "state": "reserved",
+            "event_sequence": 1,
+        }
+        for timestamp in (
+            "2026-07-31T10:11:12Z",
+            "2026-07-31T10:11:12.12Z",
+            "2026-07-31T10:11:12.1234Z",
+            "2026-07-31T10:11:12.123+00:00",
+        ):
+            with self.subTest(timestamp=timestamp):
+                self.session.request.return_value = response(202, {**base, "accepted_at": timestamp})
                 self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
 
     def test_rejects_untrusted_urls(self):
@@ -193,14 +255,14 @@ class TestRecorderClient(unittest.TestCase):
             )
 
     def test_grant_delivery_requires_explicit_success(self):
-        self.session.request.return_value = response(200, {"status": "accepted"})
+        self.session.request.return_value = response(200, {"protocol_version": 1, "status": "accepted"})
         self.assertTrue(self.client.deliver_grant(**self.arguments, grant="token", endpoint_generation=2))
         self.assertEqual(
             self.session.request.call_args.args[:2], ("POST", "http://recorder.test/v1/recordings/job/grant")
         )
         self.assertEqual(
             self.session.request.call_args.kwargs["json"],
-            {"grant": "token", "endpoint_generation": 2},
+            {"protocol_version": 1, "grant": "token", "endpoint_generation": 2},
         )
 
         self.session.request.return_value = response(500, {"status": "error"})
@@ -208,11 +270,13 @@ class TestRecorderClient(unittest.TestCase):
 
     def test_stop_requires_exact_acknowledgement_and_sends_operation_id(self):
         self.session.request.return_value = response(
-            202, {"status": "accepted", "job": "job", "operation_id": "stop-1"}
+            202,
+            {"protocol_version": 1, "status": "accepted", "job": "job", "operation_id": "stop-1"},
         )
         self.assertTrue(self.client.stop(**self.arguments, operation_id="stop-1"))
         self.assertEqual(
-            self.session.request.call_args.kwargs["json"], {"job": "job", "operation_id": "stop-1"}
+            self.session.request.call_args.kwargs["json"],
+            {"protocol_version": 1, "job": "job", "operation_id": "stop-1"},
         )
 
         for result in (

--- a/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
+++ b/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
@@ -6,6 +6,7 @@ import {
 	verify as verifySignature,
 } from 'node:crypto';
 import * as jwt from 'jsonwebtoken';
+import type { RecordingProofChallenge } from '../../../types';
 import type { RecordingGrantPersistenceFile } from './RecordingGrantPersistenceFile';
 
 const GRANT_TYPE = 'meet-recording-grant+jwt';
@@ -13,8 +14,33 @@ const GRANT_AUDIENCE = 'meet-sfu-recorder';
 const MAX_AUTHORIZATION_SECONDS = 4 * 60 * 60;
 const CHALLENGE_SECONDS = 10;
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const ACCEPTED_PROTOCOL_VERSIONS = new Set([1]);
+const GRANT_CLAIM_KEYS = [
+	'protocol_version',
+	'iss',
+	'aud',
+	'scope',
+	'jti',
+	'site',
+	'meeting_id',
+	'recording_id',
+	'recorder_job_id',
+	'cnf',
+	'iat',
+	'exp',
+	'authorization_expires_at',
+] as const;
+const CHALLENGE_KEYS = [
+	'protocol_version',
+	'jti',
+	'socket_id',
+	'nonce',
+	'issued_at',
+	'expires_at',
+] as const;
 
 export type RecordingGrantClaims = {
+	protocol_version: 1;
 	iss: string;
 	aud: typeof GRANT_AUDIENCE;
 	scope: 'recording';
@@ -29,14 +55,7 @@ export type RecordingGrantClaims = {
 	authorization_expires_at: number;
 };
 
-export type RecordingProofChallenge = {
-	version: 1;
-	jti: string;
-	socket_id: string;
-	nonce: string;
-	issued_at: number;
-	expires_at: number;
-};
+export type { RecordingProofChallenge } from '../../../types';
 
 export class RecordingGrantManager {
 	constructor(
@@ -111,7 +130,7 @@ export class RecordingGrantManager {
 	): RecordingProofChallenge {
 		if (!socketId) throw new Error('Socket ID is required');
 		return {
-			version: 1,
+			protocol_version: 1,
 			jti: claims.jti,
 			socket_id: socketId,
 			nonce: randomBytes(32).toString('base64url'),
@@ -171,9 +190,19 @@ export function jwkThumbprint(jwk: JsonWebKey): string {
 	return createHash('sha256').update(canonical).digest('base64url');
 }
 
-function parseClaims(payload: unknown): RecordingGrantClaims {
+export function parseClaims(payload: unknown): RecordingGrantClaims {
 	if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
 		throw new Error('Invalid recording grant claims');
+	}
+	if (!hasExactKeys(payload, GRANT_CLAIM_KEYS)) {
+		throw new Error('Invalid recording grant claim shape');
+	}
+	const protocolVersion = property(payload, 'protocol_version');
+	if (
+		!Number.isSafeInteger(protocolVersion) ||
+		!ACCEPTED_PROTOCOL_VERSIONS.has(protocolVersion as number)
+	) {
+		throw new Error('Unsupported recording grant protocol version');
 	}
 	if (
 		!('aud' in payload) ||
@@ -184,6 +213,7 @@ function parseClaims(payload: unknown): RecordingGrantClaims {
 		throw new Error('Invalid recording grant audience or scope');
 	}
 	return {
+		protocol_version: 1,
 		iss: requiredClaimString(property(payload, 'iss'), 'iss'),
 		aud: GRANT_AUDIENCE,
 		scope: 'recording',
@@ -215,6 +245,14 @@ function property(value: object, key: string): unknown {
 	return key in value ? value[key as keyof typeof value] : undefined;
 }
 
+function hasExactKeys(value: object, expected: readonly string[]): boolean {
+	const keys = Object.keys(value);
+	return (
+		keys.length === expected.length &&
+		expected.every((key) => keys.includes(key))
+	);
+}
+
 function requiredClaimString(value: unknown, name: string): string {
 	if (typeof value !== 'string' || value.length === 0) {
 		throw new Error(`Missing recording grant claim: ${name}`);
@@ -233,7 +271,12 @@ function parseConfirmation(value: unknown): { jwk: JsonWebKey; jkt: string } {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) {
 		throw new Error('Missing recording grant claim: cnf');
 	}
-	if (!('jwk' in value) || !('jkt' in value) || typeof value.jkt !== 'string') {
+	if (
+		!hasExactKeys(value, ['jwk', 'jkt']) ||
+		!('jwk' in value) ||
+		!('jkt' in value) ||
+		typeof value.jkt !== 'string'
+	) {
 		throw new Error('Invalid recording grant cnf');
 	}
 	return { jwk: parsePublicJwk(value.jwk), jkt: value.jkt };
@@ -244,6 +287,7 @@ function parsePublicJwk(value: unknown): JsonWebKey {
 		throw new Error('Invalid recording grant public JWK');
 	}
 	if (
+		!hasExactKeys(value, ['crv', 'kty', 'x', 'y']) ||
 		!('kty' in value) ||
 		value.kty !== 'EC' ||
 		!('crv' in value) ||
@@ -269,16 +313,19 @@ function validatePublicJwk(jwk: JsonWebKey): void {
 	decodeBase64Url(jwk.y, 32, 'JWK y');
 }
 
-function validateChallenge(
+export function validateChallenge(
 	challenge: RecordingProofChallenge,
 	jti: string,
 	socketId: string,
 	now: number,
 ): void {
 	if (
-		challenge.version !== 1 ||
+		!hasExactKeys(challenge, CHALLENGE_KEYS) ||
+		!Number.isSafeInteger(challenge.protocol_version) ||
+		!ACCEPTED_PROTOCOL_VERSIONS.has(challenge.protocol_version) ||
 		challenge.jti !== jti ||
 		challenge.socket_id !== socketId ||
+		typeof challenge.nonce !== 'string' ||
 		!Number.isSafeInteger(challenge.issued_at) ||
 		!Number.isSafeInteger(challenge.expires_at) ||
 		challenge.expires_at - challenge.issued_at !== CHALLENGE_SECONDS ||

--- a/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
+++ b/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
@@ -31,6 +31,7 @@ import { RoomLifecycleCoordinator } from './RoomLifecycleCoordinator';
 import { RoomRegistry } from './RoomRegistry';
 
 const RECORDING_PROOF_TIMEOUT_MS = 10_000;
+const RECORDING_PROOF_KEYS = ['protocol_version', 'signature'] as const;
 
 export class SocketHandlerManager {
 	private io: Server<ClientToServerEvents, ServerToClientEvents>;
@@ -222,7 +223,7 @@ export class SocketHandlerManager {
 				socket.once('recording:proof', async (data, callback) => {
 					try {
 						const claims = socket.recordingClaims;
-						if (!claims || !challenge || typeof data?.signature !== 'string')
+						if (!claims || !challenge || !isRecordingProofRequest(data))
 							throw new Error('Invalid recording proof');
 						const expiresAt = await manager.verifyProofAndConsume(
 							claims,
@@ -239,10 +240,15 @@ export class SocketHandlerManager {
 						clearProofTimeout();
 						socket.tokenExpiresAt = expiresAt * 1000;
 						challenge = undefined;
-						callback({ success: true });
+						callback({ protocol_version: 1, success: true });
 					} catch (error) {
 						clearProofTimeout();
-						callback({ success: false, error: (error as Error).message });
+						callback({
+							protocol_version: 1,
+							success: false,
+							reason_code: 'invalid_proof',
+							diagnostic: (error as Error).message.slice(0, 256),
+						});
 						socket.disconnect(true);
 					}
 				});
@@ -286,4 +292,20 @@ export class SocketHandlerManager {
 			this.idleExpirySweep = null;
 		}
 	}
+}
+
+export function isRecordingProofRequest(
+	value: unknown,
+): value is import('../types').RecordingProofRequest {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+	const keys = Object.keys(value);
+	return (
+		keys.length === RECORDING_PROOF_KEYS.length &&
+		RECORDING_PROOF_KEYS.every((key) => keys.includes(key)) &&
+		'protocol_version' in value &&
+		value.protocol_version === 1 &&
+		'signature' in value &&
+		typeof value.signature === 'string' &&
+		value.signature.length > 0
+	);
 }

--- a/suite/meet/sfu-server/src/server/__tests__/ProtocolContract.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/ProtocolContract.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { RecordingProofChallenge } from '../../types';
+import { parseClaims, validateChallenge } from '../RecordingGrantManager';
+import { isRecordingProofRequest } from '../SocketHandlerManager';
+
+type JsonValue = null | boolean | number | string | JsonValue[] | JsonObject;
+type JsonObject = { [key: string]: JsonValue };
+
+const contract = JSON.parse(
+	readFileSync(
+		resolve(process.cwd(), '../recording/contracts/v1.json'),
+		'utf8',
+	),
+) as {
+	vectors: {
+		proof_challenges: {
+			accepted: RecordingProofChallenge[];
+			rejected: RecordingProofChallenge[];
+		};
+		recording_grant_claims: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		proof_requests: { accepted: JsonObject[]; rejected: JsonObject[] };
+	};
+};
+
+describe('recording protocol contract v1', () => {
+	it('runs shared proof challenge vectors through the production validator', () => {
+		for (const value of contract.vectors.proof_challenges.accepted)
+			expect(() =>
+				validateChallenge(
+					value,
+					value.jti,
+					value.socket_id,
+					value.issued_at + 1,
+				),
+			).not.toThrow();
+		for (const value of contract.vectors.proof_challenges.rejected)
+			expect(() =>
+				validateChallenge(
+					value,
+					value.jti,
+					value.socket_id,
+					value.issued_at + 1,
+				),
+			).toThrow();
+	});
+
+	it('runs shared Recording Grant claim vectors through the production parser', () => {
+		for (const value of contract.vectors.recording_grant_claims.accepted)
+			expect(parseClaims(value)).toBeDefined();
+		for (const value of contract.vectors.recording_grant_claims.rejected)
+			expect(() => parseClaims(value)).toThrow();
+	});
+
+	it('runs shared proof request vectors through the production parser', () => {
+		for (const value of contract.vectors.proof_requests.accepted)
+			expect(isRecordingProofRequest(value)).toBe(true);
+		for (const value of contract.vectors.proof_requests.rejected)
+			expect(isRecordingProofRequest(value)).toBe(false);
+	});
+});

--- a/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
@@ -29,7 +29,7 @@ const publicJwk: JsonWebKey = {
 	y: privateJwk.y,
 };
 const vectorChallenge: RecordingProofChallenge = {
-	version: 1,
+	protocol_version: 1,
 	jti: 'jti-vector',
 	socket_id: 'socket-vector',
 	nonce: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -81,6 +81,15 @@ describe('RecordingGrantManager', () => {
 				NOW,
 			),
 		).toThrow('public JWK');
+	});
+
+	it.each([
+		['missing protocol version', { protocol_version: undefined }],
+		['wrong protocol version', { protocol_version: 2 }],
+		['non-integer protocol version', { protocol_version: 1.5 }],
+		['unknown claim', { unexpected: 'claim' }],
+	])('rejects %s before using grant claims', (_name, overrides) => {
+		expect(() => manager.verifyGrant(makeToken(overrides), NOW)).toThrow();
 	});
 
 	it.each([
@@ -264,19 +273,41 @@ describe('RecordingGrantManager', () => {
 			NOW,
 		);
 		expect(Buffer.from(challenge.nonce, 'base64url')).toHaveLength(32);
+		expect(challenge.protocol_version).toBe(1);
 		expect(challenge.expires_at).toBe(NOW + 10);
+	});
+
+	it.each([
+		{ ...vectorChallenge, protocol_version: 2 },
+		{ ...vectorChallenge, protocol_version: 1.5 },
+		{ ...vectorChallenge, extra: true },
+	])('rejects a non-contract challenge %#', async (challenge) => {
+		await expect(
+			manager.verifyProofAndConsume(
+				manager.verifyGrant(makeToken(), NOW),
+				challenge as RecordingProofChallenge,
+				vectorSignature,
+				'socket-vector',
+				NOW + 1,
+			),
+		).rejects.toThrow('challenge');
 	});
 });
 
 function makeToken(
 	overrides: Record<
 		string,
-		string | number | readonly string[] | { jwk: JsonWebKey; jkt: string }
+		| string
+		| number
+		| readonly string[]
+		| { jwk: JsonWebKey; jkt: string }
+		| undefined
 	> = {},
 	header: Record<string, string> = {},
 	algorithm: jwt.Algorithm = 'HS256',
 ): string {
 	const claims: RecordingGrantClaims = {
+		protocol_version: 1,
 		iss: 'frappe-site:test.local',
 		aud: 'meet-sfu-recorder',
 		scope: 'recording',

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -373,7 +373,11 @@ describe('SocketHandlerManager characterization', () => {
 		});
 		const provedDisconnect = vi.spyOn(proved, 'disconnect');
 		harness.connect(proved);
-		proved.fire('recording:proof', { signature: 'valid' }, vi.fn());
+		proved.fire(
+			'recording:proof',
+			{ protocol_version: 1, signature: 'valid' },
+			vi.fn(),
+		);
 		await vi.runAllTicks();
 		await vi.advanceTimersByTimeAsync(10_000);
 		expect(provedDisconnect).not.toHaveBeenCalled();
@@ -421,9 +425,16 @@ describe('SocketHandlerManager characterization', () => {
 			} as never,
 		});
 		const firstProof = vi.fn();
-		first.fire('recording:proof', { signature: 'valid' }, firstProof);
+		first.fire(
+			'recording:proof',
+			{ protocol_version: 1, signature: 'valid' },
+			firstProof,
+		);
 		await new Promise((resolve) => setImmediate(resolve));
-		expect(firstProof).toHaveBeenCalledWith({ success: true });
+		expect(firstProof).toHaveBeenCalledWith({
+			protocol_version: 1,
+			success: true,
+		});
 
 		first.fire('disconnect', 'client namespace disconnect');
 		await new Promise((resolve) => setImmediate(resolve));
@@ -438,12 +449,50 @@ describe('SocketHandlerManager characterization', () => {
 		const replacementProof = vi.fn();
 		replacement.fire(
 			'recording:proof',
-			{ signature: 'valid' },
+			{ protocol_version: 1, signature: 'valid' },
 			replacementProof,
 		);
 		await new Promise((resolve) => setImmediate(resolve));
 
-		expect(replacementProof).toHaveBeenCalledWith({ success: true });
+		expect(replacementProof).toHaveBeenCalledWith({
+			protocol_version: 1,
+			success: true,
+		});
+	});
+
+	it.each([
+		{ signature: 'valid' },
+		{ protocol_version: 2, signature: 'valid' },
+		{ protocol_version: 1, signature: 'valid', extra: true },
+	])('rejects a non-contract recording proof before verification %#', async (proof) => {
+		const grantManager = {
+			createChallenge: vi.fn(() => ({
+				protocol_version: 1,
+				nonce: 'challenge',
+			})),
+			verifyProofAndConsume: vi.fn(),
+		};
+		const harness = createManager(grantManager as never);
+		const socket = connectFullSocket(harness, {
+			scope: 'recording',
+			recordingClaims: {
+				recording_id: 'recording-1',
+				recorder_job_id: 'job-1',
+			} as never,
+		});
+		const callback = vi.fn();
+
+		socket.fire('recording:proof', proof, callback);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(grantManager.verifyProofAndConsume).not.toHaveBeenCalled();
+		expect(callback).toHaveBeenCalledWith({
+			protocol_version: 1,
+			success: false,
+			reason_code: 'invalid_proof',
+			diagnostic: 'Invalid recording proof',
+		});
+		expect(socket.recordingProofComplete).not.toBe(true);
 	});
 
 	it('join_room with scope:full adds the socket to fullAccessSockets, calls mediasoup.createRoom + addPeer, and emits existing_raised_hands to the joiner', async () => {

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -50,7 +50,9 @@ import type {
 	ReactionMessage,
 	ReactionSendRequest,
 	RecordingJoinRequest,
+	RecordingProofChallenge,
 	RecordingProofRequest,
+	RecordingProofResponse,
 	ScreenShareRequest,
 	ScreenShareStartedEvent,
 	ScreenShareStoppedEvent,
@@ -102,7 +104,9 @@ export type {
 	ReactionMessage,
 	ReactionSendRequest,
 	RecordingJoinRequest,
+	RecordingProofChallenge,
 	RecordingProofRequest,
+	RecordingProofResponse,
 	Router,
 	RouterRtpCodecCapability,
 	RtpCapabilities,
@@ -123,9 +127,7 @@ export type {
 
 // Socket.IO types
 export interface ServerToClientEvents {
-	'recording:challenge': (
-		data: import('../server/RecordingGrantManager').RecordingProofChallenge,
-	) => void;
+	'recording:challenge': (data: RecordingProofChallenge) => void;
 	participant_joined: (data: ParticipantJoinedEvent) => void;
 	participant_left: (data: ParticipantLeftEvent) => void;
 	participant_connection_replaced: (data: {
@@ -158,7 +160,7 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
 	'recording:proof': (
 		data: RecordingProofRequest,
-		callback: (response: SFUResponse) => void,
+		callback: (response: RecordingProofResponse) => void,
 	) => void;
 	'recording:join': (
 		data: RecordingJoinRequest,

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -4,9 +4,28 @@ export interface RecordingJoinRequest {
 	roomId: string;
 }
 
+export interface RecordingProofChallenge {
+	protocol_version: 1;
+	jti: string;
+	socket_id: string;
+	nonce: string;
+	issued_at: number;
+	expires_at: number;
+}
+
 export interface RecordingProofRequest {
+	protocol_version: 1;
 	signature: string;
 }
+
+export type RecordingProofResponse =
+	| { protocol_version: 1; success: true }
+	| {
+			protocol_version: 1;
+			success: false;
+			reason_code: 'invalid_proof';
+			diagnostic?: string;
+	  };
 
 export interface UserData {
 	name: string;


### PR DESCRIPTION
## Summary

- version recording commands, callbacks, browser lifecycle, and Recording Grant proof seams
- enforce exact fail-closed shapes, finite reason codes, and canonical timestamps before side effects
- add immutable v1 semantic vectors exercised by independent Python and TypeScript adapters