### PR TITLE
ci(e2e): run vouched forks on hosted runners

### DIFF
--- a/.github/arc/README.md
+++ b/.github/arc/README.md
@@ -8,9 +8,10 @@ because the E2E workflows require MariaDB and Redis service containers.
 
 - Both scale sets are scoped to `frappe/suite` and start at zero. Meet permits
   three 6-CPU jobs; Drive permits two 2-CPU jobs.
-- E2E jobs run only for pushes, manual dispatches, and `pull_request_target`
-  events whose head repository is `frappe/suite`. The protected base workflow
-  enforces that gate before explicitly checking out the internal PR commit.
+- Self-hosted E2E jobs run only for pushes, schedules, manual dispatches, and
+  `pull_request_target` events whose head repository is `frappe/suite`.
+  Vouched fork pull requests run on GitHub-hosted runners instead; fork code
+  never reaches these scale sets.
 - The Yarn Classic cache is baked into the runner image. Each runner receives a
   private writable copy-on-write view, so cache misses and dependency changes
   remain pod-local and are discarded with the runner.

--- a/.github/workflows/drive-backed-apps-e2e.yml
+++ b/.github/workflows/drive-backed-apps-e2e.yml
@@ -109,9 +109,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  author_check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      trusted: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository || steps.vouch.outputs.vouched == 'true' }}
+    steps:
+      - if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+        id: vouch
+        uses: mitchellh/vouch/action/check-user@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
+        with:
+          user: ${{ github.event.pull_request.user.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   e2e:
-    if: github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: suite-e2e-drive
+    needs: author_check
+    if: needs.author_check.outputs.trusted == 'true'
+    runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'suite-e2e-drive' }}
     timeout-minutes: 45
     permissions:
       contents: read
@@ -138,6 +157,8 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -151,6 +172,13 @@ jobs:
 
       - name: Setup Yarn
         run: corepack enable && corepack prepare yarn@1.22.22 --activate
+
+      - name: Install GitHub-hosted dependencies
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mariadb-client
+          python -m pip install uv
 
       - name: Add to hosts
         run: echo "127.0.0.1 drive-writer.test" | sudo tee -a /etc/hosts
@@ -202,6 +230,11 @@ jobs:
         run: |
           yarn install --frozen-lockfile --non-interactive
           google-chrome --version
+
+      - name: Install Playwright system dependencies
+        if: runner.environment == 'github-hosted'
+        working-directory: ${{ github.workspace }}/e2e
+        run: yarn playwright install-deps chromium
 
       - name: Start Frappe server
         id: start-frappe

--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -108,12 +108,12 @@ jobs:
     permissions:
       contents: read
     outputs:
-      vouched: ${{ github.event_name != 'pull_request_target' || steps.vouch.outputs.vouched }}
+      trusted: ${{ github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.repository || steps.vouch.outputs.vouched == 'true' }}
     steps:
-      - if: github.event_name == 'pull_request_target'
+      - if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - if: github.event_name == 'pull_request_target'
+      - if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
         id: vouch
         uses: mitchellh/vouch/action/check-user@d66fa29a64600490892131ad87597c30c91fcac4 # v1.5.0
         with:
@@ -123,8 +123,8 @@ jobs:
 
   e2e:
     needs: author_check
-    if: needs.author_check.outputs.vouched == 'true'
-    runs-on: suite-e2e-meet
+    if: needs.author_check.outputs.trusted == 'true'
+    runs-on: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'ubuntu-latest' || 'suite-e2e-meet' }}
     # Historical durations keep each self-contained group near the same runtime.
     strategy:
       fail-fast: false
@@ -157,6 +157,8 @@ jobs:
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -170,6 +172,13 @@ jobs:
 
       - name: Setup Yarn
         run: corepack enable && corepack prepare yarn@1.22.22 --activate
+
+      - name: Install GitHub-hosted dependencies
+        if: runner.environment == 'github-hosted'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mariadb-client
+          python -m pip install uv
 
       - name: Add to Hosts
         run: echo "127.0.0.1 meet.test" | sudo tee -a /etc/hosts
@@ -231,6 +240,11 @@ jobs:
         run: |
           yarn install --frozen-lockfile --non-interactive
           google-chrome --version
+
+      - name: Install Playwright system dependencies
+        if: runner.environment == 'github-hosted'
+        working-directory: ${{ github.workspace }}/e2e
+        run: yarn playwright install-deps chromium
 
       - name: Start Frappe Server
         id: start-frappe


### PR DESCRIPTION
## Summary

- keep contributor vouching as the first gate for external pull requests
- run vouched fork E2E code on disposable GitHub-hosted runners
- retain self-hosted ARC runners for internal and protected-branch events