### PR TITLE
fix(meet): preserve active media attachments

### DIFF
--- a/frontend/src/apps/meet/utils/media/VideoElementManager.ts
+++ b/frontend/src/apps/meet/utils/media/VideoElementManager.ts
@@ -50,13 +50,11 @@ interface Attachment {
 	stream: MediaStream | null;
 	ownsTracks: boolean;
 	createdElement: boolean;
-	lastAttachAt?: number;
 	attachedStreamId?: string;
 	attachedTrackIds?: string;
 	revision: number;
 }
 
-const STALE_REATTACH_MS = 60_000;
 const LOCAL_PREVIEW_ID = "local";
 
 const attachmentKey = (role: MediaAttachmentRole, id: string) => `${role}:${id}`;
@@ -392,9 +390,6 @@ export class VideoElementManager implements MediaAttachmentFacade {
 			?.getTracks()
 			.map((track) => track.id)
 			.join(",");
-		const stale =
-			attachment.lastAttachAt !== undefined &&
-			Date.now() - attachment.lastAttachAt > STALE_REATTACH_MS;
 		const sourceStreamChanged =
 			role !== "remote-video" &&
 			role !== "remote-audio" &&
@@ -404,14 +399,13 @@ export class VideoElementManager implements MediaAttachmentFacade {
 			sourceStreamChanged ||
 			attachment.attachedTrackIds !== trackIds ||
 			currentTracks !== trackIds;
-		if (!changed && !stale) return;
+		if (!changed) return;
 
 		this.configureElement(element, role);
 		this.clearPlaybackHandler(element);
 		element.srcObject = new MediaStream(tracks);
 		attachment.attachedStreamId = stream.id;
 		attachment.attachedTrackIds = trackIds;
-		attachment.lastAttachAt = Date.now();
 		const revision = ++attachment.revision;
 		const played = await this.playElement(
 			element,
@@ -497,7 +491,6 @@ export class VideoElementManager implements MediaAttachmentFacade {
 		attachment.stream = null;
 		attachment.attachedStreamId = undefined;
 		attachment.attachedTrackIds = undefined;
-		attachment.lastAttachAt = undefined;
 		if (attachment.element) this.detachElement(attachment.element, false);
 	}
 

--- a/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
+++ b/frontend/src/apps/meet/utils/media/__tests__/VideoElementManager.test.ts
@@ -61,7 +61,7 @@ function deferred<T>() {
 	return { promise, resolve, reject };
 }
 
-describe("VideoElementManager.attachStream stale re-attach", () => {
+describe("VideoElementManager.attachStream continuity", () => {
 	let manager: VideoElementManager;
 
 	beforeEach(() => {
@@ -207,7 +207,7 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 		expect(el.srcObject).toBe(originalSrc);
 	});
 
-	it("re-attaches when the last attach is older than the stale threshold", async () => {
+	it("keeps an unchanged video track attached across later tile updates", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_000_000));
 
@@ -219,14 +219,12 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 
 		vi.setSystemTime(new Date(1_000_000 + 70_000));
 
-		await manager.attachStream("p1", makeStream([track1]), false);
-		expect(el.srcObject).not.toBe(originalSrc);
-		expect((el.srcObject as MediaStream).getVideoTracks()[0].id).toBe(
-			"track-1",
-		);
+		manager.registerRemoteVideoElement("p1", el);
+		await Promise.resolve();
+		expect(el.srcObject).toBe(originalSrc);
 	});
 
-	it("clears the attach timestamp when the element is removed", async () => {
+	it("reattaches after an element is removed and replaced", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_000_000));
 
@@ -260,7 +258,7 @@ describe("VideoElementManager.attachStream stale re-attach", () => {
 	});
 });
 
-describe("VideoElementManager.attachAudioStream stale re-attach", () => {
+describe("VideoElementManager.attachAudioStream continuity", () => {
 	let manager: VideoElementManager;
 
 	beforeEach(() => {
@@ -271,7 +269,7 @@ describe("VideoElementManager.attachAudioStream stale re-attach", () => {
 		vi.useRealTimers();
 	});
 
-	it("re-attaches audio when the last attach is older than the stale threshold", () => {
+	it("keeps an unchanged audio track attached over time", async () => {
 		vi.useFakeTimers();
 		vi.setSystemTime(new Date(1_000_000));
 
@@ -289,15 +287,15 @@ describe("VideoElementManager.attachAudioStream stale re-attach", () => {
 			}) as never);
 
 		const track = { id: "a1", kind: "audio" } as MediaStreamTrack;
-		manager.attachAudioStream("p1", [track]);
+		await manager.attachAudioStream("p1", [track]);
 		const audioEl = manager.audioElements.get("p1");
 		expect(audioEl).toBeDefined();
 		const originalSrc = audioEl?.srcObject;
 
 		vi.setSystemTime(new Date(1_000_000 + 70_000));
 
-		manager.attachAudioStream("p1", [track]);
-		expect(audioEl?.srcObject).not.toBe(originalSrc);
+		await manager.attachAudioStream("p1", [track]);
+		expect(audioEl?.srcObject).toBe(originalSrc);
 
 		createElementSpy.mockRestore();
 	});


### PR DESCRIPTION
## Summary

- keep unchanged media tracks attached across routine tile updates
- preserve reattachment when the track, stream, or media element actually changes

## Context

The media element manager replaced unchanged `srcObject` streams once an attachment was older than 60 seconds. Routine Vue ref updates could therefore interrupt playback with a brief black frame for participants whose attachments were created at similar times.