### PR TITLE
fix(meet): align chat composer styling

### DIFF
--- a/frontend/src/apps/meet/components/ChatPanel.vue
+++ b/frontend/src/apps/meet/components/ChatPanel.vue
@@ -162,7 +162,7 @@
 				<form class="relative shrink-0 p-3" @submit.prevent="handleSend">
 					<template v-if="canSendMessages">
 						<div
-							class="chat-composer relative flex cursor-text items-center gap-2 rounded-6 border border-outline-gray-2 bg-surface-gray-1 px-2.5 py-1.5 shadow-sm transition-[border-color,box-shadow] focus-within:border-outline-gray-3 focus-within:shadow-[0_0_0_1px_var(--outline-gray-3)]"
+							class="chat-composer relative flex cursor-text items-center gap-2 rounded-5 border border-outline-gray-2 bg-surface-base py-1.5 pe-2 transition-colors hover:border-outline-gray-3 hover:shadow-sm focus-within:border-outline-gray-4 focus-within:shadow-sm"
 							@click="focusInput"
 						>
 							<div
@@ -202,7 +202,7 @@
 								v-model="draft"
 								rows="1"
 								placeholder="Type a message"
-								class="chat-composer-input min-w-0 flex-1 resize-none border-0 bg-transparent py-0 text-sm leading-5 text-ink-gray-8 tracking-[0.28px] shadow-none outline-none ring-0 placeholder:text-ink-gray-5 focus:border-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
+								class="chat-composer-input min-h-7 min-w-0 flex-1 resize-none border-0 bg-transparent py-1.5 text-base text-ink-gray-8 shadow-none outline-none ring-0 placeholder-ink-gray-4 focus:border-0 focus:outline-none focus:ring-0 focus-visible:outline-none focus-visible:ring-0"
 								@input="onInput"
 								@keydown="onKeydown"
 							/>
@@ -210,7 +210,7 @@
 								type="submit"
 								variant="subtle"
 								theme="gray"
-								class="!h-7 !w-7 shrink-0 !rounded-4 p-0"
+								size="sm"
 								label="Send message"
 							>
 								<template #icon>
@@ -502,9 +502,7 @@ watch([chatItems], scrollToBottom, { deep: true });
 
 <style scoped>
 .chat-composer-input {
-	min-height: 1.375rem;
 	max-height: 88px;
-	padding: 0;
 	margin: 0;
 	overflow-y: auto;
 	caret-color: var(--ink-gray-8);


### PR DESCRIPTION
## Summary

- align the Meet chat composer with Frappe UI input tokens
- keep the autosizing message field at a 28px minimum height
- use the native small button sizing for the send action