### PR TITLE
ci: report coverage in PR descriptions

### DIFF
--- a/.github/scripts/coverage_report.py
+++ b/.github/scripts/coverage_report.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Render backend and frontend Cobertura totals as a PR Markdown fragment."""
+
+import argparse
+import os
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+
+MAX_XML_BYTES = 10 * 1024 * 1024
+
+
+@dataclass
+class Coverage:
+    covered: int
+    total: int
+    branches_covered: int | None
+    branches_total: int | None
+
+
+def parse_coverage(path: str) -> Coverage | None:
+    try:
+        if os.path.getsize(path) > MAX_XML_BYTES:
+            raise ValueError("report exceeds the 10 MiB limit")
+        with open(path, "rb") as handle:
+            data = handle.read(MAX_XML_BYTES + 1)
+        if b"<!ENTITY" in data.upper():
+            raise ValueError("XML entity declarations are not allowed")
+        root = ET.fromstring(data)
+        covered = int(root.attrib["lines-covered"])
+        total = int(root.attrib["lines-valid"])
+        branches_covered = root.attrib.get("branches-covered")
+        branches_total = root.attrib.get("branches-valid")
+        return Coverage(
+            covered,
+            total,
+            int(branches_covered) if branches_covered is not None else None,
+            int(branches_total) if branches_total is not None else None,
+        )
+    except (FileNotFoundError, KeyError, OSError, ET.ParseError, ValueError) as error:
+        print(f"Coverage unavailable for {path}: {error}")
+        return None
+
+
+def metric(covered: int | None, total: int | None) -> str:
+    if covered is None or total is None or total == 0:
+        return "Unavailable"
+    return f"**{100 * covered / total:.1f}%** ({covered:,} / {total:,})"
+
+
+def rate(covered: int | None, total: int | None) -> float | None:
+    if covered is None or total is None or total == 0:
+        return None
+    return 100 * covered / total
+
+
+def delta(current: float | None, baseline: float | None) -> str:
+    if current is None or baseline is None:
+        return ""
+    change = current - baseline
+    if abs(change) < 0.05:
+        return " (no change)"
+    return f" ({change:+.1f}%)"
+
+
+def row(label: str, coverage: Coverage | None, baseline: Coverage | None) -> str:
+    if coverage is None:
+        return f"| {label} | Unavailable | Unavailable |"
+    baseline_lines = rate(baseline.covered, baseline.total) if baseline else None
+    baseline_branches = rate(baseline.branches_covered, baseline.branches_total) if baseline else None
+    return (
+        f"| {label} | {metric(coverage.covered, coverage.total)}"
+        f"{delta(rate(coverage.covered, coverage.total), baseline_lines)} | "
+        f"{metric(coverage.branches_covered, coverage.branches_total)}"
+        f"{delta(rate(coverage.branches_covered, coverage.branches_total), baseline_branches)} |"
+    )
+
+
+def summary_metric(label: str, coverage: Coverage | None, baseline: Coverage | None) -> str:
+    if coverage is None:
+        return f"{label} unavailable"
+    current = rate(coverage.covered, coverage.total)
+    if current is None:
+        return f"{label} unavailable"
+    baseline_rate = rate(baseline.covered, baseline.total) if baseline else None
+    return f"{label} {current:.1f}%{delta(current, baseline_rate)}"
+
+
+def render(
+    backend: Coverage | None,
+    frontend: Coverage | None,
+    backend_baseline: Coverage | None,
+    frontend_baseline: Coverage | None,
+    baseline_ref: str,
+    run_url: str,
+    commit: str,
+) -> str:
+    short_commit = commit[:7]
+    summary = " · ".join(
+        [
+            summary_metric("Backend", backend, backend_baseline),
+            summary_metric("Frontend", frontend, frontend_baseline),
+        ]
+    )
+    return (
+        "\n".join(
+            [
+                "<details>",
+                f"<summary><strong>Test coverage</strong>: {summary}</summary>",
+                "",
+                "| Suite | Lines | Branches |",
+                "| --- | ---: | ---: |",
+                row("Backend", backend, backend_baseline),
+                row("Frontend", frontend, frontend_baseline),
+                "",
+                f"<sub>Delta is against the latest available `{baseline_ref}` coverage. Coverage is informational. "
+                f"[Workflow run]({run_url}) for commit `{short_commit}`.</sub>",
+                "",
+                "</details>",
+            ]
+        )
+        + "\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", required=True)
+    parser.add_argument("--frontend", required=True)
+    parser.add_argument("--backend-baseline", required=True)
+    parser.add_argument("--frontend-baseline", required=True)
+    parser.add_argument("--baseline-ref", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--commit", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    report = render(
+        parse_coverage(args.backend),
+        parse_coverage(args.frontend),
+        parse_coverage(args.backend_baseline),
+        parse_coverage(args.frontend_baseline),
+        args.baseline_ref,
+        args.run_url,
+        args.commit,
+    )
+    with open(args.output, "w", encoding="utf-8") as handle:
+        handle.write(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/download_baseline_coverage.py
+++ b/.github/scripts/download_baseline_coverage.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Download the newest coverage artifact for each suite on a base branch."""
+
+import argparse
+import io
+import json
+import os
+import subprocess
+import zipfile
+from urllib.parse import quote
+
+ARTIFACTS = {
+    "suite-backend-coverage": ("coverage.xml", "backend.xml"),
+    "suite-frontend-coverage": ("cobertura-coverage.xml", "frontend.xml"),
+}
+MAX_ARTIFACT_BYTES = 20 * 1024 * 1024
+
+
+def gh(*args: str) -> bytes:
+    result = subprocess.run(["gh", "api", *args], capture_output=True, check=False)
+    if result.returncode:
+        raise RuntimeError(result.stderr.decode(errors="replace").strip())
+    return result.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--branch", required=True)
+    parser.add_argument("--output", required=True)
+    args = parser.parse_args()
+
+    query = (
+        f"repos/{args.repo}/actions/workflows/suite-ci.yml/runs"
+        f"?branch={quote(args.branch, safe='')}&event=push&status=success&per_page=100"
+    )
+    runs = json.loads(gh(query))["workflow_runs"]
+    remaining = dict(ARTIFACTS)
+    os.makedirs(args.output, exist_ok=True)
+
+    for run in runs:
+        artifacts = json.loads(gh(f"repos/{args.repo}/actions/runs/{run['id']}/artifacts"))["artifacts"]
+        for artifact in artifacts:
+            if artifact["name"] not in remaining or artifact["expired"]:
+                continue
+            source_name, output_name = remaining[artifact["name"]]
+            try:
+                archive = gh(f"repos/{args.repo}/actions/artifacts/{artifact['id']}/zip")
+                if len(archive) > MAX_ARTIFACT_BYTES:
+                    print(f"Skipping oversized baseline artifact {artifact['name']}.")
+                    continue
+                with zipfile.ZipFile(io.BytesIO(archive)) as bundle:
+                    member = next(
+                        (name for name in bundle.namelist() if os.path.basename(name) == source_name), None
+                    )
+                    if member is None:
+                        print(f"Could not find {source_name} in {artifact['name']}.")
+                        continue
+                    if bundle.getinfo(member).file_size > MAX_ARTIFACT_BYTES:
+                        print(f"Skipping oversized {source_name} in {artifact['name']}.")
+                        continue
+                    with (
+                        bundle.open(member) as source,
+                        open(os.path.join(args.output, output_name), "wb") as target,
+                    ):
+                        target.write(source.read())
+                remaining.pop(artifact["name"])
+            except (RuntimeError, OSError, zipfile.BadZipFile) as error:
+                print(f"Could not use baseline artifact {artifact['name']}: {error}")
+        if not remaining:
+            break
+
+    for artifact_name in remaining:
+        print(f"No {artifact_name} baseline found on {args.branch}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test_coverage_reporting.py
+++ b/.github/scripts/test_coverage_reporting.py
@@ -1,4 +1,5 @@
 import importlib.util
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,6 +10,7 @@ def load(name: str):
     spec = importlib.util.spec_from_file_location(name, path)
     module = importlib.util.module_from_spec(spec)
     assert spec and spec.loader
+    sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/.github/scripts/test_coverage_reporting.py
+++ b/.github/scripts/test_coverage_reporting.py
@@ -1,0 +1,69 @@
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def load(name: str):
+    path = Path(__file__).with_name(f"{name}.py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+coverage_report = load("coverage_report")
+update_pr_coverage = load("update_pr_coverage")
+
+
+class CoverageReportTest(unittest.TestCase):
+    def test_parses_cobertura_totals(self):
+        with tempfile.NamedTemporaryFile() as report:
+            report.write(
+                b'<coverage lines-covered="8" lines-valid="10" branches-covered="3" branches-valid="4"/>'
+            )
+            report.flush()
+            coverage = coverage_report.parse_coverage(report.name)
+
+        self.assertEqual((coverage.covered, coverage.total), (8, 10))
+        self.assertEqual((coverage.branches_covered, coverage.branches_total), (3, 4))
+
+    def test_rejects_entity_declarations(self):
+        with tempfile.NamedTemporaryFile() as report:
+            report.write(b'<!DOCTYPE coverage [<!ENTITY x "x">]><coverage/>')
+            report.flush()
+            self.assertIsNone(coverage_report.parse_coverage(report.name))
+
+    def test_renders_delta_in_collapsed_section(self):
+        current = coverage_report.Coverage(85, 100, 70, 100)
+        baseline = coverage_report.Coverage(80, 100, 72, 100)
+
+        markdown = coverage_report.render(
+            current,
+            current,
+            baseline,
+            baseline,
+            "develop",
+            "https://example.test/run",
+            "abcdef123456",
+        )
+
+        self.assertIn("<details>", markdown)
+        self.assertIn("Backend 85.0% (+5.0%)", markdown)
+        self.assertIn("**70.0%** (70 / 100) (-2.0%)", markdown)
+
+
+class UpdatePrCoverageTest(unittest.TestCase):
+    def test_appends_and_replaces_one_block(self):
+        first = update_pr_coverage.replace_coverage("Human description\n", "## Test coverage\n10%")
+        second = update_pr_coverage.replace_coverage(first, "## Test coverage\n20%")
+
+        self.assertIn("Human description", second)
+        self.assertNotIn("10%", second)
+        self.assertEqual(second.count(update_pr_coverage.START), 1)
+        self.assertIn("20%", second)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/update_pr_coverage.py
+++ b/.github/scripts/update_pr_coverage.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Replace the generated coverage block at the end of a pull request body."""
+
+import argparse
+import json
+import re
+import subprocess
+
+START = "<!-- suite-coverage:start -->"
+END = "<!-- suite-coverage:end -->"
+
+
+def replace_coverage(body: str, report: str) -> str:
+    block = f"{START}\n{report.strip()}\n{END}"
+    pattern = re.compile(rf"\n*{re.escape(START)}.*?{re.escape(END)}", re.DOTALL)
+    without_old = pattern.sub("", body or "").rstrip()
+    return f"{without_old}\n\n{block}\n" if without_old else f"{block}\n"
+
+
+def gh(*args: str, input_text: str | None = None) -> str:
+    result = subprocess.run(
+        ["gh", *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip())
+    return result.stdout
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--pr", required=True)
+    parser.add_argument("--head-sha", required=True)
+    parser.add_argument("--report", required=True)
+    args = parser.parse_args()
+
+    pull_request = json.loads(gh("api", f"repos/{args.repo}/pulls/{args.pr}"))
+    if pull_request["head"]["sha"] != args.head_sha:
+        print("The PR has advanced since this coverage run; leaving its description unchanged.")
+        return
+    with open(args.report, encoding="utf-8") as handle:
+        body = replace_coverage(pull_request.get("body") or "", handle.read())
+
+    gh(
+        "api",
+        "-X",
+        "PATCH",
+        f"repos/{args.repo}/pulls/{args.pr}",
+        "--input",
+        "-",
+        input_text=json.dumps({"body": body}),
+    )
+    print("Updated the PR coverage block.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,94 @@
+name: PR Coverage Report
+
+# Keep write access away from pull-request code. This workflow runs from the
+# default branch after Suite CI and only parses the artifacts produced there.
+on:
+  workflow_run:
+    workflows: ["Suite CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  report:
+    name: Update PR description
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event.workflow_run.conclusion == 'success'
+      || github.event.workflow_run.conclusion == 'failure')
+      && github.repository_owner == 'frappe'
+      && github.event.workflow_run.event == 'pull_request'
+
+    steps:
+      - name: Checkout trusted report scripts
+        uses: actions/checkout@v7
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v7
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts
+          pattern: suite-*-coverage
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          matches="$(gh api "repos/${REPO}/commits/${HEAD_SHA}/pulls" --paginate \
+            --jq "[.[]
+              | select(.state == \"open\")
+              | select(.head.sha == \"${HEAD_SHA}\")
+              | select(.head.repo.full_name == \"${HEAD_REPO}\")
+              | {number, base_ref: .base.ref}]")"
+          count="$(jq -r 'length' <<<"$matches")"
+
+          if [ "$count" = "1" ]; then
+            echo "number=$(jq -r '.[0].number' <<<"$matches")" >> "$GITHUB_OUTPUT"
+            echo "base_ref=$(jq -r '.[0].base_ref' <<<"$matches")" >> "$GITHUB_OUTPUT"
+          else
+            echo "Expected one open PR at ${HEAD_SHA} on ${HEAD_REPO}, found ${count}; not updating a PR."
+            echo "number=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download base branch coverage
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/download_baseline_coverage.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --branch "${{ steps.pr.outputs.base_ref }}" \
+            --output artifacts/baseline
+
+      - name: Build coverage report
+        if: steps.pr.outputs.number != ''
+        run: |
+          python .github/scripts/coverage_report.py \
+            --backend artifacts/suite-backend-coverage/coverage.xml \
+            --frontend artifacts/suite-frontend-coverage/cobertura-coverage.xml \
+            --backend-baseline artifacts/baseline/backend.xml \
+            --frontend-baseline artifacts/baseline/frontend.xml \
+            --baseline-ref "${{ steps.pr.outputs.base_ref }}" \
+            --run-url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${{ github.event.workflow_run.id }}" \
+            --commit "${{ github.event.workflow_run.head_sha }}" \
+            --output "${RUNNER_TEMP}/coverage.md"
+          cat "${RUNNER_TEMP}/coverage.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update PR description
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/update_pr_coverage.py \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "${{ steps.pr.outputs.number }}" \
+            --head-sha "${{ github.event.workflow_run.head_sha }}" \
+            --report "${RUNNER_TEMP}/coverage.md"

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -249,6 +249,15 @@ jobs:
           if-no-files-found: warn
           retention-days: 30
 
+      - name: Upload Backend Coverage
+        if: always() && (github.event_name == 'pull_request' || github.event_name == 'push')
+        uses: actions/upload-artifact@v7
+        with:
+          name: suite-backend-coverage
+          path: test-results/backend/coverage.xml
+          if-no-files-found: warn
+          retention-days: 7
+
   mail-calendar:
     runs-on: ubuntu-latest
     name: ${{ matrix.name }}
@@ -482,3 +491,12 @@ jobs:
           path: frontend/test-results/
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Upload Frontend Coverage
+        if: always() && (github.event_name == 'pull_request' || github.event_name == 'push') && steps.frontend-changes.outputs.run == '1'
+        uses: actions/upload-artifact@v7
+        with:
+          name: suite-frontend-coverage
+          path: frontend/test-results/coverage/cobertura-coverage.xml
+          if-no-files-found: warn
+          retention-days: 7


### PR DESCRIPTION
## Summary

- append a collapsed backend and frontend coverage report to PR descriptions
- show deltas against the latest available base-branch coverage artifacts
- keep write access in a trusted post-run workflow for fork safety
- register dynamically loaded report modules before test execution