### PR TITLE
chore(mail): rename Suite Infra to Suite Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Frappe Suite brings seven collaboration products into one Frappe app. Keep files
 
 ## Deploying Mail Servers
 
-Provisioning Stalwart mail servers (Mail Cluster, Mail Server, Server Deployment, Server Job, Ansible plays, DNS Records) lives in the separate [Suite Infra](https://github.com/frappe/suite_infra) app. Suite only needs the server URL and admin credentials in Mail Settings to talk to a Stalwart server. Sites that deployed servers through Suite keep their data: update Suite, run `bench --site yoursite migrate`, then `bench --site yoursite install-app suite_infra`. Installing it adopts the existing records and copies the root domain, DNS provider and timeouts that Mail Settings used to hold.
+Provisioning Stalwart mail servers (Mail Cluster, Mail Server, Server Deployment, Server Job, Ansible plays, DNS Records) lives in the separate [Suite Cloud](https://github.com/frappe/suite_cloud) app. Suite only needs the server URL and admin credentials in Mail Settings to talk to a Stalwart server. Sites that deployed servers through Suite keep their data: update Suite, run `bench --site yoursite migrate`, then `bench --site yoursite install-app suite_cloud`. Installing it adopts the existing records and copies the root domain, DNS provider and timeouts that Mail Settings used to hold.
 
 ## Under the Hood
 

--- a/suite/mail/patches/hand_over_deployment_to_suite_cloud.py
+++ b/suite/mail/patches/hand_over_deployment_to_suite_cloud.py
@@ -1,7 +1,7 @@
 import click
 import frappe
 
-# Moved to the Suite Infra app, child tables included.
+# Moved to the Suite Cloud app, child tables included.
 MOVED_DOCTYPES = (
     "Mail Cluster",
     "Mail Cluster Store",
@@ -22,17 +22,17 @@ DATA_DOCTYPES = ("Mail Cluster", "Mail Server", "DNS Record")
 
 
 def execute() -> None:
-    """Releases the mail server deployment DocTypes to the Suite Infra app.
+    """Releases the mail server deployment DocTypes to the Suite Cloud app.
 
-    With Suite Infra installed its own sync has already retagged them, so there is nothing to do.
+    With Suite Cloud installed its own sync has already retagged them, so there is nothing to do.
     Otherwise the DocType records go, so nothing resolves to controllers Suite no longer ships.
     Tables that hold data stay (clusters carry the SSH keys that reach the servers) and are adopted
-    as they are when Suite Infra is installed later; empty ones are dropped. The retired
+    as they are when Suite Cloud is installed later; empty ones are dropped. The retired
     cluster/server backfills (SSH keypair, recovery admin, recovery port, bootstrap plan) run again
-    in Suite Infra's installer at adoption, so rows that never saw them are completed there.
+    in Suite Cloud's installer at adoption, so rows that never saw them are completed there.
     """
 
-    if "suite_infra" in frappe.get_installed_apps():
+    if "suite_cloud" in frappe.get_installed_apps():
         return
 
     keep_tables = has_deployment_data()
@@ -51,8 +51,8 @@ def execute() -> None:
 
     if keep_tables:
         click.secho(
-            "Mail server deployment data (clusters, servers, DNS records) was kept for the Suite Infra app. "
-            "Install suite_infra on this site to keep managing it.",
+            "Mail server deployment data (clusters, servers, DNS records) was kept for the Suite Cloud app. "
+            "Install suite_cloud on this site to keep managing it.",
             fg="yellow",
         )
 

--- a/suite/mail/tests/docker/start-stalwart.sh
+++ b/suite/mail/tests/docker/start-stalwart.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Boots a bootstrapped Stalwart server for the mail/calendar integration tests.
-# Mirrors the production sequence in the Suite Infra app's deploy-mail-server.yml playbook:
+# Mirrors the production sequence in the Suite Cloud app's deploy-mail-server.yml playbook:
 # start container -> wait for :8080 -> stalwart-cli apply bootstrap.ndjson -> restart -> wait.
 set -euo pipefail
 

--- a/suite/patches.txt
+++ b/suite/patches.txt
@@ -96,7 +96,7 @@ suite.mail.patches.rename_skip_schedule_fetch_changes
 execute:frappe.db.set_single_value("Mail Settings", "expand_mailing_list_participants", 1)
 execute:frappe.db.set_single_value("Mail Settings", "max_mailing_list_participants", 100)
 suite.mail.patches.remove_held_queue_statuses
-suite.mail.patches.hand_over_deployment_to_suite_infra
+suite.mail.patches.hand_over_deployment_to_suite_cloud
 # --- calendar ---
 # (no patches)
 # --- suite_core ---


### PR DESCRIPTION
## Summary
- The deployment app split out in #783 was renamed from `suite_infra` to `suite_cloud`; the repository now lives at https://github.com/frappe/suite_cloud.
- Update the README (link, name, `install-app suite_cloud`), the Stalwart test script comment, and the hand-over patch's docstring, messages and installed-app check.
- The patch module is renamed to `suite.mail.patches.hand_over_deployment_to_suite_cloud` along with its `patches.txt` entry. Sites that already ran it under the old name run it once more: a no-op when `suite_cloud` is installed, otherwise it only re-deletes DocType records that are already gone and keeps any deployment tables that hold data, as before.

## Test plan
- `grep -ri suite_infra` / `Suite Infra` over the repo returns nothing.
- `bench --site <site> migrate` on a site with the renamed app installed: the patch is a no-op and Suite Cloud's DocTypes keep their tables and data (verified on a dev site with a seeded cluster, server and DNS record).
- ruff check and format pass on the renamed patch.