### PR TITLE
fix(ci): correct coverage artifact paths

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -26,13 +26,23 @@ jobs:
       - name: Checkout trusted report scripts
         uses: actions/checkout@v7
 
-      - name: Download coverage artifacts
+      - name: Download backend coverage
         uses: actions/download-artifact@v7
+        continue-on-error: true
         with:
+          name: suite-backend-coverage
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
-          path: artifacts
-          pattern: suite-*-coverage
+          path: artifacts/current/backend
+
+      - name: Download frontend coverage
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          name: suite-frontend-coverage
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+          path: artifacts/current/frontend
 
       - name: Resolve PR number
         id: pr
@@ -72,8 +82,8 @@ jobs:
         if: steps.pr.outputs.number != ''
         run: |
           python .github/scripts/coverage_report.py \
-            --backend artifacts/suite-backend-coverage/coverage.xml \
-            --frontend artifacts/suite-frontend-coverage/cobertura-coverage.xml \
+            --backend artifacts/current/backend/coverage.xml \
+            --frontend artifacts/current/frontend/cobertura-coverage.xml \
             --backend-baseline artifacts/baseline/backend.xml \
             --frontend-baseline artifacts/baseline/frontend.xml \
             --baseline-ref "${{ steps.pr.outputs.base_ref }}" \

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -232,8 +232,8 @@ jobs:
       - name: Collect Backend Evidence
         if: always()
         run: |
-          if [ -f /home/runner/frappe-bench/coverage.xml ]; then
-            cp /home/runner/frappe-bench/coverage.xml test-results/backend/coverage.xml
+          if [ -f /home/runner/frappe-bench/sites/coverage.xml ]; then
+            cp /home/runner/frappe-bench/sites/coverage.xml test-results/backend/coverage.xml
           fi
 
       - name: Upload Backend Evidence


### PR DESCRIPTION
## Summary

- collect backend coverage from Frappe’s actual `sites/coverage.xml` output
- download current backend and frontend artifacts by exact name into deterministic directories
- keep missing coverage non-blocking while reporting available results

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.4% · Frontend 34.6% (no change)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.4%** (21,072 / 37,354) | Unavailable |
| Frontend | **34.6%** (13,875 / 40,073) (no change) | **29.1%** (8,910 / 30,628) (no change) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33478259561) for commit `630b34c`.</sub>

</details>
<!-- suite-coverage:end -->
