### PR TITLE
fix(meet): reset e2e rate limits

### DIFF
--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -8,7 +8,7 @@ import {
 import { MEDIA_FAULT_SCRIPT, STUB_MEDIA_SCRIPT } from "./media";
 import { loginViaApi } from "../../shared/auth";
 import {
-	clearMeetingCreateRateLimit,
+	clearMeetingRateLimits,
 	createMeetingViaApi,
 	type MeetingType,
 } from "../helpers/meeting";
@@ -198,7 +198,7 @@ export const test = base.extend<TestFixtures>({
 		await loginViaApi(api, meetHost);
 
 		await use(async (meetingType = "open") => {
-			await clearMeetingCreateRateLimit(api);
+			await clearMeetingRateLimits(api);
 			return createMeetingViaApi(api, meetingType);
 		});
 
@@ -207,7 +207,7 @@ export const test = base.extend<TestFixtures>({
 
 	createMeetingViaUi: async ({ hostPage }, use) => {
 		await use(async (meetingType = "open") => {
-			await clearMeetingCreateRateLimit(hostPage.request);
+			await clearMeetingRateLimits(hostPage.request);
 			return createMeetingViaUi(hostPage, meetingType);
 		});
 	},

--- a/e2e/meet/helpers/meeting.ts
+++ b/e2e/meet/helpers/meeting.ts
@@ -34,13 +34,16 @@ export async function createMeetingViaApi(
 	return meetingId;
 }
 
-export async function clearMeetingCreateRateLimit(
+export async function clearMeetingRateLimits(
 	request: APIRequestContext,
 ): Promise<void> {
-	await request.post(
-		"/api/method/suite.meet.api.test_helpers.clear_create_rate_limit",
+	const response = await request.post(
+		"/api/method/suite.meet.api.test_helpers.clear_rate_limits",
 		{ data: {} },
 	);
+	if (!response.ok()) {
+		throw new Error(`Meeting rate-limit reset failed with status ${response.status()}`);
+	}
 }
 
 export type { MeetingType };

--- a/suite/meet/api/test_helpers.py
+++ b/suite/meet/api/test_helpers.py
@@ -35,12 +35,6 @@ def provision_host() -> dict[str, str]:
 
 
 @whitelist_for_tests()
-def clear_create_rate_limit() -> None:
-    """Clear rate-limit buckets shared by meeting E2E browser contexts."""
-    for pattern in (
-        "rl:suite.meet.api.meeting.join_meeting_as_guest:*",
-        "rl:suite.meet.api.meeting.create:*",
-        "rl:suite.meet.api.meeting.get_public_meeting_preview:*",
-        "rl:suite.meet.api.meeting.check_meeting_access:*",
-    ):
-        frappe.cache.delete_keys(pattern)
+def clear_rate_limits() -> None:
+    """Clear Meet API rate-limit buckets shared by E2E browser contexts."""
+    frappe.cache.delete_keys("rl:suite.meet.api.meeting.*")


### PR DESCRIPTION
## Summary

Meet e2e browser contexts share an IP, so newly protected guest endpoints can exhaust dynamic rate-limit buckets across tests and retries. Clear the complete Meet API rate-limit namespace before creating each test room and fail fast when the reset endpoint is unavailable.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33478506577) for commit `f887f6c`.</sub>

</details>
<!-- suite-coverage:end -->
