### PR TITLE
fix(drive): stop chunked uploads corrupting on retry

### DIFF
--- a/e2e/drive-backed-apps/specs/drive/chunked-upload-retry-integrity.spec.ts
+++ b/e2e/drive-backed-apps/specs/drive/chunked-upload-retry-integrity.spec.ts
@@ -1,11 +1,25 @@
-import { createHash, randomBytes } from "node:crypto";
+import { createHash } from "node:crypto";
 import { expect, test } from "../../fixtures/test";
 
 // Matches FileUploader.vue's Dropzone chunkSize (20MB). A file just over one
 // chunk produces exactly 2 chunks, so the second needs a real offset to land
 // at rather than offset 0.
 const CHUNK_SIZE = 20 * 1024 * 1024;
-const fileBuffer = randomBytes(CHUNK_SIZE + 5 * 1024 * 1024);
+
+// Deterministic, not `randomBytes()`: a failing run must be reproducible from
+// its SHA-256 alone, and content has to actually differ from one chunk to the
+// next so a duplication or reorder bug is guaranteed to change the hash.
+function fillDeterministic(size: number): Buffer {
+  const buf = Buffer.alloc(size);
+  let state = 0x2f6e2b1;
+  for (let i = 0; i < size; i++) {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    buf[i] = state & 0xff;
+  }
+  return buf;
+}
+
+const fileBuffer = fillDeterministic(CHUNK_SIZE + 5 * 1024 * 1024);
 const expectedSha256 = createHash("sha256").update(fileBuffer).digest("hex");
 
 /**

--- a/e2e/drive-backed-apps/specs/drive/chunked-upload-retry-integrity.spec.ts
+++ b/e2e/drive-backed-apps/specs/drive/chunked-upload-retry-integrity.spec.ts
@@ -1,0 +1,76 @@
+import { createHash, randomBytes } from "node:crypto";
+import { expect, test } from "../../fixtures/test";
+
+// Matches FileUploader.vue's Dropzone chunkSize (20MB). A file just over one
+// chunk produces exactly 2 chunks, so the second needs a real offset to land
+// at rather than offset 0.
+const CHUNK_SIZE = 20 * 1024 * 1024;
+const fileBuffer = randomBytes(CHUNK_SIZE + 5 * 1024 * 1024);
+const expectedSha256 = createHash("sha256").update(fileBuffer).digest("hex");
+
+/**
+ * Retrying a failed upload resends chunk 0 under the same upload id. The
+ * retry must overwrite the already-staged bytes, not duplicate them.
+ */
+test("retrying a failed chunked upload does not duplicate already-staged bytes", async ({
+  owner,
+}) => {
+  const { page } = owner;
+  let uploadRequestsSeen = 0;
+
+  await page.route(
+    "**/api/method/suite.drive.api.files.upload_file",
+    async (route) => {
+      uploadRequestsSeen++;
+      // Let chunk 0 through; drop chunk 1 exactly once to simulate a network
+      // failure partway through the upload (the second upload_file call is
+      // always chunk 1 here, since Dropzone sends chunks sequentially and
+      // `parallelChunkUploads` is unset).
+      if (uploadRequestsSeen === 2) {
+        await route.abort("failed");
+      } else {
+        await route.continue();
+      }
+    },
+  );
+
+  await page.goto("/drive");
+  const fileName = `chunked-retry-${Date.now()}.bin`;
+  await page.getByTestId("drive-file-input").setInputFiles({
+    name: fileName,
+    mimeType: "application/octet-stream",
+    buffer: fileBuffer,
+  });
+
+  await expect(page.getByText(/upload.*failed/i)).toBeVisible({ timeout: 30_000 });
+
+  let finalizedFile: { name: string; file_size: number } | null = null;
+  page.on("response", async (response) => {
+    if (!response.url().includes("upload_file") || !response.ok()) return;
+    try {
+      const body = await response.json();
+      if (body?.message?.name) finalizedFile = body.message;
+    } catch {
+      // Intermediate chunk responses have an empty body.
+    }
+  });
+
+  await page.getByTestId("upload-retry-button").click();
+
+  await expect
+    .poll(() => finalizedFile, { timeout: 30_000, message: "retry never finalized the upload" })
+    .not.toBeNull();
+
+  const finalized = finalizedFile as unknown as { name: string; file_size: number };
+  expect(finalized.file_size, "reported file_size must match the original, not an inflated retry").toBe(
+    fileBuffer.length,
+  );
+
+  const content = await page.request.get(
+    `/api/method/suite.drive.api.files.get_file_content?entity_name=${finalized.name}`,
+  );
+  expect(content.ok()).toBe(true);
+  const bytes = await content.body();
+  expect(bytes.length).toBe(fileBuffer.length);
+  expect(createHash("sha256").update(bytes).digest("hex")).toBe(expectedSha256);
+});

--- a/frontend/src/apps/drive/components/Sidebar.vue
+++ b/frontend/src/apps/drive/components/Sidebar.vue
@@ -3,7 +3,7 @@
     <SidebarHeader title="Drive" :subtitle="currentUserFullName" :menu-items="settingsItems" :logo="FrappeDriveLogo" />
     <div class="flex-1 overflow-y-auto px-2">
       <SidebarSection v-for="(section, index) in sidebarItems" :key="section.label || index" :label="section.label" :collapsible="section.collapsible">
-        <SidebarItem v-for="item in section.items" :key="item.label" :class="draggedSpace === item.label && 'ring-1 ring-outline-gray-3 !bg-surface-gray-3'" :label="item.label" :access-key="item.accessKey" :icon="item.icon" :suffix="item.suffix" :to="item.to" :active="item.isActive" :on-click="item.onClick" @dragover.prevent=";['Trash', 'Home'].includes(item.label) && (draggedSpace = item.label)" @dragleave="draggedSpace = null" @drop.prevent="handleDrop($event, item)" />
+        <SidebarItem v-for="item in section.items" :key="item.label" :class="[draggedSpace === item.label && 'ring-1 ring-outline-gray-3 !bg-surface-gray-3', 'has-[>*:first-child:focus-visible]:focus-ring [&>*:first-child]:focus-visible:outline-none']" :label="item.label" :access-key="item.accessKey" :icon="item.icon" :suffix="item.suffix" :to="item.to" :active="item.isActive" :on-click="item.onClick" @dragover.prevent=";['Trash', 'Home'].includes(item.label) && (draggedSpace = item.label)" @dragleave="draggedSpace = null" @drop.prevent="handleDrop($event, item)" />
       </SidebarSection>
     </div>
     <div class="p-2">

--- a/frontend/src/apps/drive/components/UploadTracker.vue
+++ b/frontend/src/apps/drive/components/UploadTracker.vue
@@ -55,6 +55,7 @@
               variant="ghost"
               :icon="LucideRefreshCcw"
               class="rounded-full hover:bg-surface-gray-2"
+              data-testid="upload-retry-button"
               @click.stop="emitter.emit('retryUpload', upload.uuid)"
             />
             <!-- <Button
@@ -96,8 +97,9 @@ import LucideX from '~icons/lucide/x'
 import LucideRefreshCcw from '~icons/lucide/refresh-ccw'
 import { uploadsInProgress, uploadsCompleted, uploadsFailed, clearUploads } from '@/apps/drive/data/uploads'
 import { useRouter } from 'vue-router'
-import { ref } from 'vue'
+import { inject, ref } from 'vue'
 
+const emitter = inject('emitter')
 const collapsed = ref(false)
 const showErrorDialog = ref(false)
 const hoverIndex = ref(null)

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -164,7 +164,10 @@ def upload_file(
         acquire_owner_storage_lock(frappe.session.user)
         validate_quota(incoming_size=file_size)
 
-        mime_type = mimemapper.get_mime_type(str(staging_path), native_first=False)
+        # mimemapper reads the extension off this string, not the file's actual
+        # bytes - it must be the uploaded name, not the staging path, which is
+        # a content-addressed `.part` file with no extension of its own.
+        mime_type = mimemapper.get_mime_type(file_name, native_first=False)
         file_type = get_file_type(mime_type)
         manager = FileManager()
 

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -186,12 +186,15 @@ def upload_file(
             drive_file.save()
     except Exception:
         # Let the same uuid be retried from scratch instead of inheriting a
-        # half-finalized partial.
+        # half-finalized partial. The claim is released only here - on success
+        # it stays in place until its TTL, so a resend of the same session
+        # (e.g. the client never saw the response) can't re-finalize and
+        # insert the file twice.
         staging_path.unlink(missing_ok=True)
+        cache.delete_value(claim, make_keys=False)
         raise
     finally:
         cache.delete_value(chunks_key)
-        cache.delete_value(claim, make_keys=False)
 
     try:
         update_file_size(parent, file_size)

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -154,9 +154,12 @@ def upload_file(
         return
 
     # With a complete ledger, two concurrent requests can both reach this line;
-    # the winner of this claim is the one that finalizes.
+    # the winner of this claim is the one that finalizes. No TTL: a completed
+    # session must never be re-finalizable, at any distance in time, not just
+    # within a window - an expiring claim would let a sufficiently late resend
+    # (or a deliberate replay) insert the file a second time.
     claim = cache.make_key(f"drive-upload-done:{staging_name}")
-    if not cache.set(claim, frappe.session.user, ex=UPLOAD_SESSION_TTL, nx=True):
+    if not cache.set(claim, frappe.session.user, nx=True):
         return
 
     try:
@@ -189,10 +192,10 @@ def upload_file(
             drive_file.save()
     except Exception:
         # Let the same uuid be retried from scratch instead of inheriting a
-        # half-finalized partial. The claim is released only here - on success
-        # it stays in place until its TTL, so a resend of the same session
-        # (e.g. the client never saw the response) can't re-finalize and
-        # insert the file twice.
+        # half-finalized partial. The claim is released only here - on
+        # success it is never released, so a resend of the same session
+        # (e.g. the client never saw the response, or a later replay) can't
+        # re-finalize and insert the file twice.
         staging_path.unlink(missing_ok=True)
         cache.delete_value(claim, make_keys=False)
         raise

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -13,7 +13,7 @@ import frappe
 import mimemapper
 from frappe.rate_limiter import rate_limit
 from pypika import Order
-from werkzeug.utils import secure_filename, send_file
+from werkzeug.utils import send_file
 from werkzeug.wrappers import Response
 from werkzeug.wsgi import wrap_file
 
@@ -46,6 +46,10 @@ from .permissions import user_has_permission
 
 FORBIDDEN_DOWNLOAD_TYPES = ["Folder", "Link", "Document", "Presentation"]
 
+# How long a partial upload's staging file and chunk ledger are kept before
+# `clear_stale_uploads` reclaims them.
+UPLOAD_SESSION_TTL = 24 * 60 * 60
+
 
 @frappe.whitelist(allow_guest=True)
 def upload_file(
@@ -76,7 +80,8 @@ def upload_file(
         parent = ensure_path(fullpath, parent)
 
     # Support both chunked and non-chunked uploads
-    if frappe.form_dict.chunk_index:
+    chunked = bool(frappe.form_dict.chunk_index)
+    if chunked:
         current_chunk = int(frappe.form_dict.chunk_index)
         total_chunks = int(frappe.form_dict.total_chunk_count)
         offset = int(frappe.form_dict.chunk_byte_offset)
@@ -85,6 +90,7 @@ def upload_file(
         current_chunk = 0
         total_chunks = 1
 
+    total_file_size = int(total_file_size or 0)
     file = frappe.request.files["file"]
     file_name = get_new_file_name(file.filename, parent)
     upload_session = frappe.form_dict.uuid
@@ -92,42 +98,100 @@ def upload_file(
         upload_session = frappe.generate_hash(12)
     if not isinstance(upload_session, str) or not re.fullmatch(r"[A-Za-z0-9-]{1,64}", upload_session):
         frappe.throw("Invalid upload session.", frappe.ValidationError)
-    temp_path = get_upload_path(f"{upload_session}_{secure_filename(file_name)}")
-    with temp_path.open("ab") as f:
-        f.seek(offset)
-        f.write(file.stream.read())
-        if not f.tell() >= int(total_file_size) or current_chunk != total_chunks - 1:
-            return
 
-    # Validate that file size is matching
-    file_size = temp_path.stat().st_size
-    acquire_owner_storage_lock(frappe.session.user)
+    # chunk_byte_offset is client-supplied and decides where a write lands, so
+    # bound it before anything touches disk.
+    if total_chunks < 1 or not 0 <= current_chunk < total_chunks:
+        frappe.throw("Invalid chunk index.", frappe.ValidationError)
+    if offset < 0:
+        frappe.throw("Invalid chunk offset.", frappe.ValidationError)
+    if chunked and total_file_size <= 0:
+        frappe.throw("Chunked uploads must declare the total file size.", frappe.ValidationError)
+
+    data = file.stream.read()
+    if total_file_size and offset + len(data) > total_file_size:
+        frappe.throw("Chunk falls outside the declared file size.", frappe.ValidationError)
+
+    # Check quota before writing, not after.
+    validate_quota(incoming_size=total_file_size or len(data))
+
+    staging_name = get_staging_name(upload_session)
+    staging_path = get_upload_path(staging_name)
+
+    # pwrite at the chunk's own offset, instead of opening in append mode and
+    # seeking: POSIX O_APPEND ignores the seek and always writes at EOF, so a
+    # re-sent chunk (e.g. a retried upload) would duplicate bytes instead of
+    # overwriting them.
+    fd = os.open(staging_path, os.O_RDWR | os.O_CREAT | os.O_NOFOLLOW, 0o600)
     try:
+        os.pwrite(fd, data, offset)
+    finally:
+        os.close(fd)
+
+    # Track which chunks have actually arrived instead of inferring completion
+    # from file size, which can't tell "every chunk arrived" from "one chunk
+    # arrived twice".
+    cache = frappe.cache()
+    chunks_key = f"drive-upload-chunks:{staging_name}"
+    cache.hset(chunks_key, current_chunk, len(data))
+    # RedisWrapper namespaces keys inside hset/hgetall but not inside expire.
+    cache.expire(cache.make_key(chunks_key), UPLOAD_SESSION_TTL)
+    received = cache.hgetall(chunks_key)
+    if len(received) < total_chunks:
+        return
+
+    try:
+        staged_size = staging_path.stat().st_size
+    except FileNotFoundError:
+        # A concurrent request for this session already finalized and moved
+        # the staging file; it owns the insert.
+        return
+    if total_file_size and (staged_size != total_file_size or sum(received.values()) != total_file_size):
+        # Every index arrived but the bytes don't add up - could be a sparse
+        # file (a write at a far offset inflates st_size without allocating
+        # anything) or overlapping chunks. Leave it for the sweep rather than
+        # committing a short or fake-sized file.
+        return
+
+    # With a complete ledger, two concurrent requests can both reach this line;
+    # the winner of this claim is the one that finalizes.
+    claim = cache.make_key(f"drive-upload-done:{staging_name}")
+    if not cache.set(claim, frappe.session.user, ex=UPLOAD_SESSION_TTL, nx=True):
+        return
+
+    try:
+        file_size = staged_size
+        acquire_owner_storage_lock(frappe.session.user)
         validate_quota(incoming_size=file_size)
+
+        mime_type = mimemapper.get_mime_type(str(staging_path), native_first=False)
+        file_type = get_file_type(mime_type)
+        manager = FileManager()
+
+        drive_file = create_drive_file(
+            file_name,
+            parent,
+            file_type,
+            lambda file: "/" + str(manager.get_disk_path(file, embed)),
+            mime_type,
+            file_size,
+            int(file_modified) / 1000 if file_modified else None,
+        )
+
+        # Upload and update parent folder size
+        manager.upload_file(staging_path, drive_file, not embed)
+        # Change path to be s3 compatible
+        if manager.s3_enabled:
+            drive_file.file_url = get_s3_url(get_s3_key(drive_file.file_url))
+            drive_file.save()
     except Exception:
-        temp_path.unlink(missing_ok=True)
+        # Let the same uuid be retried from scratch instead of inheriting a
+        # half-finalized partial.
+        staging_path.unlink(missing_ok=True)
         raise
-
-    mime_type = mimemapper.get_mime_type(str(temp_path), native_first=False)
-    file_type = get_file_type(mime_type)
-    manager = FileManager()
-
-    drive_file = create_drive_file(
-        file_name,
-        parent,
-        file_type,
-        lambda file: "/" + str(manager.get_disk_path(file, embed)),
-        mime_type,
-        file_size,
-        int(file_modified) / 1000 if file_modified else None,
-    )
-
-    # Upload and update parent folder size
-    manager.upload_file(temp_path, drive_file, not embed)
-    # Change path to be s3 compatible
-    if manager.s3_enabled:
-        drive_file.file_url = get_s3_url(get_s3_key(drive_file.file_url))
-        drive_file.save()
+    finally:
+        cache.delete_value(chunks_key)
+        cache.delete_value(claim, make_keys=False)
 
     try:
         update_file_size(parent, file_size)
@@ -994,6 +1058,16 @@ def track_visit(
         "read",
         True,
     )
+
+
+def get_staging_name(upload_session: str) -> str:
+    """Staging file name for an upload session, hashed from the session user
+    and upload id rather than taken from the request - `.uploads` is a single
+    namespace shared by every caller, so this keeps one user's chunks out of
+    another's staging file. Deliberately excludes the uploaded file's name,
+    which can change mid-upload if a same-named sibling appears."""
+    digest = hashlib.blake2b(f"{frappe.session.user}\0{upload_session}".encode(), digest_size=16).hexdigest()
+    return f"{digest}.part"
 
 
 def get_upload_path(file_name):

--- a/suite/drive/api/scripts.py
+++ b/suite/drive/api/scripts.py
@@ -161,3 +161,18 @@ def clear_download_archives():
             stale = [{"Key": o["Key"]} for o in objects if o["LastModified"] < cutoff_dt]
             if stale:
                 manager.conn.delete_objects(Bucket=bucket, Delete={"Objects": stale})
+
+
+def clear_stale_uploads():
+    """Delete chunked-upload staging files abandoned mid-transfer (e.g. a
+    closed browser tab), which nothing in the request path otherwise reclaims."""
+    import time
+
+    from suite.drive.api.files import UPLOAD_SESSION_TTL, get_upload_path
+
+    cutoff = time.time() - UPLOAD_SESSION_TTL
+    uploads_dir = get_upload_path("probe").parent
+
+    for path in uploads_dir.iterdir():
+        if path.is_file() and path.stat().st_mtime < cutoff:
+            path.unlink(missing_ok=True)

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -440,6 +440,17 @@ class TestDriveFilesAPI(IntegrationTestCase):
                 1,
             )
 
+    def test_completion_claim_never_expires(self):
+        """A TTL'd claim would let a resend past the window re-finalize and
+        duplicate the file - the claim guarding a completed session must
+        outlive any retry, not just the working-upload TTL."""
+        session = frappe.generate_hash(12)
+        with self.set_user(OWNER):
+            self.assertIsNotNone(self.upload(b"AAAA", "no-expiry.txt", session=session, total_size=4))
+            claim_key = frappe.cache().make_key(f"drive-upload-done:{get_staging_name(session)}")
+
+        self.assertEqual(frappe.cache().ttl(claim_key), -1)
+
     def test_chunk_past_the_declared_size_is_rejected_before_writing(self):
         session = frappe.generate_hash(12)
         with self.staging_dir() as uploads:

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -3,6 +3,7 @@ from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock, patch
+from uuid import uuid4
 
 import frappe
 from frappe.tests import IntegrationTestCase
@@ -419,6 +420,26 @@ class TestDriveFilesAPI(IntegrationTestCase):
             with FileManager().get_file(uploaded) as stored:
                 self.assertEqual(stored.read(), b"pasted image bytes")
 
+    def test_retrying_after_a_lost_success_response_does_not_duplicate_the_file(self):
+        """The client can resend the same session after a successful finalize
+        it never saw the response for (e.g. the reply dropped on the way
+        back). That must be a no-op, not a second File."""
+        session = frappe.generate_hash(12)
+        with self.set_user(OWNER):
+            first = self.upload(b"AAAA", "retry-after-success.txt", session=session, total_size=4)
+            self.assertIsNotNone(first)
+
+            second = self.upload(b"AAAA", "retry-after-success.txt", session=session, total_size=4)
+            self.assertIsNone(second)
+
+            self.assertEqual(
+                frappe.db.count(
+                    "File",
+                    {"file_name": ["like", "retry-after-success%"], "folder": self.folder.name},
+                ),
+                1,
+            )
+
     def test_chunk_past_the_declared_size_is_rejected_before_writing(self):
         session = frappe.generate_hash(12)
         with self.staging_dir() as uploads:
@@ -671,7 +692,11 @@ class TestDriveFilesAPI(IntegrationTestCase):
                 file.save()
 
     def test_ordered_chunks_are_assembled_byte_for_byte(self):
-        session = "123e4567-e89b-42d3-a456-426614174000"
+        # A real (hyphenated) UUID, like a real client sends - and unique per
+        # run, or a completed session's claim (now deliberately kept past a
+        # successful finalize, see the retry-after-success test) would make a
+        # second run of this same test a no-op against a stale one.
+        session = str(uuid4())
         with self.set_user(OWNER):
             self.assertIsNone(self.upload(b"hello ", session=session, chunk=(0, 2, 0), total_size=11))
             uploaded = self.upload(b"world", session=session, chunk=(1, 2, 6), total_size=11)

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -15,6 +15,7 @@ from suite.drive.api.files import (
     does_entity_exist,
     get_file_content,
     get_new_title,
+    get_staging_name,
     move,
     remove_or_restore,
     rename,
@@ -245,7 +246,10 @@ class TestDriveFilesAPI(IntegrationTestCase):
             ):
                 upload_file(total_file_size=8, parent=self.folder.name)
 
-            staged_files = list((storage_root / ".uploads").iterdir())
+            # Quota is now checked before anything touches disk, so a rejection
+            # on the very first chunk never creates `.uploads` at all.
+            uploads_dir = storage_root / ".uploads"
+            staged_files = list(uploads_dir.iterdir()) if uploads_dir.exists() else []
             self.assertEqual(staged_files, [])
 
     def test_chunked_upload_without_session_is_rejected_before_writing(self):
@@ -338,8 +342,38 @@ class TestDriveFilesAPI(IntegrationTestCase):
             uploads_root = storage_root / ".uploads"
             uploads_root.mkdir(parents=True)
             outside_file = Path(temp_dir) / "outside.txt"
-            (uploads_root / "valid-session_upload.txt").symlink_to(outside_file)
 
+            with self.set_user(OWNER):
+                # The staging name is derived from the session user, so the
+                # symlink has to be planted at the name that user will resolve to.
+                (uploads_root / get_staging_name("valid-session")).symlink_to(outside_file)
+
+                with (
+                    patch(
+                        "suite.drive.api.files.frappe.get_site_path",
+                        return_value=str(storage_root),
+                    ),
+                    patch(
+                        "suite.drive.api.files.frappe.get_single",
+                        return_value=frappe._dict(root_folder=""),
+                    ),
+                    self.assertRaises(frappe.ValidationError),
+                ):
+                    self.upload(
+                        b"partial",
+                        session="valid-session",
+                        chunk=(0, 2, 0),
+                        total_size=20,
+                    )
+
+            self.assertFalse(outside_file.exists())
+
+    @contextmanager
+    def staging_dir(self):
+        """Run an upload against a throwaway staging root and hand back its path."""
+        with TemporaryDirectory() as temp_dir:
+            storage_root = Path(temp_dir) / "private" / "files"
+            storage_root.mkdir(parents=True)
             with (
                 self.set_user(OWNER),
                 patch("suite.drive.api.files.frappe.get_site_path", return_value=str(storage_root)),
@@ -347,16 +381,91 @@ class TestDriveFilesAPI(IntegrationTestCase):
                     "suite.drive.api.files.frappe.get_single",
                     return_value=frappe._dict(root_folder=""),
                 ),
-                self.assertRaises(frappe.ValidationError),
             ):
-                self.upload(
-                    b"partial",
-                    session="valid-session",
-                    chunk=(0, 2, 0),
-                    total_size=20,
-                )
+                yield storage_root / ".uploads"
 
-            self.assertFalse(outside_file.exists())
+    def test_resent_chunk_overwrites_instead_of_appending(self):
+        """A re-sent chunk must land back on its own offset, not duplicate.
+        Three chunks are declared so the upload never finalizes and the
+        assertion can read the staged bytes directly."""
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            staged = uploads / get_staging_name(session)
+            self.upload(b"AAAA", session=session, chunk=(0, 3, 0), total_size=12)
+            self.upload(b"AAAA", session=session, chunk=(0, 3, 0), total_size=12)
+            self.upload(b"BBBB", session=session, chunk=(1, 3, 4), total_size=12)
+
+            # Before this fix: b"AAAAAAAABBBB".
+            self.assertEqual(staged.read_bytes(), b"AAAABBBB")
+
+    def test_chunks_arriving_out_of_order_are_assembled_by_offset(self):
+        """Arrival order must not decide byte order - only the offset may."""
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            staged = uploads / get_staging_name(session)
+            self.upload(b"BBBB", session=session, chunk=(1, 3, 4), total_size=12)
+            self.upload(b"AAAA", session=session, chunk=(0, 3, 0), total_size=12)
+
+            # Before this fix: b"BBBBAAAA".
+            self.assertEqual(staged.read_bytes(), b"AAAABBBB")
+
+    def test_single_upload_without_a_declared_size_still_completes(self):
+        """`uploadImage` posts one part through frappe-ui's uploader and sends no
+        total_file_size at all, so none of the size checks may assume one."""
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"pasted image bytes", "paste.png", total_size=0)
+
+            self.assertIsNotNone(uploaded)
+            with FileManager().get_file(uploaded) as stored:
+                self.assertEqual(stored.read(), b"pasted image bytes")
+
+    def test_chunk_past_the_declared_size_is_rejected_before_writing(self):
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            with self.assertRaises(frappe.ValidationError):
+                self.upload(b"AAAA", session=session, chunk=(1, 2, 1024), total_size=8)
+
+            self.assertFalse(uploads.exists())
+
+    def test_single_chunk_upload_cannot_smuggle_an_offset(self):
+        """A one-chunk request still carries a client-supplied chunk_byte_offset,
+        so it needs a declared total to bound it too, not just multi-chunk ones."""
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            with self.assertRaises(frappe.ValidationError):
+                self.upload(b"AAAA", session=session, chunk=(0, 1, 1 << 40), total_size=0)
+
+            self.assertFalse(uploads.exists())
+
+    def test_a_declared_total_does_not_let_a_sparse_file_finalize(self):
+        """Writing only the last few bytes of an honestly-declared total leaves
+        a file whose st_size matches but whose contents were never sent."""
+        session = frappe.generate_hash(12)
+        total = 1 << 30
+        with self.staging_dir() as uploads:
+            staged = uploads / get_staging_name(session)
+            self.assertIsNone(
+                self.upload(b"AAAA", session=session, chunk=(0, 1, total - 4), total_size=total)
+            )
+
+            # Staged at the declared length, but only 4 bytes were ever sent.
+            self.assertEqual(staged.stat().st_size, total)
+
+    def test_chunk_index_outside_the_declared_total_is_rejected(self):
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            with self.assertRaises(frappe.ValidationError):
+                self.upload(b"AAAA", session=session, chunk=(5, 2, 0), total_size=8)
+
+            self.assertFalse(uploads.exists())
+
+    def test_chunked_upload_must_declare_a_total_size(self):
+        session = frappe.generate_hash(12)
+        with self.staging_dir() as uploads:
+            with self.assertRaises(frappe.ValidationError):
+                self.upload(b"AAAA", session=session, chunk=(0, 2, 0), total_size=0)
+
+            self.assertFalse(uploads.exists())
 
     def test_owner_can_read_and_unrelated_user_cannot(self):
         with self.set_user(OWNER):

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -684,6 +684,16 @@ class TestDriveFilesAPI(IntegrationTestCase):
             with FileManager().get_file(uploaded) as stored:
                 self.assertEqual(stored.read(), b"unknown file contents")
 
+    def test_mime_type_is_read_from_the_uploaded_name_not_the_staging_path(self):
+        """mimemapper resolves type from a filename string alone, not file
+        content - it has to see the name the user uploaded, not the
+        content-addressed `.part` staging path, which carries no extension."""
+        with self.set_user(OWNER):
+            uploaded = self.upload(b"plain text content", "notes.txt")
+
+            self.assertEqual(uploaded.file_type, "Text")
+            self.assertEqual(uploaded.mime_type, "text/plain")
+
     def test_file_url_update_requires_valid_storage_path(self):
         with self.set_user(OWNER):
             file = frappe.get_doc("File", self.file.name)

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -279,6 +279,11 @@ setup_wizard_url = "/suite/setup"
 # ============================================================================
 # Scheduled Tasks (per-frequency lists combined; cron keys de-duplicated)
 # ============================================================================
+# Chunked-upload progress lives in the cache; keep it across `bench clear-cache`.
+persistent_cache_keys = [
+    "drive-upload-*",
+]
+
 scheduler_events = {
     "daily": [
         # meet
@@ -286,6 +291,7 @@ scheduler_events = {
         # drive
         "suite.drive.api.scripts.auto_delete_from_trash",
         "suite.drive.api.scripts.clear_deleted_files",
+        "suite.drive.api.scripts.clear_stale_uploads",
         # sheets
         "suite.sheets.versioning.tasks.rollup_snapshots",
         "suite.sheets.versioning.tasks.truncate_op_log",


### PR DESCRIPTION
## Problem

Chunked uploads wrote each chunk with `open(path, "ab")` + `seek(offset)`. POSIX
append mode ignores the seek and always writes at EOF, so any chunk delivered
out of order — including a retried chunk after a dropped connection — silently
duplicated or misordered bytes into the final file. No error surfaced to the
user.

This was reachable in practice, not just in theory: `UploadTracker.vue`'s
Retry button re-sends a failed upload under its original session id starting
from chunk 0, which lands squarely on this bug. That button was also broken
(missing `emitter` injection, so it threw and did nothing) — fixed here too,
since the corruption can't be demonstrated end-to-end without it.

## Fix

- Chunks are now written with `os.pwrite(fd, data, offset)` — offset-addressed,
  so resent or out-of-order chunks land correctly regardless of arrival order.
- A Redis-backed ledger tracks which chunk indices have actually arrived.
  Finalization requires both the full set of indices *and* the summed byte
  count to match the declared total, closing a sparse-file variant where a
  single chunk at a far offset could otherwise pass an `st_size`-only check.
- `chunk_index` / `chunk_byte_offset` are bounds-checked against the declared
  total before any byte touches disk.
- Quota is validated before writing, not after.
- The staging file is now named from a hash of `(session user, upload id)`
  instead of the client-supplied session id, closing a same-name collision
  across users in the shared `.uploads` directory.
- Concurrent duplicate finalize requests (two requests both seeing a complete
  ledger) resolve to a single winner via an atomic Redis claim.
- A new daily job (`clear_stale_uploads`) sweeps orphaned partials left by
  abandoned uploads — nothing in the request path previously reclaimed these.
- Fixed the Retry button crash in `UploadTracker.vue` (missing `emitter`
  injection).
- Also folded in a small frontend fix of focus ring on the search item in the left sidebar

## Testing

- Backend: `test_files.py`, covering resent/out-of-order chunks, offset and
  index bounds, the sparse-file-under-honest-total case, and the
  no-declared-size path used by `frappe-ui`'s single-part uploader. 57/57
  pass, plus the full `suite` app suite (452/454 — the 2 failures are a
  pre-existing, unrelated mock mismatch in `MarkOnboarded`).
- `ruff check` / `ruff format --check` clean.
- E2E: `e2e/drive-backed-apps/specs/drive/chunked-upload-retry-integrity.spec.ts`
  — drops a chunk mid-upload, clicks Retry through a real browser, and asserts
  the finalized file is byte-identical (SHA-256) to the original.