### PR TITLE
feat(meet): project recorded shared stage

### DIFF
--- a/frontend/recorder/RecorderRenderer.test.ts
+++ b/frontend/recorder/RecorderRenderer.test.ts
@@ -15,6 +15,18 @@ describe("RecorderRenderer", () => {
 		raiseHandStore: { raisedHands: {} }, reactionStore: { reactions: {} }, networkQuality: ref("good"),
 	});
 
+	it("shows zero before an authoritative recording start", () => {
+		const root = document.createElement("div");
+		const app = createApp(RecorderRenderer, {
+			startedAt: null,
+			videoManager: { registerVideoElement: vi.fn(), removeVideoElement: vi.fn() },
+			meetingContext: meetingContext(),
+		});
+		app.mount(root);
+		expect(root.querySelector(".rec")?.textContent).toContain("00:00");
+		app.unmount();
+	});
+
 	it("renders chat fields as text rather than executable markup", () => {
 		const root = document.createElement("div");
 		const app = createApp(RecorderRenderer, {

--- a/frontend/recorder/RecorderRenderer.vue
+++ b/frontend/recorder/RecorderRenderer.vue
@@ -38,7 +38,7 @@ import { provideMeetingContext } from "../src/apps/meet/composables/useMeetingCo
 import type { VideoElementManager } from "../src/apps/meet/utils/media/VideoElementManager";
 
 const props = withDefaults(defineProps<{
-	startedAt: number;
+	startedAt?: number | null;
 	interruption?: string | null;
 	messages?: Array<{ id: string; author: string; text: string; avatar?: string | null }>;
 	meetingContext: Parameters<typeof provideMeetingContext>[0];
@@ -97,6 +97,7 @@ const now = ref(Date.now());
 const timer = window.setInterval(() => now.value = Date.now(), 1000);
 onBeforeUnmount(() => clearInterval(timer));
 const elapsed = computed(() => {
+	if (props.startedAt == null) return "00:00";
 	const seconds = Math.max(0, Math.floor((now.value - props.startedAt) / 1000));
 	return `${String(Math.floor(seconds / 60)).padStart(2, "0")}:${String(seconds % 60).padStart(2, "0")}`;
 });

--- a/frontend/recorder/RecorderSocketController.test.ts
+++ b/frontend/recorder/RecorderSocketController.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import type {
-	Participant,
-	ParticipantData,
-} from "../src/apps/meet/utils/media/ParticipantManager";
+	RecorderStageProjectionEvent,
+	RecorderStageSnapshot,
+} from "../../suite/meet/types";
+import type { Participant } from "../src/apps/meet/utils/media/ParticipantManager";
 import type {
 	RecorderParticipantData,
 	RecorderParticipantUpdate,
@@ -12,10 +13,16 @@ import {
 	type RecorderState,
 	trustedAvatar,
 } from "./RecorderSocketController";
-import type { RecorderConfig, RecordingChallenge } from "./rendererBridge";
+import {
+	CaptureCommandSupersededError,
+	type RecorderConfig,
+	type RecordingChallenge,
+} from "./rendererBridge";
 
 vi.stubGlobal("MediaStream", class MediaStream {});
 
+const timestamp = (seconds: number) =>
+	`2026-08-30T12:00:${String(seconds).padStart(2, "0")}.000Z`;
 const config: RecorderConfig = {
 	job: "j",
 	grant: "g",
@@ -23,7 +30,7 @@ const config: RecorderConfig = {
 	sfuOrigin: "https://sfu.test",
 	frappeOrigin: "https://frappe.test",
 	socketPath: "/socket.io",
-	acceptedAt: "2026-08-30T12:00:00.000Z",
+	acceptedAt: timestamp(0),
 };
 const challenge: RecordingChallenge = {
 	protocol_version: 1,
@@ -33,13 +40,36 @@ const challenge: RecordingChallenge = {
 	issued_at: 1,
 	expires_at: 11,
 };
-type ChallengeFixture = RecordingChallenge | { protocol_version: 2 };
-
-interface ProducerFixture {
-	id: string;
-	participantId: string;
-	isScreen?: boolean;
-}
+const participant = {
+	participant_id: "alice",
+	name: "Alice",
+	audio_enabled: true,
+	video_enabled: false,
+};
+const snapshot = (
+	overrides: Partial<RecorderStageSnapshot> = {},
+): RecorderStageSnapshot => ({
+	protocol_version: 1,
+	room_id: "site::r",
+	cursor: 0,
+	observed_at: timestamp(0),
+	participants: [],
+	producers: [],
+	raised_hands: {},
+	active_speaker_ids: [],
+	...overrides,
+});
+const projectionEvent = (
+	cursor: number,
+	payload: RecorderStageProjectionEvent["payload"],
+	observedAt = timestamp(cursor),
+): RecorderStageProjectionEvent => ({
+	protocol_version: 1,
+	room_id: "site::r",
+	cursor,
+	observed_at: observedAt,
+	payload,
+});
 
 interface ConsumerFixture {
 	id: string;
@@ -49,29 +79,6 @@ interface ConsumerFixture {
 	isScreen: boolean;
 }
 
-interface ParticipantHandlers {
-	onParticipantAdded?: (participant: Participant) => void;
-	onParticipantRemoved?: (participantId: string) => void;
-	onParticipantUpdated?: (
-		participantId: string,
-		participant: Participant,
-		updates: RecorderParticipantUpdate,
-	) => void;
-}
-
-interface ConsumerHandlers {
-	onConsumerAdded?: (consumer: ConsumerFixture) => void;
-	onConsumerRemoved?: (consumerId: string, consumer: ConsumerFixture) => void;
-}
-
-interface MediaHandlers {
-	onScreenShareStarted?: (value: {
-		participantId: string;
-		stream: MediaStream;
-		consumer: ConsumerFixture;
-	}) => void;
-}
-
 const participantFixture = (data: RecorderParticipantData): Participant => ({
 	user_id: data.participantId || data.user_id || "",
 	user_name: data.userData?.name || data.user_name || "",
@@ -79,43 +86,54 @@ const participantFixture = (data: RecorderParticipantData): Participant => ({
 	initials: "",
 	audio_enabled: data.userData?.audio_enabled ?? data.audio_enabled,
 	video_enabled: data.userData?.video_enabled ?? data.video_enabled,
-	is_guest: data.userData?.is_guest ?? data.is_guest,
 	participantId: data.participantId,
 	userData: data.userData,
 });
 
 function harness(
-	existing: ProducerFixture[] = [],
-	subscription?: ConsumerFixture | null,
-	state: RecorderState = {},
-	challengeFixture: ChallengeFixture = challenge,
+	options: {
+		snapshot?: unknown | unknown[];
+		state?: RecorderState;
+		noConsumer?: boolean;
+		attachment?: (consumer: ConsumerFixture) => Promise<void>;
+		onSnapshotRequest?: (emitProjection: (value: unknown) => void) => void;
+	} = {},
 ) {
 	const calls: string[] = [];
 	const socketHandlers = new Map<string, (...args: unknown[]) => void>();
 	const sfuHandlers = new Map<string, (...args: unknown[]) => void>();
-	let consumerHandlers: ConsumerHandlers = {};
-	let participantHandlers: ParticipantHandlers = {};
-	let mediaHandlers: MediaHandlers = {};
+	let consumerHandlers: Record<string, (...args: never[]) => void> = {};
+	let participantHandlers: Record<string, (...args: never[]) => void> = {};
+	let mediaHandlers: Record<string, (...args: never[]) => void> = {};
+	let snapshotRequest = 0;
+	const participants = new Map<string, Participant>();
+	const consumers = new Map<string, ConsumerFixture>();
+	const emitProjection = (value: unknown) =>
+		sfuHandlers.get("recording:projection")?.(value);
 	const channel = {
 		on: vi.fn((event: string, handler: (...args: unknown[]) => void) =>
 			socketHandlers.set(event, handler),
 		),
 		connect: vi.fn(async () => {
 			calls.push("connect");
-			socketHandlers.get("recording:challenge")?.(challengeFixture);
+			socketHandlers.get("recording:challenge")?.(challenge);
 		}),
 		emit: vi.fn(
-			(
-				event: string,
-				_data: { protocol_version: 1; signature: string } | { roomId: string },
-				callback?: (value: unknown) => void,
-			) => {
+			(event: string, _data: unknown, callback?: (value: unknown) => void) => {
 				calls.push(event);
-				callback?.(
-					event === "recording:proof"
-						? { protocol_version: 1, success: true }
-						: { success: true },
-				);
+				if (event === "recording:proof")
+					callback?.({ protocol_version: 1, success: true });
+				else if (event === "recording:get_projection_snapshot") {
+					const configured = Array.isArray(options.snapshot)
+						? options.snapshot[Math.min(snapshotRequest, options.snapshot.length - 1)]
+						: options.snapshot;
+					snapshotRequest += 1;
+					options.onSnapshotRequest?.(emitProjection);
+					callback?.({
+						success: true,
+						snapshot: configured ?? snapshot(),
+					});
+				} else callback?.({ success: true });
 			},
 		),
 		disconnect: vi.fn(),
@@ -132,31 +150,23 @@ function harness(
 		reportJoinComplete: vi.fn(),
 		reportFailure: vi.fn(),
 	};
-	const participants = new Map<string, Participant>();
-	const consumers = new Map<string, ConsumerFixture>();
 	const removeConsumer = vi.fn((id: string) => {
 		const consumer = consumers.get(id);
-		if (!consumer) return undefined;
+		if (!consumer) return;
 		consumers.delete(id);
-		consumerHandlers.onConsumerRemoved?.(id, consumer);
-		return consumer;
+		consumerHandlers.onConsumerRemoved?.(id as never, consumer as never);
 	});
 	const dependencies = {
-		sfuClient: {
+			sfuClient: {
 			connected: false,
 			connectionDetails: {},
-			on: vi.fn((event: string, handler: (...args: unknown[]) => void) =>
-				sfuHandlers.set(event, handler),
-			),
+				on: vi.fn((event: string, handler: (...args: unknown[]) => void) =>
+					sfuHandlers.set(event, handler),
+				),
+				off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+					if (sfuHandlers.get(event) === handler) sfuHandlers.delete(event);
+				}),
 			registerEventHandlers: vi.fn(),
-			getRoomParticipants: vi.fn(async (): Promise<ParticipantData[]> => {
-				calls.push("participants");
-				return [];
-			}),
-			getExistingProducers: vi.fn(async () => {
-				calls.push("producers");
-				return existing;
-			}),
 			disconnect: vi.fn(),
 		},
 		transportManager: {
@@ -166,16 +176,14 @@ function harness(
 			cleanup: vi.fn(),
 		},
 		consumerManager: {
-			setEventHandlers: vi.fn((handlers: ConsumerHandlers) => {
-				consumerHandlers = { ...consumerHandlers, ...handlers };
+			setEventHandlers: vi.fn((handlers: typeof consumerHandlers) => {
+				consumerHandlers = handlers;
 			}),
 			getConsumersByParticipant: vi.fn((id: string) =>
-				[...consumers.values()].filter(
-					(consumer) => consumer.participantId === id,
-				),
+				[...consumers.values()].filter((item) => item.participantId === id),
 			),
 			getScreenShareConsumers: vi.fn(() =>
-				[...consumers.values()].filter((consumer) => consumer.isScreen),
+				[...consumers.values()].filter((item) => item.isScreen),
 			),
 			cleanupParticipantConsumers: vi.fn((id: string) => {
 				for (const consumer of [...consumers.values()])
@@ -188,29 +196,43 @@ function harness(
 			removeConsumer,
 		},
 		participantManager: {
-			setEventHandlers: vi.fn((handlers: ParticipantHandlers) => {
+			setEventHandlers: vi.fn((handlers: typeof participantHandlers) => {
 				participantHandlers = handlers;
 			}),
-			syncParticipants: vi.fn((values: RecorderParticipantData[]) =>
-				values.forEach((value) => {
-					const participant = participantFixture(value);
-					participants.set(participant.user_id, participant);
-				}),
-			),
+			syncParticipants: vi.fn((values: RecorderParticipantData[]) => {
+				for (const value of values) {
+					const item = participantFixture(value);
+					participants.set(item.user_id, item);
+					participantHandlers.onParticipantAdded?.(item as never);
+				}
+			}),
 			addParticipant: vi.fn((value: RecorderParticipantData) => {
-				const participant = participantFixture(value);
-				participants.set(participant.user_id, participant);
-				participantHandlers.onParticipantAdded?.(participant);
-				return participant;
+				const item = participantFixture(value);
+				participants.set(item.user_id, item);
+				participantHandlers.onParticipantAdded?.(item as never);
+				return item;
 			}),
 			removeParticipant: vi.fn((id: string) => {
 				const removed = participants.delete(id);
-				if (removed) participantHandlers.onParticipantRemoved?.(id);
+				if (removed) participantHandlers.onParticipantRemoved?.(id as never);
 				return removed;
 			}),
 			updateMediaState: vi.fn(),
+			updateParticipant: vi.fn(
+				(id: string, updates: RecorderParticipantUpdate) => {
+					const current = participants.get(id);
+					if (!current) return null;
+					const updated = { ...current, ...updates } as Participant;
+					participants.set(id, updated);
+					participantHandlers.onParticipantUpdated?.(
+						id as never,
+						updated as never,
+						updates as never,
+					);
+					return updated;
+				},
+			),
 			getAllParticipants: vi.fn(() => [...participants.values()]),
-			hasParticipant: vi.fn((id: string) => participants.has(id)),
 		},
 		videoManager: {
 			removeVideoElement: vi.fn(),
@@ -218,34 +240,35 @@ function harness(
 			cleanup: vi.fn(),
 		},
 		mediaManager: {
-			setEventHandlers: vi.fn((handlers: MediaHandlers) => {
+			setEventHandlers: vi.fn((handlers: typeof mediaHandlers) => {
 				mediaHandlers = handlers;
 			}),
 			handleNewConsumer: vi.fn(async (consumer: ConsumerFixture) => {
+				await options.attachment?.(consumer);
 				if (consumer.isScreen)
 					mediaHandlers.onScreenShareStarted?.({
 						participantId: consumer.participantId,
 						stream: new MediaStream(),
 						consumer,
-					});
+					} as never);
 			}),
 			handleConsumerLost: vi.fn(),
 			subscribeToRemoteProducer: vi.fn(
-				async (event: {
+				async (producer: {
 					producerId: string;
 					participantId: string;
 					isScreen: boolean;
 				}) => {
-					if (subscription === null) return null;
-					const consumer: ConsumerFixture = subscription || {
-						id: `c-${event.producerId}`,
-						producerId: event.producerId,
-						participantId: event.participantId,
-						kind: event.isScreen ? "video" : "audio",
-						isScreen: event.isScreen,
+					if (options.noConsumer) return null;
+					const consumer: ConsumerFixture = {
+						id: `c-${producer.producerId}`,
+						producerId: producer.producerId,
+						participantId: producer.participantId,
+						kind: producer.isScreen ? "video" : "audio",
+						isScreen: producer.isScreen,
 					};
 					consumers.set(consumer.id, consumer);
-					consumerHandlers.onConsumerAdded?.(consumer);
+					consumerHandlers.onConsumerAdded?.(consumer as never);
 					return consumer;
 				},
 			),
@@ -256,26 +279,26 @@ function harness(
 	const controller = new RecorderSocketController(
 		bridge as never,
 		channel,
-		state,
+		options.state,
 		dependencies as never,
 	);
 	return {
+		bridge,
 		calls,
 		channel,
-		bridge,
 		consumers,
-		dependencies,
-		sfuHandlers,
-		getConsumerHandlers: () => consumerHandlers,
-		getParticipantHandlers: () => participantHandlers,
-		participants,
 		controller,
+		dependencies,
+		emitProjection,
+		participants,
+		sfuHandlers,
 	};
 }
 
 describe("RecorderSocketController", () => {
-	it("waits for proof, receive transport, and initial sync before reporting ready", async () => {
-		const h = harness();
+	it("uses one projection snapshot after the receive transport", async () => {
+		const frameCommitted = vi.fn(async () => undefined);
+		const h = harness({ state: { frameCommitted } });
 		await h.controller.connect(config);
 		expect(h.calls).toEqual([
 			"connect",
@@ -283,509 +306,537 @@ describe("RecorderSocketController", () => {
 			"recording:join",
 			"device",
 			"recv",
-			"participants",
-			"producers",
+			"recording:get_projection_snapshot",
 		]);
-		expect(h.channel.emit).toHaveBeenCalledWith(
-			"recording:proof",
-			{ protocol_version: 1, signature: "signature" },
-			expect.any(Function),
-		);
 		expect(h.controller.ready.value).toBe(true);
+		expect(frameCommitted).toHaveBeenCalledOnce();
 		expect(h.bridge.reportCaptureReady).toHaveBeenCalledOnce();
 	});
 
-	it("deduplicates snapshot and live producers during sync", async () => {
-		const h = harness([{ id: "p1", participantId: "alice" }]);
-		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(
-			async () => {
-				h.sfuHandlers.get("producer_created")?.({
-					producerId: "p1",
-					participantId: "alice",
-				});
-				return [{ id: "p1", participantId: "alice" }];
-			},
+	it("binds the first projection snapshot to the configured Meet Room", async () => {
+		const h = harness({ snapshot: snapshot({ room_id: "site::other" }) });
+		await expect(h.controller.connect(config)).rejects.toThrow(
+			"Projection meeting mismatch",
 		);
-		await h.controller.connect(config);
-		expect(
-			h.dependencies.mediaManager.subscribeToRemoteProducer,
-		).toHaveBeenCalledOnce();
+		expect(h.bridge.reportCaptureReady).not.toHaveBeenCalled();
 	});
 
-	it("claims duplicate live producers synchronously", async () => {
-		const h = harness();
-		await h.controller.connect(config);
-
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "p1",
-			participantId: "alice",
-		});
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "p1",
-			participantId: "alice",
-		});
-		await vi.waitFor(() =>
-			expect(
-				h.dependencies.mediaManager.subscribeToRemoteProducer,
-			).toHaveBeenCalledOnce(),
-		);
-	});
-
-	it("tombstones producer closes and participant leaves during snapshots", async () => {
-		const h = harness([{ id: "p1", participantId: "alice" }]);
-		h.dependencies.sfuClient.getRoomParticipants.mockImplementationOnce(
-			async () => {
-				h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
-				h.sfuHandlers.get("producer_closed")?.({
-					producerId: "p1",
-					participantId: "alice",
-				});
-				return [
-					{
-						participantId: "alice",
-						user_id: "alice",
-						userData: { name: "Alice" },
+	it("attaches producers created during the initial committed-frame window", async () => {
+		let h!: ReturnType<typeof harness>;
+		const frameCommitted = vi.fn(async () => {
+			if (frameCommitted.mock.calls.length !== 1) return;
+			h.emitProjection(
+				projectionEvent(1, {
+					type: "producer_created",
+					producer: {
+						producer_id: "late",
+						participant_id: "alice",
+						kind: "audio",
+						paused: false,
+						is_screen: false,
+						observed_at: timestamp(1),
 					},
-				];
-			},
-		);
+				}),
+			);
+		});
+		h = harness({
+			state: { frameCommitted },
+			snapshot: snapshot({ participants: [participant] }),
+		});
 		await h.controller.connect(config);
-		expect(h.participants.has("alice")).toBe(false);
-		expect(
-			h.dependencies.mediaManager.subscribeToRemoteProducer,
-		).not.toHaveBeenCalled();
+		expect(frameCommitted).toHaveBeenCalledTimes(2);
+		expect(h.consumers.has("c-late")).toBe(true);
+		expect(h.bridge.reportCaptureReady).toHaveBeenCalledOnce();
 	});
 
-	it("does not resurrect old producers when a participant leaves and rejoins", async () => {
-		const h = harness([{ id: "old", participantId: "alice" }]);
-		h.dependencies.sfuClient.getRoomParticipants.mockResolvedValueOnce([
-			{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } },
-		]);
-		h.dependencies.sfuClient.getExistingProducers.mockImplementationOnce(
-			async () => {
-				h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
-				h.sfuHandlers.get("participant_joined")?.({ participantId: "alice" });
-				h.sfuHandlers.get("producer_created")?.({
-					producerId: "new",
-					participantId: "alice",
-				});
-				return [{ id: "old", participantId: "alice" }];
-			},
-		);
+	it("recommits for persistent frame races without starving on transient events", async () => {
+		let h!: ReturnType<typeof harness>;
+		const frameCommitted = vi.fn(async () => {
+			if (frameCommitted.mock.calls.length === 1) {
+				h.emitProjection(
+					projectionEvent(1, {
+						type: "participant_updated",
+						participant: { ...participant, name: "Alice Updated" },
+					}),
+				);
+			} else if (frameCommitted.mock.calls.length === 2) {
+				h.emitProjection(
+					projectionEvent(2, {
+						type: "hand_raised",
+						participant_id: "alice",
+						raised: true,
+					}),
+				);
+			} else if (frameCommitted.mock.calls.length === 3) {
+				h.emitProjection(
+					projectionEvent(3, {
+						type: "active_speaker",
+						participant_ids: ["alice"],
+					}),
+				);
+			} else {
+				h.emitProjection(
+					projectionEvent(4, {
+						type: "chat_message",
+						message_id: "during-commit",
+						message: "transient",
+						from_user: "alice",
+						from_name: "Alice",
+					}),
+				);
+			}
+		});
+		h = harness({
+			state: { frameCommitted },
+			snapshot: snapshot({ participants: [participant] }),
+		});
 
 		await h.controller.connect(config);
 
+		expect(frameCommitted).toHaveBeenCalledTimes(4);
+		expect(h.bridge.reportCaptureReady).toHaveBeenCalledOnce();
+	});
+
+	it("reconciles snapshot races and ignores duplicate cursors", async () => {
+		const joined = projectionEvent(1, {
+			type: "participant_joined",
+			participant,
+		});
+		const producer = projectionEvent(2, {
+			type: "producer_created",
+			producer: {
+				producer_id: "p1",
+				participant_id: "alice",
+				kind: "audio",
+				paused: false,
+				is_screen: false,
+				observed_at: timestamp(2),
+			},
+		});
+		const h = harness({
+			onSnapshotRequest: (emit) => {
+				emit(producer);
+				emit(joined);
+				emit(producer);
+			},
+		});
+		await h.controller.connect(config);
+		expect(h.participants.has("alice")).toBe(true);
 		expect(
 			h.dependencies.mediaManager.subscribeToRemoteProducer,
 		).toHaveBeenCalledOnce();
-		expect(
-			h.dependencies.mediaManager.subscribeToRemoteProducer,
-		).toHaveBeenCalledWith({
-			producerId: "new",
-			participantId: "alice",
-			isScreen: false,
-		});
 	});
 
-	it("fails readiness when an initial producer returns no consumer", async () => {
-		const h = harness([{ id: "p1", participantId: "alice" }], null);
+	it.each([
+		projectionEvent(2, { type: "active_speaker", participant_ids: [] }),
+		{
+			...projectionEvent(1, { type: "active_speaker", participant_ids: [] }),
+			extra: true,
+		},
+		{
+			...projectionEvent(1, { type: "active_speaker", participant_ids: [] }),
+			room_id: "other",
+		},
+	])(
+		"interrupts and cleans up for a gap, invalid event, or room mismatch",
+		async (event) => {
+			const h = harness();
+			await h.controller.connect(config);
+			h.emitProjection(event);
+			expect(h.bridge.reportInterruption).toHaveBeenCalledWith(
+				"projection_invalid",
+				expect.any(String),
+			);
+			expect(h.controller.ready.value).toBe(false);
+			expect(h.dependencies.sfuClient.disconnect).toHaveBeenCalled();
+		},
+	);
+
+	it("fails closed on an invalid snapshot without reporting configuration failure", async () => {
+		const h = harness({ snapshot: { ...snapshot(), cursor: -1 } });
+		await expect(h.controller.connect(config)).rejects.toThrow(
+			"Invalid recorder projection snapshot",
+		);
+		expect(h.bridge.reportInterruption).toHaveBeenCalledWith(
+			"projection_invalid",
+			expect.any(String),
+		);
+		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
+	});
+
+	it("uses the producer observation time for screen state", async () => {
+		const screenStarted = vi.fn();
+		const h = harness({
+			state: { screenStarted },
+			snapshot: snapshot({
+				observed_at: timestamp(7),
+				participants: [participant],
+				producers: [
+					{
+						producer_id: "screen",
+						participant_id: "alice",
+						kind: "video",
+						paused: false,
+						is_screen: true,
+						observed_at: timestamp(7),
+					},
+				],
+			}),
+		});
+		await h.controller.connect(config);
+		expect(screenStarted).toHaveBeenCalledWith(
+			expect.objectContaining({ startedAt: Date.parse(timestamp(7)) }),
+		);
+	});
+
+	it("fails readiness when required media does not produce a consumer", async () => {
+		const h = harness({
+			noConsumer: true,
+			snapshot: snapshot({
+				observed_at: timestamp(1),
+				participants: [participant],
+				producers: [
+					{
+						producer_id: "p1",
+						participant_id: "alice",
+						kind: "audio",
+						paused: false,
+						is_screen: false,
+						observed_at: timestamp(1),
+					},
+				],
+			}),
+		});
 		await expect(h.controller.connect(config)).rejects.toThrow(
 			"did not create a consumer",
 		);
-		expect(h.controller.ready.value).toBe(false);
 		expect(h.bridge.reportCaptureReady).not.toHaveBeenCalled();
-		expect(h.bridge.reportFailure).toHaveBeenCalled();
-		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
 	});
 
-	it("accepts an initial snapshot with no media", async () => {
-		const h = harness([]);
-		await h.controller.connect(config);
-		expect(h.controller.ready.value).toBe(true);
-		expect(
-			h.dependencies.mediaManager.subscribeToRemoteProducer,
-		).not.toHaveBeenCalled();
-	});
-
-	it("rejects a malformed recording challenge", async () => {
-		const h = harness([], undefined, {}, { protocol_version: 2 });
-
-		await expect(h.controller.connect(config)).rejects.toThrow(
-			"Invalid recording challenge",
-		);
-		expect(h.bridge.sign).not.toHaveBeenCalled();
-		expect(h.bridge.reportFailure).toHaveBeenCalledWith(
-			"configuration_failed",
-			"Invalid recording challenge",
-		);
-	});
-
-	it("defaults missing snapshot media state to off", async () => {
-		const h = harness([]);
-		h.dependencies.sfuClient.getRoomParticipants.mockResolvedValueOnce([
-			{ participantId: "alice", user_id: "alice", userData: { name: "Alice" } },
-		]);
-
-		await h.controller.connect(config);
-
-		expect(h.participants.get("alice")).toMatchObject({
-			audio_enabled: false,
-			video_enabled: false,
+	it("retains persistent state while capture preparation clears transients", async () => {
+		const transientsCleared = vi.fn();
+		const frameCommitted = vi.fn(async () => undefined);
+		const h = harness({
+			state: { transientsCleared, frameCommitted },
+			snapshot: snapshot({ participants: [participant] }),
 		});
-	});
-
-	it("reports a room that remains empty when leave races the participant snapshot", async () => {
-		vi.useFakeTimers();
-		const roomEmpty = vi.fn();
-		const h = harness([], undefined, { roomEmpty });
 		await h.controller.connect(config);
-
-		h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
-		vi.advanceTimersByTime(9_999);
-		expect(roomEmpty).not.toHaveBeenCalled();
-		vi.advanceTimersByTime(1);
-		expect(roomEmpty).toHaveBeenCalledOnce();
-		vi.useRealTimers();
+		frameCommitted.mockClear();
+		await h.controller.prepareCapture(0);
+		expect(transientsCleared).toHaveBeenCalledOnce();
+		expect(frameCommitted).toHaveBeenCalledOnce();
+		expect(h.participants.has("alice")).toBe(true);
 	});
 
-	it("cancels room-empty termination when a participant rejoins during grace", () => {
-		vi.useFakeTimers();
-		const roomEmpty = vi.fn();
-		const h = harness([], undefined, { roomEmpty });
-
-		h.getParticipantHandlers().onParticipantRemoved?.("alice");
-		vi.advanceTimersByTime(5_000);
-		h.getParticipantHandlers().onParticipantAdded?.({
-			user_id: "alice",
-			user_name: "Alice",
-			avatar: null,
-			initials: "A",
+	it("applies participant updates without adding a duplicate participant", async () => {
+		const participantUpdated = vi.fn();
+		const h = harness({
+			state: { participantUpdated },
+			snapshot: snapshot({ participants: [participant] }),
 		});
-		vi.advanceTimersByTime(5_000);
-
-		expect(roomEmpty).not.toHaveBeenCalled();
-		vi.useRealTimers();
+		await h.controller.connect(config);
+		h.emitProjection(
+			projectionEvent(1, {
+				type: "participant_updated",
+				participant: {
+					...participant,
+					name: "Alice Updated",
+					avatar: "/files/updated.png",
+					audio_enabled: false,
+					video_enabled: true,
+				},
+			}),
+		);
+		expect(h.dependencies.participantManager.addParticipant).not.toHaveBeenCalled();
+		expect(participantUpdated).toHaveBeenCalledWith(
+			"alice",
+			expect.objectContaining({
+				user_name: "Alice Updated",
+				audio_enabled: false,
+				video_enabled: true,
+			}),
+		);
 	});
 
-	it("waits for the renderer to acknowledge an initial screen attachment", async () => {
-		let acknowledge!: () => void;
-		const screenStarted = vi.fn(
-			() =>
-				new Promise<void>((resolve) => {
-					acknowledge = resolve;
-				}),
-		);
-		const consumer = {
-			id: "screen-c1",
-			producerId: "p1",
-			participantId: "alice",
-			kind: "video",
-			isScreen: true,
+	it("reconciles and attaches a changed producer set before a second epoch frame", async () => {
+		let release!: () => void;
+		const delayed = new Promise<void>((resolve) => (release = resolve));
+		const frameCommitted = vi.fn(async () => undefined);
+		const firstProducer = {
+			producer_id: "p1", participant_id: "alice", kind: "audio" as const,
+			paused: false, is_screen: false, observed_at: timestamp(0),
 		};
-		const h = harness(
-			[{ id: "p1", participantId: "alice", isScreen: true }],
-			consumer,
-			{ screenStarted },
-		);
-		const connected = h.controller.connect(config);
-		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledOnce());
-		expect(h.controller.ready.value).toBe(false);
-		acknowledge();
-		await connected;
-		expect(h.controller.ready.value).toBe(true);
-	});
-
-	it("cancels an initial screen attachment removed before mount", async () => {
-		vi.useFakeTimers();
-		let acknowledge!: () => void;
-		const screenStarted = vi.fn(
-			() =>
-				new Promise<void>((resolve) => {
-					acknowledge = resolve;
-				}),
-		);
-		const consumer = {
-			id: "screen-c1",
-			producerId: "p1",
-			participantId: "alice",
-			kind: "video",
-			isScreen: true,
-		} as const;
-		const h = harness(
-			[{ id: "p1", participantId: "alice", isScreen: true }],
-			consumer,
-			{ screenStarted },
-		);
-		const connected = h.controller.connect(config);
-		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledOnce());
-
-		h.sfuHandlers.get("producer_closed")?.({
-			producerId: "p1",
-			participantId: "alice",
-			isScreen: true,
+		const secondProducer = { ...firstProducer, producer_id: "p2", observed_at: timestamp(2) };
+		const h = harness({
+			state: { frameCommitted },
+			attachment: (consumer) => consumer.producerId === "p2" ? delayed : Promise.resolve(),
+			snapshot: [
+				snapshot({ participants: [participant], producers: [firstProducer] }),
+				snapshot({ participants: [participant], producers: [firstProducer] }),
+				snapshot({ cursor: 2, observed_at: timestamp(2), participants: [participant], producers: [secondProducer] }),
+			],
 		});
-
-		await connected;
-		expect(h.controller.ready.value).toBe(true);
-		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
-		expect(Reflect.get(h.controller, "attachmentPromises").size).toBe(0);
-		expect(Reflect.get(h.controller, "screenAttachmentPromises").size).toBe(0);
-		await vi.advanceTimersByTimeAsync(
-			RecorderSocketController.ATTACHMENT_TIMEOUT_MS,
-		);
-		acknowledge();
-		await Promise.resolve();
-		expect(h.bridge.reportFailure).not.toHaveBeenCalled();
-		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
-		vi.useRealTimers();
-	});
-
-	it("cancels a participant attachment removed before its tile mounts", async () => {
-		let rejectAttachment!: (error: Error) => void;
-		const h = harness();
 		await h.controller.connect(config);
-		h.dependencies.mediaManager.handleNewConsumer.mockReturnValueOnce(
-			new Promise<void>((_resolve, reject) => {
-				rejectAttachment = reject;
-			}),
-		);
-		h.sfuHandlers.get("participant_joined")?.({
-			participantId: "alice",
-			userData: { name: "Alice" },
-		});
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "camera-1",
-			participantId: "alice",
-			isScreen: false,
-		});
+		frameCommitted.mockClear();
+		await h.controller.prepareCapture(0);
+		await h.controller.captureStarted(0, timestamp(1));
+		const recovery = h.controller.prepareCapture(1);
 		await vi.waitFor(() =>
-			expect(h.dependencies.mediaManager.handleNewConsumer).toHaveBeenCalled(),
-		);
-
-		h.sfuHandlers.get("participant_left")?.({ participantId: "alice" });
-		await vi.waitFor(() =>
-			expect(Reflect.get(h.controller, "attachmentPromises").size).toBe(0),
-		);
-		expect(
-			h.dependencies.videoManager.cancelDeferredAttachment,
-		).toHaveBeenCalledWith("alice");
-		rejectAttachment(new Error("obsolete attachment failed"));
-		await Promise.resolve();
-		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
-	});
-
-	it("replaces a participant screen and ignores the old producer's late close", async () => {
-		const screenStarted = vi.fn();
-		const screenStopped = vi.fn();
-		const h = harness([], undefined, { screenStarted, screenStopped });
-		await h.controller.connect(config);
-
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "screen-old",
-			participantId: "alice",
-			isScreen: true,
-		});
-		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledTimes(1));
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "screen-current",
-			participantId: "alice",
-			isScreen: true,
-		});
-		await vi.waitFor(() => expect(screenStarted).toHaveBeenCalledTimes(2));
-
-		expect(screenStopped).toHaveBeenCalledWith("alice", "screen-old");
-		screenStopped.mockClear();
-		h.sfuHandlers.get("producer_closed")?.({
-			producerId: "screen-old",
-			participantId: "alice",
-			isScreen: true,
-		});
-
-		expect(screenStopped).not.toHaveBeenCalled();
-		expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
-			consumerId: "c-screen-current",
-			producerId: "screen-current",
-		});
-	});
-
-	it("matches recorder screen stops by participant and producer", async () => {
-		const screenStopped = vi.fn();
-		const h = harness([], undefined, { screenStopped });
-		await h.controller.connect(config);
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "screen-1",
-			participantId: "alice",
-			isScreen: true,
-		});
-		await vi.waitFor(() =>
-			expect(
-				h.dependencies.mediaManager.subscribeToRemoteProducer,
-			).toHaveBeenCalled(),
-		);
-		h.dependencies.consumerManager.removeConsumer.mockClear();
-
-		h.sfuHandlers.get("screen_share_stopped")?.({
-			participantId: "bob",
-			producerId: "screen-1",
-		});
-
-		expect(
-			h.dependencies.consumerManager.removeConsumer,
-		).not.toHaveBeenCalled();
-		expect(screenStopped).not.toHaveBeenCalled();
-	});
-
-	it("ignores an old consumer removal after same-producer resubscription", async () => {
-		const screenStopped = vi.fn();
-		const h = harness([], undefined, { screenStopped });
-		await h.controller.connect(config);
-		const oldConsumer = {
-			id: "screen-old-consumer",
-			producerId: "screen-1",
-			participantId: "alice",
-			kind: "video",
-			isScreen: true,
-		} as const;
-		const replacement = {
-			...oldConsumer,
-			id: "screen-new-consumer",
-		};
-		h.consumers.set(oldConsumer.id, oldConsumer);
-		h.getConsumerHandlers().onConsumerAdded?.(oldConsumer);
-		await vi.waitFor(() =>
-			expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
-				consumerId: oldConsumer.id,
-				producerId: oldConsumer.producerId,
-			}),
-		);
-		h.consumers.set(replacement.id, replacement);
-		h.getConsumerHandlers().onConsumerAdded?.(replacement);
-		await vi.waitFor(() =>
-			expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
-				consumerId: replacement.id,
-				producerId: replacement.producerId,
-			}),
-		);
-		screenStopped.mockClear();
-
-		h.getConsumerHandlers().onConsumerRemoved?.(oldConsumer.id, oldConsumer);
-
-		expect(screenStopped).not.toHaveBeenCalled();
-		expect(Reflect.get(h.controller, "activeScreens").get("alice")).toEqual({
-			consumerId: replacement.id,
-			producerId: replacement.producerId,
-		});
-	});
-
-	it("settles active screen state during recorder cleanup", async () => {
-		const screenStopped = vi.fn();
-		const h = harness([], undefined, { screenStopped });
-		await h.controller.connect(config);
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "screen-1",
-			participantId: "alice",
-			isScreen: true,
-		});
-		await vi.waitFor(() =>
-			expect(Reflect.get(h.controller, "activeScreens").has("alice")).toBe(
-				true,
+			expect(h.dependencies.mediaManager.subscribeToRemoteProducer).toHaveBeenCalledWith(
+				expect.objectContaining({ producerId: "p2" }),
 			),
 		);
-
-		h.controller.disconnect();
-
-		expect(screenStopped).toHaveBeenCalledWith("alice", "screen-1");
-		expect(Reflect.get(h.controller, "activeScreens").size).toBe(0);
-		expect(Reflect.get(h.controller, "screenAttachmentPromises").size).toBe(0);
+		expect(frameCommitted).toHaveBeenCalledTimes(1);
+		expect(h.consumers.has("c-p1")).toBe(false);
+		release();
+		await recovery;
+		expect(frameCommitted).toHaveBeenCalledTimes(2);
+		expect(h.consumers.has("c-p2")).toBe(true);
 	});
 
-	it("reports only failure when initial screen playback is rejected", async () => {
-		const consumer = {
-			id: "screen-c1",
-			producerId: "p1",
-			participantId: "alice",
-			kind: "video",
-			isScreen: true,
+	it("rejects a recovery prepare when the replacement attachment fails", async () => {
+		const producer = {
+			producer_id: "p2", participant_id: "alice", kind: "audio" as const,
+			paused: false, is_screen: false, observed_at: timestamp(2),
 		};
-		const h = harness(
-			[{ id: "p1", participantId: "alice", isScreen: true }],
-			consumer,
-			{
-				screenStarted: () => Promise.reject(new Error("screen decoder failed")),
+		const h = harness({
+			attachment: (consumer) => consumer.producerId === "p2"
+				? Promise.reject(new Error("attachment failed"))
+				: Promise.resolve(),
+			snapshot: [
+				snapshot({ participants: [participant] }),
+				snapshot({ participants: [participant] }),
+				snapshot({ cursor: 2, observed_at: timestamp(2), participants: [participant], producers: [producer] }),
+			],
+		});
+		await h.controller.connect(config);
+		await h.controller.prepareCapture(0);
+		await h.controller.captureStarted(0, timestamp(1));
+		await expect(h.controller.prepareCapture(1)).rejects.toThrow();
+		expect(h.bridge.reportInterruption).toHaveBeenCalledWith(
+			"media_attachment_failed",
+			"attachment failed",
+		);
+	});
+
+	it("excludes startup transients and filters buffered events at capture start", async () => {
+		const chatReceived = vi.fn();
+		const reactionReceived = vi.fn();
+		const captureStarted = vi.fn();
+		const h = harness({
+			state: { chatReceived, reactionReceived, captureStarted },
+			snapshot: [
+				snapshot(),
+				snapshot({ cursor: 1, observed_at: timestamp(1) }),
+			],
+		});
+		await h.controller.connect(config);
+		h.emitProjection(
+			projectionEvent(1, {
+				type: "chat_message",
+				message_id: "startup",
+				message: "startup",
+				from_user: "alice",
+				from_name: "Alice",
+			}),
+		);
+		await h.controller.prepareCapture(0);
+		h.emitProjection(
+			projectionEvent(
+				2,
+				{ type: "reaction", from_user: "alice", reaction: "+1" },
+				timestamp(4),
+			),
+		);
+		h.emitProjection(
+			projectionEvent(
+				3,
+				{
+					type: "chat_message",
+					message_id: "kept",
+					message: "kept",
+					from_user: "alice",
+					from_name: "Alice",
+				},
+				timestamp(5),
+			),
+		);
+		await h.controller.captureStarted(0, timestamp(5));
+		expect(captureStarted).toHaveBeenCalledWith(timestamp(5));
+		expect(reactionReceived).not.toHaveBeenCalled();
+		expect(chatReceived).toHaveBeenCalledWith(
+			expect.objectContaining({ id: "kept", text: "kept" }),
+		);
+		h.emitProjection(
+			projectionEvent(
+				4,
+				{ type: "reaction", from_user: "alice", reaction: "wave" },
+				timestamp(6),
+			),
+		);
+		expect(reactionReceived).toHaveBeenCalledWith("alice", "wave");
+	});
+
+	it("makes exact capture repeats idempotent and rejects conflicts", async () => {
+		const transientsCleared = vi.fn();
+		const captureStarted = vi.fn();
+		const h = harness({ state: { transientsCleared, captureStarted } });
+		await h.controller.connect(config);
+		await h.controller.prepareCapture(2);
+		await h.controller.prepareCapture(2);
+		await h.controller.captureStarted(2, timestamp(5));
+		await h.controller.captureStarted(2, timestamp(5));
+		expect(transientsCleared).toHaveBeenCalledOnce();
+		expect(captureStarted).toHaveBeenCalledOnce();
+		await expect(h.controller.prepareCapture(1)).rejects.toThrow("Stale");
+		await expect(h.controller.captureStarted(2, timestamp(6))).rejects.toThrow(
+			"Conflicting",
+		);
+		await h.controller.prepareCapture(3);
+		await expect(h.controller.prepareCapture(4)).resolves.toBeUndefined();
+	});
+
+	it("lets a later epoch supersede a prepared epoch whose start command was lost", async () => {
+		const transientsCleared = vi.fn();
+		const h = harness({ state: { transientsCleared } });
+		await h.controller.connect(config);
+
+		await h.controller.prepareCapture(0);
+		await h.controller.prepareCapture(1);
+		await h.controller.captureStarted(1, timestamp(2));
+
+		expect(transientsCleared).toHaveBeenCalledTimes(2);
+	});
+
+	it("prevents an in-flight prepare from mutating after a newer epoch supersedes it", async () => {
+		let releaseOldFrame!: () => void;
+		const oldFrame = new Promise<void>((resolve) => (releaseOldFrame = resolve));
+		const frameCommitted = vi
+			.fn<() => Promise<void>>()
+			.mockResolvedValueOnce(undefined)
+			.mockReturnValueOnce(oldFrame)
+			.mockResolvedValue(undefined);
+		const captureStarted = vi.fn();
+		const h = harness({ state: { frameCommitted, captureStarted } });
+		await h.controller.connect(config);
+
+		const oldPrepare = h.controller.prepareCapture(0);
+		await vi.waitFor(() => expect(frameCommitted).toHaveBeenCalledTimes(2));
+		await expect(h.controller.prepareCapture(1)).resolves.toBeUndefined();
+		releaseOldFrame();
+		await expect(oldPrepare).rejects.toBeInstanceOf(CaptureCommandSupersededError);
+		await h.controller.captureStarted(1, timestamp(2));
+		expect(captureStarted).toHaveBeenCalledOnce();
+	});
+
+	it("allows exact retries after failed prepare and start attempts", async () => {
+		const frameCommitted = vi
+			.fn<() => Promise<void>>()
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new Error("frame failed"))
+			.mockResolvedValue(undefined);
+		const captureStarted = vi
+			.fn<(timestamp: string) => void>()
+			.mockImplementationOnce(() => {
+				throw new Error("render start failed");
+			});
+		const h = harness({ state: { frameCommitted, captureStarted } });
+		await h.controller.connect(config);
+		await expect(h.controller.prepareCapture(0)).rejects.toThrow("frame failed");
+		await expect(h.controller.prepareCapture(0)).resolves.toBeUndefined();
+		await expect(h.controller.captureStarted(0, timestamp(1))).rejects.toThrow(
+			"render start failed",
+		);
+		await expect(
+			h.controller.captureStarted(0, timestamp(1)),
+		).resolves.toBeUndefined();
+		expect(frameCommitted).toHaveBeenCalledTimes(3);
+		expect(captureStarted).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects capture commands after disconnect or projection failure", async () => {
+		const disconnected = harness();
+		await disconnected.controller.connect(config);
+		disconnected.controller.disconnect();
+		await expect(disconnected.controller.prepareCapture(0)).rejects.toThrow(
+			"not ready",
+		);
+		await expect(
+			disconnected.controller.captureStarted(0, timestamp(1)),
+		).rejects.toThrow("not ready");
+
+		const failed = harness();
+		await failed.controller.connect(config);
+		failed.emitProjection(
+			projectionEvent(2, { type: "active_speaker", participant_ids: [] }),
+		);
+		await expect(failed.controller.prepareCapture(0)).rejects.toThrow();
+	});
+
+	it("fails closed locally when a capture command is rejected", async () => {
+		const h = harness();
+		await h.controller.connect(config);
+		h.controller.failCaptureCommand("invalid command");
+		expect(h.controller.ready.value).toBe(false);
+		expect(h.bridge.reportInterruption).toHaveBeenCalledWith(
+			"projection_invalid",
+			"invalid command",
+		);
+		expect(h.dependencies.sfuClient.disconnect).toHaveBeenCalled();
+	});
+
+	it("retains consumer_closed transport cleanup", async () => {
+		const h = harness();
+		await h.controller.connect(config);
+		h.sfuHandlers.get("consumer_closed")?.({ consumerId: "c1" });
+		expect(h.dependencies.consumerManager.removeConsumer).toHaveBeenCalledWith(
+			"c1",
+		);
+	});
+
+	it("does not replay persistent events after syncing reconciled state", async () => {
+		const updated = { ...participant, name: "Updated" };
+		const h = harness({
+			snapshot: [
+				snapshot({ participants: [participant] }),
+				snapshot({ participants: [participant] }),
+			],
+			onSnapshotRequest: (emit) => {
+				if (h.controller.ready.value)
+					emit(
+						projectionEvent(1, {
+							type: "participant_updated",
+							participant: updated,
+						}),
+					);
 			},
-		);
-		await expect(h.controller.connect(config)).rejects.toThrow(
-			"screen decoder failed",
-		);
-		expect(h.bridge.reportFailure).toHaveBeenCalledWith(
-			"configuration_failed",
-			"screen decoder failed",
-		);
-		expect(h.bridge.reportInterruption).not.toHaveBeenCalled();
+		});
+		await h.controller.connect(config);
+		h.dependencies.participantManager.updateParticipant.mockClear();
+		await h.controller.prepareCapture(0);
+		expect(
+			h.dependencies.participantManager.updateParticipant,
+		).not.toHaveBeenCalled();
 	});
 
-	it("rejects malformed external SFU values without mutating recorder state", async () => {
-		const activeSpeakersChanged = vi.fn();
-		const h = harness([], undefined, { activeSpeakersChanged });
+	it("removes recorder listeners and manager handlers during cleanup", async () => {
+		const h = harness();
 		await h.controller.connect(config);
-
-		h.sfuHandlers.get("participant_joined")?.({ participantId: 42 });
-		h.sfuHandlers.get("producer_created")?.({
-			producerId: "p1",
-			participantId: null,
-		});
-		h.sfuHandlers.get("media_control_update")?.({
-			participantId: "alice",
-			action: { type: "audio", enabled: "yes" },
-		});
-		h.sfuHandlers.get("active_speaker")?.({ participantIds: ["alice", 42] });
-
-		expect(h.participants).toHaveLength(0);
-		expect(
-			h.dependencies.mediaManager.subscribeToRemoteProducer,
-		).not.toHaveBeenCalled();
-		expect(
-			h.dependencies.participantManager.updateMediaState,
-		).not.toHaveBeenCalled();
-		expect(activeSpeakersChanged).not.toHaveBeenCalled();
-	});
-
-	it("normalizes valid media controls and preserves precise participant updates", async () => {
-		const participantUpdated = vi.fn();
-		const h = harness([], undefined, { participantUpdated });
-		await h.controller.connect(config);
-
-		h.sfuHandlers.get("media_control_update")?.({
-			participantId: "alice",
-			action: "unmute",
-		});
-		h.sfuHandlers.get("media_control_update")?.({
-			participantId: "alice",
-			action: { type: "video", enabled: true },
-		});
-		h.getParticipantHandlers().onParticipantUpdated?.(
-			"alice",
-			{ user_id: "alice", user_name: "Alice", avatar: null, initials: "A" },
-			{ audio_enabled: true },
+		h.controller.disconnect();
+		expect(h.channel.off).toHaveBeenCalledWith(
+			"recording:challenge",
+			expect.any(Function),
 		);
-
-		expect(
-			h.dependencies.participantManager.updateMediaState,
-		).toHaveBeenNthCalledWith(1, "alice", { audioEnabled: true });
-		expect(
-			h.dependencies.participantManager.updateMediaState,
-		).toHaveBeenNthCalledWith(2, "alice", { videoEnabled: true });
-		expect(participantUpdated).toHaveBeenCalledWith("alice", {
-			audio_enabled: true,
-		});
+		expect(h.dependencies.sfuClient.off).toHaveBeenCalledWith(
+			"recording:projection",
+			expect.any(Function),
+		);
+		expect(h.sfuHandlers.size).toBe(0);
 	});
 
 	it("rewrites only public avatars on the trusted Frappe origin", () => {
 		expect(trustedAvatar("/files/avatar.png", "https://frappe.test")).toBe(
 			"https://frappe.test/files/avatar.png",
-		);
-		expect(trustedAvatar("/files/avatar.png", "http://frappe.test")).toBe(
-			"http://frappe.test/files/avatar.png",
 		);
 		for (const value of [
 			"https://evil.test/a.png",

--- a/frontend/recorder/RecorderSocketController.ts
+++ b/frontend/recorder/RecorderSocketController.ts
@@ -11,46 +11,34 @@ import {
 import { TransportManager } from "../src/apps/meet/utils/media/TransportManager";
 import { VideoElementManager } from "../src/apps/meet/utils/media/VideoElementManager";
 import { SFUClient } from "../src/apps/meet/utils/SFUClient";
-import {
-	applyMeetingReconciliationEvent,
-	createMeetingReconciliationState,
-	type MeetingReconciliationEvent,
-	type MeetingReconciliationState,
-	reconcileMeetingSnapshot,
-} from "../src/apps/meet/utils/sfu/MeetingSnapshotReconciler";
 import { SFUMediaManager } from "../src/apps/meet/utils/sfu/SFUMediaManager";
 import {
-	type MediaControlMessage,
 	type ProducerEvent,
-	parseActiveSpeakers,
-	parseChatMessage,
 	parseConsumerId,
-	parseHandChange,
-	parseMediaControlMessage,
-	parseParticipantMessage,
 	parseParticipantUpdate,
-	parseProducerMessage,
-	parseProducerSnapshot,
-	parseRaisedHands,
-	parseReaction,
+	parseRecorderStageProjectionEvent,
+	parseRecordingProjectionSnapshotResponse,
 	parseRecordingChallenge,
 	parseRecordingProofResponse,
 	parseRequestResponse,
 	parseScreenShareStarted,
-	parseScreenShareStopped,
 	type RecorderParticipantData,
 	type RecorderParticipantUpdate,
 } from "./protocol";
+import { RecorderStageProjection } from "./RecorderStageProjection";
 import type {
 	RecorderConfig,
 	RecorderRendererBridge,
 	RendererReasonCode,
 } from "./rendererBridge";
+import { CaptureCommandSupersededError } from "./rendererBridge";
+import type {
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionEvent,
+	RecorderStageSnapshot,
+} from "../../suite/meet/types";
 
-type ReconciledRecorderParticipant = RecorderParticipantData & {
-	participantId: string;
-};
-type SyncEvent = MeetingReconciliationEvent<ReconciledRecorderParticipant>;
 export type RecorderState = {
 	participantAdded?: (participant: Participant) => void;
 	participantRemoved?: (participantId: string) => void;
@@ -77,6 +65,9 @@ export type RecorderState = {
 		text: string;
 	}) => void;
 	roomEmpty?: () => void;
+	transientsCleared?: () => void;
+	captureStarted?: (timestamp: string) => void;
+	frameCommitted?: () => Promise<void>;
 };
 
 interface RecorderDependencies {
@@ -99,10 +90,9 @@ export class RecorderSocketController {
 	static readonly ATTACHMENT_TIMEOUT_MS = 10_000;
 	private channel: SignalChannel;
 	private deps: RecorderDependencies;
-	private bufferedEvents: SyncEvent[] = [];
-	private reconciliation: MeetingReconciliationState<ReconciledRecorderParticipant> =
-		createMeetingReconciliationState();
-	private producerClaims = new Set<string>();
+	private projection?: RecorderStageProjection;
+	private projectionFailure?: Error;
+	private producerClaims = new Map<string, Promise<void>>();
 	private attachmentPromises = new Map<string, PendingAttachment>();
 	private screenAttachmentPromises = new Map<string, PendingAttachment>();
 	private currentParticipantAttachments = new Map<
@@ -113,10 +103,24 @@ export class RecorderSocketController {
 		string,
 		{ consumerId: string; producerId: string }
 	>();
-	private initialSync = true;
-	private captureStartedAt = 0;
+	private captureEpoch?: {
+		epoch: number;
+		prepared: Promise<void>;
+		settled: boolean;
+		accepted: boolean;
+		superseded: boolean;
+		started?: {
+			timestamp: string;
+			promise: Promise<void>;
+			settled: boolean;
+			accepted: boolean;
+		};
+	};
+	private bufferedTransients: RecorderStageProjectionEvent[] = [];
+	private transientsLive = false;
 	private cleaningUp = false;
 	private roomEmptyTimer?: ReturnType<typeof setTimeout>;
+	private listenerCleanup: Array<() => void> = [];
 	private state: RecorderState;
 	private _ready = ref(false);
 	private _interruption = ref<string | null>(null);
@@ -170,7 +174,7 @@ export class RecorderSocketController {
 	}
 
 	async connect(config: RecorderConfig): Promise<void> {
-		this.captureStartedAt = Date.parse(config.acceptedAt);
+		this.projection = new RecorderStageProjection(config.meetingId);
 		this.frappeOrigin = new URL(config.frappeOrigin).origin;
 		let resolveProof!: () => void;
 		let rejectProof!: (error: Error) => void;
@@ -178,7 +182,7 @@ export class RecorderSocketController {
 			resolveProof = resolve;
 			rejectProof = reject;
 		});
-		this.channel.on("recording:challenge", (value) => {
+		const onChallenge = (value: unknown) => {
 			const challenge = parseRecordingChallenge(value);
 			if (!challenge) {
 				rejectProof(new Error("Invalid recording challenge"));
@@ -188,12 +192,14 @@ export class RecorderSocketController {
 				.sign(challenge)
 				.then((signature) => this.requestProof(signature))
 				.then(resolveProof, rejectProof);
-		});
-		this.channel.on("disconnect", () => {
+		};
+		const onDisconnect = () => {
 			if (this.cleaningUp) return;
 			this.interrupt("sfu_disconnected", "SFU connection lost");
 			this.cleanup();
-		});
+		};
+		this.listenChannel("recording:challenge", onChallenge);
+		this.listenChannel("disconnect", onDisconnect);
 		try {
 			await this.channel.connect({
 				origin: config.sfuOrigin,
@@ -211,6 +217,7 @@ export class RecorderSocketController {
 			await this.deps.transportManager.initializeDevice();
 			await this.deps.transportManager.createReceiveTransport();
 			await this.initialSynchronize();
+			await this.commitStableFrame();
 			this._ready.value = true;
 			this.bridge.reportCaptureReady();
 		} catch (error) {
@@ -220,10 +227,112 @@ export class RecorderSocketController {
 					: "Recorder connection interrupted";
 			this._ready.value = false;
 			this._interruption.value = reason;
-			this.bridge.reportFailure("configuration_failed", reason);
+			if (!this.projectionFailure)
+				this.bridge.reportFailure("configuration_failed", reason);
 			this.cleanup();
 			throw error;
 		}
+	}
+
+	async prepareCapture(epoch: number): Promise<void> {
+		this.assertEpoch(epoch);
+		this.assertOperational();
+		if (this.captureEpoch) {
+			if (epoch === this.captureEpoch.epoch) {
+				if (!this.captureEpoch.settled || this.captureEpoch.accepted)
+					return this.captureEpoch.prepared;
+			} else {
+				if (epoch < this.captureEpoch.epoch)
+					throw new Error(`Stale capture epoch ${epoch}`);
+				if (
+					this.captureEpoch.started &&
+					!this.captureEpoch.started.accepted
+				)
+					throw new Error(`Conflicting capture epoch ${epoch}`);
+				this.captureEpoch.superseded = true;
+			}
+		}
+		this.transientsLive = false;
+		this.bufferedTransients = [];
+		const capture = {
+			epoch,
+			prepared: Promise.resolve(),
+			settled: false,
+			accepted: false,
+			superseded: false,
+		};
+		const prepared = Promise.resolve().then(async () => {
+			try {
+				this.assertCurrentCapture(capture);
+				const projection = this.requireProjection();
+				projection.beginReconciliation();
+				const snapshot = await this.requestProjectionSnapshot(() =>
+					this.assertCurrentCapture(capture),
+				);
+				this.assertCurrentCapture(capture);
+				await this.reconcileProjection(snapshot, false, () =>
+					this.assertCurrentCapture(capture),
+				);
+				this.assertCurrentCapture(capture);
+				this.state.transientsCleared?.();
+				await this.commitStableFrame(() => this.assertCurrentCapture(capture));
+				this.assertCurrentCapture(capture);
+				capture.accepted = true;
+			} catch (error) {
+				this.assertCurrentCapture(capture);
+				throw error;
+			}
+		});
+		capture.prepared = prepared.finally(() => {
+			capture.settled = true;
+		});
+		this.captureEpoch = capture;
+		return capture.prepared;
+	}
+
+	async captureStarted(epoch: number, timestamp: string): Promise<void> {
+		this.assertEpoch(epoch);
+		this.assertOperational();
+		if (!isCanonicalTimestamp(timestamp))
+			throw new Error("Invalid capture start timestamp");
+		const capture = this.captureEpoch;
+		if (!capture || epoch < capture.epoch)
+			throw new Error(`Stale capture epoch ${epoch}`);
+		if (epoch > capture.epoch)
+			throw new Error(`Conflicting capture epoch ${epoch}`);
+		if (capture.started) {
+			if (capture.started.timestamp !== timestamp)
+				throw new Error(`Conflicting capture timestamp for epoch ${epoch}`);
+			if (capture.started.accepted || !capture.started.settled)
+				return capture.started.promise;
+		}
+		const started = {
+			timestamp,
+			settled: false,
+			accepted: false,
+			promise: Promise.resolve(),
+		};
+		started.promise = capture.prepared
+			.then(() => {
+				this.assertCurrentCapture(capture);
+				this.state.captureStarted?.(timestamp);
+				const buffered = this.bufferedTransients.splice(0);
+				for (const event of buffered)
+					if (event.observed_at >= timestamp) this.applyTransient(event);
+				this.transientsLive = true;
+				started.accepted = true;
+			})
+			.catch((error) => {
+				if (error instanceof CaptureCommandSupersededError) throw error;
+				this.transientsLive = false;
+				this.state.transientsCleared?.();
+				throw error;
+			})
+			.finally(() => {
+				started.settled = true;
+			});
+		capture.started = started;
+		return started.promise;
 	}
 
 	disconnect(): void {
@@ -233,6 +342,11 @@ export class RecorderSocketController {
 
 	reportPlaybackFailure(reason: string): void {
 		this.interrupt("media_attachment_failed", reason);
+	}
+
+	failCaptureCommand(reason: string): void {
+		this.interrupt("projection_invalid", reason);
+		this.cleanup();
 	}
 
 	private setupManagerEvents(): void {
@@ -329,7 +443,10 @@ export class RecorderSocketController {
 						consumerId: data.consumerId,
 						producerId: data.producerId,
 						stream: data.stream,
-						startedAt: Date.now(),
+						startedAt: Date.parse(
+							this.requireProjection().producers.get(data.producerId)
+								?.observed_at || "",
+						),
 					}),
 				);
 				const pending = this.withTimeout(
@@ -369,193 +486,205 @@ export class RecorderSocketController {
 	}
 
 	private setupSFUEvents(): void {
-		const client = this.deps.sfuClient;
-		client.on("participant_joined", (value) => {
-			const event = parseParticipantMessage("participant-joined", value);
-			if (event) this.queueOrApply(event);
+		this.listenSFU("recording:projection", (value) => {
+			const event = parseRecorderStageProjectionEvent(value);
+			if (!event) {
+				this.failProjection("Invalid recorder projection event");
+				return;
+			}
+			try {
+				const accepted = this.requireProjection().applyEvent(event);
+				for (const item of accepted) this.applyProjectionEvent(item);
+			} catch (error) {
+				this.failProjection(
+					error instanceof Error
+						? error.message
+						: "Invalid recorder projection",
+				);
+			}
 		});
-		client.on("participant_left", (value) => {
-			const event = parseParticipantMessage("participant-left", value);
-			if (event) this.queueOrApply(event);
-		});
-		client.on("producer_created", (value) => {
-			const event = parseProducerMessage("producer-created", value);
-			if (event) this.queueOrApply(event);
-		});
-		client.on("producer_closed", (value) => {
-			const event = parseProducerMessage("producer-closed", value);
-			if (event) this.queueOrApply(event);
-		});
-		client.on("consumer_closed", (value) => {
+		this.listenSFU("consumer_closed", (value) => {
 			const id = parseConsumerId(value);
 			if (id) this.deps.consumerManager.removeConsumer(id);
-		});
-		client.on("media_control_update", (value) => {
-			const message = parseMediaControlMessage(value);
-			if (message) this.updateMedia(message);
-		});
-		client.on("active_speaker", (value) => {
-			const ids = parseActiveSpeakers(value);
-			if (ids) this.state.activeSpeakersChanged?.(ids);
-		});
-		client.on("screen_share_stopped", (value) => {
-			const stopped = parseScreenShareStopped(value);
-			if (stopped) this.stopScreen(stopped.participantId, stopped.producerId);
-		});
-		client.on("reaction:message", (value) => {
-			const reaction = parseReaction(value);
-			if (reaction)
-				this.state.reactionReceived?.(reaction.fromUser, reaction.reaction);
-		});
-		client.on("hand_raised", (value) => {
-			const hand = parseHandChange(value);
-			if (hand)
-				this.state.handChanged?.(
-					hand.participantId,
-					hand.raised,
-					hand.timestamp,
-				);
-		});
-		client.on("existing_raised_hands", (value) => {
-			const hands = parseRaisedHands(value);
-			if (hands) this.state.handsSynced?.(hands);
-		});
-		client.on("chat:message", (value) => {
-			const message = parseChatMessage(value);
-			if (!message) return;
-			const time = Date.parse(message.timestamp || "");
-			if (!Number.isFinite(time) || time >= this.captureStartedAt)
-				this.state.chatReceived?.({
-					id: `${message.fromUser || "unknown"}-${message.timestamp || Date.now()}`,
-					participantId: message.fromUser,
-					author: message.fromName || message.fromUser || "Unknown",
-					text: message.message,
-				});
 		});
 	}
 
 	private async initialSynchronize(): Promise<void> {
-		const participants = await this.deps.sfuClient.getRoomParticipants();
-		const participantSnapshot = participants
-			.map((participant) => {
-				const participantId = participant.participantId || participant.user_id;
-				if (!participantId) return null;
-				return this.sanitizeParticipant({
-					...participant,
-					participantId,
-					userData: {
-						...participant.userData,
-						audio_enabled:
-							participant.userData?.audio_enabled ??
-							participant.audio_enabled ??
-							false,
-						video_enabled:
-							participant.userData?.video_enabled ??
-							participant.video_enabled ??
-							false,
-					},
-					audio_enabled:
-						participant.userData?.audio_enabled ??
-						participant.audio_enabled ??
-						false,
-					video_enabled:
-						participant.userData?.video_enabled ??
-						participant.video_enabled ??
-						false,
-				});
-			})
-			.filter(
-				(participant): participant is ReconciledRecorderParticipant =>
-					participant !== null,
-			);
-		const existing = await this.deps.sfuClient.getExistingProducers();
-		const producers: ProducerEvent[] = [];
-		for (const value of existing) {
-			const producer = parseProducerSnapshot(value);
-			if (!producer) continue;
-			producers.push({
-				producerId: producer.id,
-				participantId: producer.participantId,
-				isScreen: producer.isScreen,
-			});
-		}
-		this.reconciliation = reconcileMeetingSnapshot(
-			this.reconciliation,
-			{ participants: participantSnapshot, producers },
-			this.bufferedEvents.splice(0),
-		);
-		this.deps.participantManager.syncParticipants([
-			...this.reconciliation.participants.values(),
-		]);
-		if (this.reconciliation.participants.size === 0) this.scheduleRoomEmpty();
-		this.initialSync = false;
-		for (const event of this.reconciliation.producers.values())
-			await this.subscribeRequired(event);
+		const snapshot = await this.requestProjectionSnapshot();
+		if (this.projectionFailure) throw this.projectionFailure;
+		await this.reconcileProjection(snapshot, true);
 	}
 
-	private queueOrApply(event: SyncEvent): void {
-		if (this.initialSync) this.bufferedEvents.push(event);
-		else this.applySyncEvent(event);
-	}
-	private applySyncEvent(event: SyncEvent): void {
-		const previous = this.reconciliation;
-		this.reconciliation = applyMeetingReconciliationEvent(previous, event);
-		if (event.type === "participant-joined") {
-			const id = event.value.participantId;
-			if (
-				!previous.participants.has(id) ||
-				previous.departedParticipantIds.has(id)
-			) {
-				this.deps.participantManager.addParticipant(
-					this.sanitizeParticipant(event.value),
-				);
-			}
-		} else if (event.type === "participant-left") {
-			const id = event.value.participantId;
-			if (!previous.departedParticipantIds.has(id)) {
-				const removed = this.deps.participantManager.removeParticipant(id);
-				if (!removed) this.scheduleRoomEmpty();
-			}
-		} else if (event.type === "producer-created") {
-			if (
-				!previous.producers.has(event.value.producerId) &&
-				this.reconciliation.producers.has(event.value.producerId)
-			)
-				void this.subscribeLive(event.value);
-		} else {
-			if (!previous.closedProducerIds.has(event.value.producerId))
-				this.removeProducer(event.value);
-		}
-	}
-	private async subscribeRequired(event: ProducerEvent): Promise<void> {
-		if (
-			!this.isCurrentProducer(event) ||
-			this.producerClaims.has(event.producerId)
-		)
-			return;
-		this.producerClaims.add(event.producerId);
+	private async reconcileProjection(
+		snapshot: RecorderStageSnapshot,
+		initialize = false,
+		assertCurrent: () => void = () => undefined,
+	): Promise<void> {
+		const projection = this.requireProjection();
+		let replayed: RecorderStageProjectionEvent[];
 		try {
-			if (!this.isCurrentProducer(event)) return;
-			const result =
-				await this.deps.mediaManager.subscribeToRemoteProducer(event);
-			if (!this.isCurrentProducer(event)) {
-				this.removeProducer(event);
-				return;
-			}
-			if (!result)
-				throw new Error(
-					`Initial producer ${event.producerId} did not create a consumer`,
-				);
-			const attached = this.attachmentPromises.get(event.producerId)?.promise;
-			if (!attached)
-				throw new Error(
-					`Initial producer ${event.producerId} was not attached`,
-				);
-			await attached;
-			if (!this.isCurrentProducer(event)) this.removeProducer(event);
-		} finally {
-			this.producerClaims.delete(event.producerId);
+			replayed = initialize
+				? projection.initialize(snapshot)
+				: projection.reconcile(snapshot);
+		} catch (error) {
+			throw this.failProjection(
+				error instanceof Error ? error.message : "Invalid recorder projection",
+			);
 		}
+		this.deps.participantManager.syncParticipants(
+			[...projection.participants.values()].map((participant) =>
+				this.sanitizeParticipant(this.participantData(participant)),
+			),
+		);
+		this.state.handsSynced?.(Object.fromEntries(projection.raisedHands));
+		this.state.activeSpeakersChanged?.([...projection.activeSpeakerIds]);
+		for (const event of replayed)
+			if (
+				event.payload.type === "reaction" ||
+				event.payload.type === "chat_message"
+			)
+				this.queueTransient(event);
+		if (projection.participants.size === 0) this.scheduleRoomEmpty();
+		this.removeStaleConsumers();
+		await Promise.all(
+			[...projection.producers.values()].map((producer) =>
+				this.subscribeRequired(this.producerEvent(producer)),
+			),
+		);
+		assertCurrent();
+	}
+
+	private applyProjectionEvent(
+		event: RecorderStageProjectionEvent,
+		subscribe = true,
+	): void {
+		const payload = event.payload;
+		switch (payload.type) {
+			case "participant_joined":
+				this.deps.participantManager.addParticipant(
+					this.sanitizeParticipant(this.participantData(payload.participant)),
+				);
+				break;
+			case "participant_updated":
+				this.deps.participantManager.updateParticipant(
+					payload.participant.participant_id,
+					this.sanitizeParticipant(this.participantData(payload.participant)),
+				);
+				break;
+			case "participant_left": {
+				const removed = this.deps.participantManager.removeParticipant(
+					payload.participant_id,
+				);
+				if (!removed) this.scheduleRoomEmpty();
+				break;
+			}
+			case "producer_created":
+				if (subscribe)
+					void this.subscribeLive(this.producerEvent(payload.producer));
+				break;
+			case "producer_updated":
+				break;
+			case "producer_closed":
+				this.removeProducer({
+					producerId: payload.producer_id,
+					participantId: payload.participant_id,
+					isScreen: payload.is_screen,
+				});
+				break;
+			case "media_control":
+				this.updateMedia(payload.participant_id, payload.action);
+				break;
+			case "active_speaker":
+				this.state.activeSpeakersChanged?.([...payload.participant_ids]);
+				break;
+			case "hand_raised":
+				this.state.handChanged?.(
+					payload.participant_id,
+					payload.raised,
+					event.observed_at,
+				);
+				break;
+			case "reaction":
+			case "chat_message":
+				this.queueTransient(event);
+				break;
+		}
+	}
+	private subscribeRequired(event: ProducerEvent): Promise<void> {
+		if (!this.isCurrentProducer(event)) return Promise.resolve();
+		const existing = this.producerClaims.get(event.producerId);
+		if (existing) return existing;
+		const operation = this.subscribeClaimed(event);
+		this.producerClaims.set(event.producerId, operation);
+		const release = () => {
+			if (this.producerClaims.get(event.producerId) === operation)
+				this.producerClaims.delete(event.producerId);
+		};
+		void operation.then(release, release);
+		return operation;
+	}
+	private async commitStableFrame(
+		assertCurrent: () => void = () => undefined,
+	): Promise<void> {
+		while (true) {
+			assertCurrent();
+			this.assertNotFailed();
+			if (this.cleaningUp) throw new Error("Recorder is shutting down");
+			const before = this.currentPersistentStageSignature();
+			await Promise.all(
+				[...this.requireProjection().producers.values()].map((producer) =>
+					this.subscribeRequired(this.producerEvent(producer)),
+				),
+			);
+			assertCurrent();
+			await this.state.frameCommitted?.();
+			assertCurrent();
+			this.assertNotFailed();
+			if (this.cleaningUp) throw new Error("Recorder is shutting down");
+			if (before === this.currentPersistentStageSignature()) return;
+		}
+	}
+	private currentPersistentStageSignature(): string {
+		const projection = this.requireProjection();
+		return JSON.stringify({
+			participants: [...projection.participants.values()].sort((a, b) =>
+				a.participant_id.localeCompare(b.participant_id),
+			),
+			producers: [...projection.producers.values()].sort((a, b) =>
+				a.producer_id.localeCompare(b.producer_id),
+			),
+			raisedHands: [...projection.raisedHands].sort(([a], [b]) =>
+				a.localeCompare(b),
+			),
+			activeSpeakerIds: projection.activeSpeakerIds,
+		});
+	}
+	private async subscribeClaimed(event: ProducerEvent): Promise<void> {
+		if (!this.isCurrentProducer(event)) return;
+		const existing = this.deps.consumerManager
+			.getConsumersByParticipant(event.participantId)
+			.find((consumer) => consumer.producerId === event.producerId);
+		if (existing) {
+			await this.attachmentPromises.get(event.producerId)?.promise;
+			if (existing.isScreen)
+				await this.screenAttachmentPromises.get(existing.id)?.promise;
+			return;
+		}
+		const result =
+			await this.deps.mediaManager.subscribeToRemoteProducer(event);
+		if (!this.isCurrentProducer(event)) {
+			this.removeProducer(event);
+			return;
+		}
+		if (!result)
+			throw new Error(
+				`Initial producer ${event.producerId} did not create a consumer`,
+			);
+		const attached = this.attachmentPromises.get(event.producerId)?.promise;
+		if (!attached)
+			throw new Error(`Initial producer ${event.producerId} was not attached`);
+		await attached;
+		if (!this.isCurrentProducer(event)) this.removeProducer(event);
 	}
 	private async subscribeLive(event: ProducerEvent): Promise<void> {
 		try {
@@ -568,7 +697,11 @@ export class RecorderSocketController {
 		}
 	}
 	private isCurrentProducer(event: ProducerEvent): boolean {
-		return this.reconciliation.producers.get(event.producerId) === event;
+		const producer = this.requireProjection().producers.get(event.producerId);
+		return (
+			producer?.participant_id === event.participantId &&
+			producer.is_screen === event.isScreen
+		);
 	}
 	private sanitizeParticipant(
 		p: RecorderParticipantData,
@@ -591,19 +724,21 @@ export class RecorderSocketController {
 		if (event.isScreen)
 			this.finishScreen(event.participantId, event.producerId);
 	}
-	private stopScreen(participantId: string, producerId: string): void {
-		const consumer = this.deps.consumerManager
-			.getScreenShareConsumers()
-			.find(
-				(candidate) =>
-					candidate.participantId === participantId &&
-					candidate.producerId === producerId,
-			);
-		if (consumer) {
-			this.deps.consumerManager.removeConsumer(consumer.id);
-			return;
+	private removeStaleConsumers(): void {
+		const projection = this.requireProjection();
+		for (const participant of this.deps.participantManager.getAllParticipants()) {
+			for (const consumer of this.deps.consumerManager.getConsumersByParticipant(
+				participant.user_id,
+			)) {
+				const producer = projection.producers.get(consumer.producerId);
+				if (
+					!producer ||
+					producer.participant_id !== consumer.participantId ||
+					producer.is_screen !== consumer.isScreen
+				)
+					this.deps.consumerManager.removeConsumer(consumer.id);
+			}
 		}
-		this.finishScreen(participantId, producerId);
 	}
 	private finishScreen(
 		participantId: string,
@@ -620,16 +755,87 @@ export class RecorderSocketController {
 		this.screenAttachmentPromises.get(screen.consumerId)?.cancel();
 		this.state.screenStopped?.(participantId, producerId);
 	}
-	private updateMedia(data: MediaControlMessage): void {
-		const action = data.action;
+	private updateMedia(
+		participantId: string,
+		action: "mute" | "unmute" | "video_off" | "video_on",
+	): void {
 		const update: { audioEnabled?: boolean; videoEnabled?: boolean } = {};
-		if (typeof action === "object") {
-			if (action.type === "audio") update.audioEnabled = action.enabled;
-			else update.videoEnabled = action.enabled;
-		} else if (action === "mute" || action === "unmute")
+		if (action === "mute" || action === "unmute")
 			update.audioEnabled = action === "unmute";
 		else update.videoEnabled = action === "video_on";
-		this.deps.participantManager.updateMediaState(data.participantId, update);
+		this.deps.participantManager.updateMediaState(participantId, update);
+	}
+	private participantData(
+		participant: RecorderStageParticipant,
+	): RecorderParticipantData & { participantId: string } {
+		return {
+			participantId: participant.participant_id,
+			user_id: participant.participant_id,
+			user_name: participant.name,
+			avatar: participant.avatar,
+			audio_enabled: participant.audio_enabled,
+			video_enabled: participant.video_enabled,
+			userData: {
+				name: participant.name,
+				avatar: participant.avatar,
+				audio_enabled: participant.audio_enabled,
+				video_enabled: participant.video_enabled,
+			},
+		};
+	}
+	private producerEvent(producer: RecorderStageProducer): ProducerEvent {
+		return {
+			producerId: producer.producer_id,
+			participantId: producer.participant_id,
+			isScreen: producer.is_screen,
+		};
+	}
+	private queueTransient(event: RecorderStageProjectionEvent): void {
+		if (this.transientsLive) this.applyTransient(event);
+		else this.bufferedTransients.push(event);
+	}
+	private applyTransient(event: RecorderStageProjectionEvent): void {
+		const payload = event.payload;
+		if (payload.type === "reaction") {
+			this.state.reactionReceived?.(payload.from_user, payload.reaction);
+		} else if (payload.type === "chat_message") {
+			this.state.chatReceived?.({
+				id: payload.message_id,
+				participantId: payload.from_user,
+				author: payload.from_name,
+				text: payload.message,
+			});
+		}
+	}
+	private requireProjection(): RecorderStageProjection {
+		if (!this.projection)
+			throw new Error("Recorder projection is not initialized");
+		return this.projection;
+	}
+	private failProjection(diagnostic: string): Error {
+		const error = new Error(diagnostic);
+		if (this.projectionFailure) return this.projectionFailure;
+		this.projectionFailure = error;
+		this.interrupt("projection_invalid", diagnostic);
+		this.cleanup();
+		return error;
+	}
+	private assertEpoch(epoch: number): void {
+		if (!Number.isSafeInteger(epoch) || epoch < 0)
+			throw new Error(`Invalid capture epoch ${epoch}`);
+	}
+	private assertOperational(): void {
+		this.assertNotFailed();
+		if (this.cleaningUp || !this._ready.value)
+			throw new Error("Recorder is not ready for capture");
+	}
+	private assertCurrentCapture(capture: { superseded: boolean }): void {
+		if (capture.superseded || this.captureEpoch !== capture)
+			throw new CaptureCommandSupersededError();
+		this.assertOperational();
+	}
+	private assertNotFailed(): void {
+		if (this.projectionFailure) throw this.projectionFailure;
 	}
 	private interrupt(reasonCode: RendererReasonCode, diagnostic: string): void {
 		if (!this._ready.value && this._interruption.value) return;
@@ -748,6 +954,9 @@ export class RecorderSocketController {
 		if (this.cleaningUp) return;
 		this.cleaningUp = true;
 		if (this.roomEmptyTimer) clearTimeout(this.roomEmptyTimer);
+		this.roomEmptyTimer = undefined;
+		this.bufferedTransients = [];
+		this.transientsLive = false;
 		for (const pending of this.attachmentPromises.values()) pending.cancel();
 		for (const [participantId, screen] of [...this.activeScreens]) {
 			this.finishScreen(participantId, screen.producerId, screen.consumerId);
@@ -755,6 +964,7 @@ export class RecorderSocketController {
 		for (const pending of this.screenAttachmentPromises.values())
 			pending.cancel();
 		this.attachmentPromises.clear();
+		this.producerClaims.clear();
 		this.screenAttachmentPromises.clear();
 		this.currentParticipantAttachments.clear();
 		this.activeScreens.clear();
@@ -766,6 +976,35 @@ export class RecorderSocketController {
 		this.deps.videoManager.cleanup();
 		this.deps.transportManager.cleanup();
 		this.deps.sfuClient.disconnect();
+		for (const remove of this.listenerCleanup.splice(0)) remove();
+		this.deps.participantManager.setEventHandlers({
+			onParticipantAdded: undefined,
+			onParticipantRemoved: undefined,
+			onParticipantUpdated: undefined,
+		});
+		this.deps.consumerManager.setEventHandlers({
+			onConsumerAdded: undefined,
+			onConsumerRemoved: undefined,
+			onConsumerLost: undefined,
+		});
+		this.deps.mediaManager.setEventHandlers({
+			onScreenShareStarted: undefined,
+			onRecoveryExhausted: undefined,
+		});
+		this.deps.transportManager.setEventHandlers({
+			onTransportConnectionStateChange: undefined,
+		});
+	}
+	private listenChannel(
+		event: string,
+		handler: (...args: unknown[]) => void,
+	): void {
+		this.channel.on(event, handler);
+		this.listenerCleanup.push(() => this.channel.off(event, handler));
+	}
+	private listenSFU(event: string, handler: (...args: unknown[]) => void): void {
+		this.deps.sfuClient.on(event, handler);
+		this.listenerCleanup.push(() => this.deps.sfuClient.off(event, handler));
 	}
 	private scheduleRoomEmpty(): void {
 		if (this.deps.participantManager.getAllParticipants().length > 0) return;
@@ -783,6 +1022,28 @@ export class RecorderSocketController {
 				response?.success
 					? resolve()
 					: reject(new Error(response?.error || `${event} failed`));
+			}),
+		);
+	}
+	private requestProjectionSnapshot(
+		assertCurrent: () => void = () => undefined,
+	): Promise<RecorderStageSnapshot> {
+		return new Promise((resolve, reject) =>
+			this.channel.emit("recording:get_projection_snapshot", {}, (value) => {
+				try {
+					assertCurrent();
+				} catch (error) {
+					reject(error);
+					return;
+				}
+				const response = parseRecordingProjectionSnapshotResponse(value);
+				if (!response) {
+					reject(this.failProjection("Invalid recorder projection snapshot"));
+					return;
+				}
+				response.success
+					? resolve(response.snapshot)
+					: reject(new Error(response.error));
 			}),
 		);
 	}
@@ -830,3 +1091,13 @@ export function trustedAvatar(
 		return null;
 	}
 }
+
+const isCanonicalTimestamp = (value: unknown): value is string => {
+	if (
+		typeof value !== "string" ||
+		!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value)
+	)
+		return false;
+	const parsed = new Date(value);
+	return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};

--- a/frontend/recorder/RecorderStageProjection.test.ts
+++ b/frontend/recorder/RecorderStageProjection.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import type {
+	RecorderStageProjectionEvent,
+	RecorderStageSnapshot,
+} from "../../suite/meet/types";
+import { RecorderStageProjection } from "./RecorderStageProjection";
+
+const at = (second: number) =>
+	`2026-08-30T12:00:${String(second).padStart(2, "0")}.000Z`;
+const snapshot = (cursor = 0): RecorderStageSnapshot => ({
+	protocol_version: 1,
+	room_id: "site::room",
+	cursor,
+	observed_at: at(0),
+	participants: [],
+	producers: [],
+	raised_hands: {},
+	active_speaker_ids: [],
+});
+const event = (
+	cursor: number,
+	payload: RecorderStageProjectionEvent["payload"] = {
+		type: "active_speaker",
+		participant_ids: [],
+	},
+): RecorderStageProjectionEvent => ({
+	protocol_version: 1,
+	room_id: "site::room",
+	cursor,
+	observed_at: at(cursor),
+	payload,
+});
+
+describe("RecorderStageProjection", () => {
+	it("buffers before snapshot, discards old events, and replays contiguously", () => {
+		const projection = new RecorderStageProjection();
+		expect(projection.applyEvent(event(3))).toEqual([]);
+		expect(projection.applyEvent(event(1))).toEqual([]);
+		expect(projection.applyEvent(event(2))).toEqual([]);
+		expect(projection.initialize(snapshot(1))).toEqual([event(2), event(3)]);
+		expect(projection.cursor).toBe(3);
+	});
+
+	it("applies duplicates idempotently and throws on gaps", () => {
+		const projection = new RecorderStageProjection();
+		projection.initialize(snapshot());
+		expect(projection.applyEvent(event(1))).toEqual([event(1)]);
+		expect(projection.applyEvent(event(1))).toEqual([]);
+		expect(() => projection.applyEvent(event(3))).toThrow("cursor gap");
+	});
+
+	it("retains projected participant, producer, hand, and speaker state", () => {
+		const projection = new RecorderStageProjection();
+		projection.initialize(snapshot());
+		projection.applyEvent(
+			event(1, {
+				type: "participant_joined",
+				participant: {
+					participant_id: "alice",
+					name: "Alice",
+					audio_enabled: true,
+					video_enabled: false,
+				},
+			}),
+		);
+		projection.applyEvent(
+			event(2, {
+				type: "producer_created",
+				producer: {
+					producer_id: "p1",
+					participant_id: "alice",
+					kind: "audio",
+					paused: false,
+					is_screen: false,
+					observed_at: at(2),
+				},
+			}),
+		);
+		projection.applyEvent(
+			event(3, { type: "producer_updated", producer_id: "p1", paused: true }),
+		);
+		projection.applyEvent(
+			event(4, { type: "hand_raised", participant_id: "alice", raised: true }),
+		);
+		projection.applyEvent(
+			event(5, { type: "active_speaker", participant_ids: ["alice"] }),
+		);
+		expect(projection.participants.has("alice")).toBe(true);
+		expect(projection.producers.get("p1")).toMatchObject({
+			paused: true,
+			observed_at: at(3),
+		});
+		expect(projection.raisedHands.get("alice")).toBe(at(4));
+		expect(projection.activeSpeakerIds).toEqual(["alice"]);
+	});
+
+	it("throws on room mismatch and repeated initialization", () => {
+		const projection = new RecorderStageProjection();
+		projection.initialize(snapshot());
+		expect(() => projection.initialize(snapshot())).toThrow(
+			"already initialized",
+		);
+		expect(() =>
+			projection.applyEvent({ ...event(1), room_id: "other" }),
+		).toThrow("room mismatch");
+	});
+
+	it("adopts the scoped snapshot room and validates pre-snapshot events against it", () => {
+		const projection = new RecorderStageProjection();
+		projection.applyEvent(event(1));
+		expect(projection.initialize(snapshot())).toEqual([event(1)]);
+		expect(projection.roomId).toBe("site::room");
+
+		const mismatch = new RecorderStageProjection();
+		mismatch.applyEvent({ ...event(1), room_id: "other::room" });
+		expect(() => mismatch.initialize(snapshot())).toThrow("room mismatch");
+	});
+
+	it("binds the first snapshot to the configured meeting id", () => {
+		expect(() =>
+			new RecorderStageProjection("other").initialize(snapshot()),
+		).toThrow("meeting mismatch");
+		expect(() =>
+			new RecorderStageProjection("room").initialize(snapshot()),
+		).not.toThrow();
+	});
+
+	it("rejects conflicting duplicates, regressions, and invalid relationships", () => {
+		const projection = new RecorderStageProjection();
+		projection.initialize(snapshot());
+		projection.applyEvent(
+			event(1, { type: "participant_joined", participant: {
+				participant_id: "alice", name: "Alice", audio_enabled: true, video_enabled: true,
+			} }),
+		);
+		expect(() => projection.applyEvent({
+			...event(1, { type: "participant_left", participant_id: "alice" }),
+		})).toThrow("Conflicting");
+		expect(() => projection.applyEvent(event(2, {
+			type: "producer_created",
+			producer: { producer_id: "orphan", participant_id: "bob", kind: "audio", paused: false, is_screen: false, observed_at: at(2) },
+		}))).toThrow("absent");
+	});
+});

--- a/frontend/recorder/RecorderStageProjection.ts
+++ b/frontend/recorder/RecorderStageProjection.ts
@@ -1,0 +1,213 @@
+import type {
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionEvent,
+	RecorderStageSnapshot,
+} from "../../suite/meet/types";
+
+export class RecorderStageProjection {
+	readonly participants = new Map<string, RecorderStageParticipant>();
+	readonly producers = new Map<string, RecorderStageProducer>();
+	readonly raisedHands = new Map<string, string>();
+	activeSpeakerIds: string[] = [];
+	roomId?: string;
+	cursor?: number;
+	private observedAt?: string;
+	private latestEvent?: RecorderStageProjectionEvent;
+	private bufferedEvents: RecorderStageProjectionEvent[] = [];
+	private reconciling = true;
+
+	constructor(private readonly meetingId?: string) {}
+
+	applyEvent(event: RecorderStageProjectionEvent): RecorderStageProjectionEvent[] {
+		if (this.reconciling || this.cursor === undefined) {
+			this.bufferedEvents.push(event);
+			return [];
+		}
+		return this.applyInitializedEvent(event);
+	}
+
+	beginReconciliation(): void {
+		if (this.reconciling) return;
+		this.reconciling = true;
+		this.bufferedEvents = [];
+	}
+
+	initialize(snapshot: RecorderStageSnapshot): RecorderStageProjectionEvent[] {
+		if (this.cursor !== undefined) throw new Error("Projection already initialized");
+		return this.reconcile(snapshot);
+	}
+
+	reconcile(snapshot: RecorderStageSnapshot): RecorderStageProjectionEvent[] {
+		if (!this.reconciling) throw new Error("Projection is not reconciling");
+		if (this.roomId === undefined && this.meetingId !== undefined) {
+			const separator = snapshot.room_id.lastIndexOf("::");
+			const snapshotMeetingId =
+				separator === -1 ? snapshot.room_id : snapshot.room_id.slice(separator + 2);
+			if (snapshotMeetingId !== this.meetingId)
+				throw new Error(
+					`Projection meeting mismatch: expected ${this.meetingId}, received ${snapshotMeetingId}`,
+				);
+		}
+		if (this.roomId !== undefined && snapshot.room_id !== this.roomId)
+			this.roomMismatch(snapshot.room_id);
+		if (this.cursor !== undefined && snapshot.cursor < this.cursor)
+			throw new Error("Projection snapshot cursor regressed");
+		if (this.observedAt !== undefined && snapshot.observed_at < this.observedAt)
+			throw new Error("Projection snapshot timestamp regressed");
+		this.validateSnapshot(snapshot);
+		this.roomId = snapshot.room_id;
+		this.cursor = snapshot.cursor;
+		this.observedAt = snapshot.observed_at;
+		if (this.latestEvent?.cursor !== snapshot.cursor) this.latestEvent = undefined;
+		this.participants.clear();
+		this.producers.clear();
+		this.raisedHands.clear();
+		for (const participant of snapshot.participants)
+			this.participants.set(participant.participant_id, participant);
+		for (const producer of snapshot.producers)
+			this.producers.set(producer.producer_id, producer);
+		for (const [participantId, timestamp] of Object.entries(snapshot.raised_hands))
+			this.raisedHands.set(participantId, timestamp);
+		this.activeSpeakerIds = [...snapshot.active_speaker_ids];
+
+		const buffered = this.bufferedEvents.splice(0).sort((a, b) => a.cursor - b.cursor);
+		for (const event of buffered) this.assertRoom(event.room_id);
+		this.reconciling = false;
+		const accepted: RecorderStageProjectionEvent[] = [];
+		for (const event of buffered) {
+			if (event.cursor < snapshot.cursor) continue;
+			if (event.cursor === snapshot.cursor && !this.latestEvent) continue;
+			accepted.push(...this.applyInitializedEvent(event));
+		}
+		return accepted;
+	}
+
+	private applyInitializedEvent(event: RecorderStageProjectionEvent): RecorderStageProjectionEvent[] {
+		this.assertRoom(event.room_id);
+		const cursor = this.cursor as number;
+		if (event.cursor < cursor)
+			throw new Error(`Projection cursor regressed: ${event.cursor} after ${cursor}`);
+		if (event.cursor === cursor) {
+			if (this.latestEvent && JSON.stringify(event) === JSON.stringify(this.latestEvent))
+				return [];
+			throw new Error(`Conflicting projection event at cursor ${cursor}`);
+		}
+		if (event.cursor !== cursor + 1)
+			throw new Error(`Projection cursor gap: expected ${cursor + 1}, received ${event.cursor}`);
+		if (this.observedAt !== undefined && event.observed_at < this.observedAt)
+			throw new Error("Projection event timestamp regressed");
+		this.applyPayload(event);
+		this.cursor = event.cursor;
+		this.observedAt = event.observed_at;
+		this.latestEvent = event;
+		return [event];
+	}
+
+	private applyPayload(event: RecorderStageProjectionEvent): void {
+		const payload = event.payload;
+		switch (payload.type) {
+			case "participant_joined":
+				if (this.participants.has(payload.participant.participant_id))
+					throw new Error("Duplicate participant relationship");
+				this.participants.set(payload.participant.participant_id, payload.participant);
+				break;
+			case "participant_updated":
+				this.requireParticipant(payload.participant.participant_id);
+				this.participants.set(payload.participant.participant_id, payload.participant);
+				break;
+			case "participant_left":
+				this.requireParticipant(payload.participant_id);
+				this.participants.delete(payload.participant_id);
+				this.raisedHands.delete(payload.participant_id);
+				this.activeSpeakerIds = this.activeSpeakerIds.filter((id) => id !== payload.participant_id);
+				for (const [id, producer] of this.producers)
+					if (producer.participant_id === payload.participant_id) this.producers.delete(id);
+				break;
+			case "producer_created":
+				this.requireParticipant(payload.producer.participant_id);
+				if (this.producers.has(payload.producer.producer_id))
+					throw new Error("Duplicate producer relationship");
+				if (payload.producer.is_screen && payload.producer.kind !== "video")
+					throw new Error("Audio producer cannot be a screen share");
+				if (payload.producer.observed_at > event.observed_at)
+					throw new Error("Producer timestamp follows event timestamp");
+				this.producers.set(payload.producer.producer_id, payload.producer);
+				break;
+			case "producer_updated": {
+				const producer = this.producers.get(payload.producer_id);
+				if (!producer) throw new Error("Projection producer is absent");
+				this.producers.set(payload.producer_id, {
+					...producer,
+					paused: payload.paused,
+					observed_at: event.observed_at,
+				});
+				break;
+			}
+			case "producer_closed": {
+				const producer = this.producers.get(payload.producer_id);
+				if (!producer || producer.participant_id !== payload.participant_id || producer.is_screen !== payload.is_screen)
+					throw new Error("Producer close metadata mismatch");
+				this.producers.delete(payload.producer_id);
+				break;
+			}
+			case "media_control": {
+				const participant = this.requireParticipant(payload.participant_id);
+				const audio = payload.action === "mute" || payload.action === "unmute";
+				this.participants.set(payload.participant_id, {
+					...participant,
+					...(audio
+						? { audio_enabled: payload.action === "unmute" }
+						: { video_enabled: payload.action === "video_on" }),
+				});
+				break;
+			}
+			case "active_speaker":
+				if (new Set(payload.participant_ids).size !== payload.participant_ids.length)
+					throw new Error("Duplicate active speaker relationship");
+				for (const id of payload.participant_ids) this.requireParticipant(id);
+				this.activeSpeakerIds = [...payload.participant_ids];
+				break;
+			case "hand_raised":
+				this.requireParticipant(payload.participant_id);
+				if (payload.raised) this.raisedHands.set(payload.participant_id, event.observed_at);
+				else this.raisedHands.delete(payload.participant_id);
+				break;
+			case "reaction":
+			case "chat_message":
+				break;
+		}
+	}
+
+	private validateSnapshot(snapshot: RecorderStageSnapshot): void {
+		const participantIds = new Set(snapshot.participants.map((p) => p.participant_id));
+		const producerIds = new Set(snapshot.producers.map((p) => p.producer_id));
+		if (participantIds.size !== snapshot.participants.length) throw new Error("Duplicate snapshot participant");
+		if (producerIds.size !== snapshot.producers.length) throw new Error("Duplicate snapshot producer");
+		for (const producer of snapshot.producers) {
+			if (!participantIds.has(producer.participant_id)) throw new Error("Orphan snapshot producer");
+			if (producer.is_screen && producer.kind !== "video") throw new Error("Audio snapshot screen producer");
+			if (producer.observed_at > snapshot.observed_at) throw new Error("Producer timestamp follows snapshot");
+		}
+		for (const id of Object.keys(snapshot.raised_hands))
+			if (!participantIds.has(id)) throw new Error("Orphan snapshot raised hand");
+		if (new Set(snapshot.active_speaker_ids).size !== snapshot.active_speaker_ids.length)
+			throw new Error("Duplicate snapshot active speaker");
+		for (const id of snapshot.active_speaker_ids)
+			if (!participantIds.has(id)) throw new Error("Orphan snapshot active speaker");
+	}
+
+	private requireParticipant(id: string): RecorderStageParticipant {
+		const participant = this.participants.get(id);
+		if (!participant) throw new Error(`Projection participant ${id} is absent`);
+		return participant;
+	}
+
+	private assertRoom(roomId: string): void {
+		if (roomId !== this.roomId) this.roomMismatch(roomId);
+	}
+
+	private roomMismatch(roomId: string): never {
+		throw new Error(`Projection room mismatch: expected ${this.roomId}, received ${roomId}`);
+	}
+}

--- a/frontend/recorder/main.ts
+++ b/frontend/recorder/main.ts
@@ -1,5 +1,5 @@
 import { createPinia } from "pinia";
-import { computed, createApp, h, ref } from "vue";
+import { computed, createApp, h, nextTick, onUnmounted, ref } from "vue";
 import "../src/index.css";
 import { useChatStore } from "../src/apps/meet/composables/useChatStore";
 import { useGridLayout } from "../src/apps/meet/composables/useGridLayout";
@@ -9,6 +9,7 @@ import { useParticipantStore } from "../src/apps/meet/composables/useParticipant
 import { useRaiseHandStore } from "../src/apps/meet/composables/useRaiseHandStore";
 import { useReactionStore } from "../src/apps/meet/composables/useReactionStore";
 import RecorderRenderer from "./RecorderRenderer.vue";
+import { firstCaptureStartedAt } from "./recordingClock";
 import { RecorderRendererBridge } from "./rendererBridge";
 import { RecorderSocketController } from "./RecorderSocketController";
 
@@ -26,14 +27,37 @@ const app = createApp({
 		const raiseHandStore = useRaiseHandStore();
 		const lobbyStore = useLobbyStore();
 		const gridLayout = useGridLayout(mediaState);
-		const messages = ref<Array<{ id: string; author: string; text: string; avatar?: string | null }>>([]);
-		const pendingScreenAttachments = new Map<string, { resolve: () => void; reject: (error?: Error) => void }>();
+		const messages = ref<
+			Array<{
+				id: string;
+				author: string;
+				text: string;
+				avatar?: string | null;
+			}>
+		>([]);
+		const captureStartedAt = ref<number | null>(null);
+		const pendingScreenAttachments = new Map<
+			string,
+			{ resolve: () => void; reject: (error?: Error) => void }
+		>();
+		const messageTimers = new Set<ReturnType<typeof setTimeout>>();
 		const controller = new RecorderSocketController(bridge, undefined, {
-			participantAdded: (participant) => participantStore.addParticipant(participant),
+			participantAdded: (participant) =>
+				participantStore.addParticipant(participant),
 			participantRemoved: (id) => participantStore.removeParticipant(id),
-			participantUpdated: (id, updates) => participantStore.updateParticipant(id, { ...updates }),
-			activeSpeakersChanged: (ids) => { participantStore.activeSpeakerIds = ids; participantStore.stableSpeakerIds = ids; },
-			screenStarted: ({ participantId, consumerId, producerId, stream, startedAt }) => {
+			participantUpdated: (id, updates) =>
+				participantStore.updateParticipant(id, { ...updates }),
+			activeSpeakersChanged: (ids) => {
+				participantStore.activeSpeakerIds = ids;
+				participantStore.stableSpeakerIds = ids;
+			},
+			screenStarted: ({
+				participantId,
+				consumerId,
+				producerId,
+				stream,
+				startedAt,
+			}) => {
 				const replaced = mediaState.activeScreenShareConsumers.filter(
 					(share) =>
 						share.participantId === participantId &&
@@ -45,38 +69,145 @@ const app = createApp({
 					delete mediaState.screenShareStreams[share.consumerId];
 				}
 				mediaState.screenShareStreams[consumerId] = stream;
-				mediaState.activeScreenShareConsumers = [...mediaState.activeScreenShareConsumers.filter((s) => s.participantId !== participantId), { source: "remote", participantId, consumerId, producerId, startedAt }];
-				return new Promise<void>((resolve, reject) => pendingScreenAttachments.set(consumerId, { resolve, reject }));
+				mediaState.activeScreenShareConsumers = [
+					...mediaState.activeScreenShareConsumers.filter(
+						(s) => s.participantId !== participantId,
+					),
+					{
+						source: "remote",
+						participantId,
+						consumerId,
+						producerId,
+						startedAt,
+					},
+				];
+				return new Promise<void>((resolve, reject) =>
+					pendingScreenAttachments.set(consumerId, { resolve, reject }),
+				);
 			},
 			screenStopped: (participantId, producerId) => {
-				const removed = mediaState.activeScreenShareConsumers.filter((s) => s.participantId === participantId && s.producerId === producerId);
-				mediaState.activeScreenShareConsumers = mediaState.activeScreenShareConsumers.filter((s) => s.participantId !== participantId || s.producerId !== producerId);
+				const removed = mediaState.activeScreenShareConsumers.filter(
+					(s) =>
+						s.participantId === participantId && s.producerId === producerId,
+				);
+				mediaState.activeScreenShareConsumers =
+					mediaState.activeScreenShareConsumers.filter(
+						(s) =>
+							s.participantId !== participantId || s.producerId !== producerId,
+					);
 				for (const share of removed) {
 					pendingScreenAttachments.get(share.consumerId)?.resolve();
 					pendingScreenAttachments.delete(share.consumerId);
 					delete mediaState.screenShareStreams[share.consumerId];
 				}
 			},
-			reactionReceived: (id, reaction) => reactionStore.showReactionForUser(id, reaction),
-			handChanged: (id, raised, timestamp) => raised ? raiseHandStore.raiseHand(id, timestamp) : raiseHandStore.lowerHand(id),
+			reactionReceived: (id, reaction) =>
+				reactionStore.showReactionForUser(id, reaction),
+			handChanged: (id, raised, timestamp) =>
+				raised
+					? raiseHandStore.raiseHand(id, timestamp)
+					: raiseHandStore.lowerHand(id),
 			handsSynced: (hands) => raiseHandStore.setHands(hands),
 			chatReceived: (message) => {
 				if (config.publicChat === false) return;
 				const participant = message.participantId
-					? participantStore.participants[message.participantId] as { avatar?: string | null } | undefined
+					? (participantStore.participants[message.participantId] as
+							{ avatar?: string | null } | undefined)
 					: undefined;
-				messages.value = [...messages.value, { ...message, avatar: participant?.avatar }].slice(-5);
-				window.setTimeout(() => messages.value = messages.value.filter((item) => item.id !== message.id), 8000);
+				messages.value = [
+					...messages.value,
+					{ ...message, avatar: participant?.avatar },
+				].slice(-5);
+				const timer = window.setTimeout(
+					() => {
+						messages.value = messages.value.filter(
+							(item) => item.id !== message.id,
+						);
+						messageTimers.delete(timer);
+					},
+					8000,
+				);
+				messageTimers.add(timer);
 			},
 			roomEmpty: () => bridge.reportRoomEmpty(),
+			transientsCleared: () => {
+				messages.value = [];
+				reactionStore.$reset();
+			},
+			captureStarted: (timestamp) => {
+				captureStartedAt.value = firstCaptureStartedAt(
+					captureStartedAt.value,
+					timestamp,
+				);
+			},
+			frameCommitted: async () => {
+				await nextTick();
+				await new Promise<void>((resolve) =>
+					requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+				);
+			},
+		});
+		const unbindCaptureCommands = bridge.bindCaptureCommands(controller);
+		onUnmounted(() => {
+			unbindCaptureCommands();
+			for (const timer of messageTimers) clearTimeout(timer);
+			messageTimers.clear();
+			for (const pending of pendingScreenAttachments.values()) pending.resolve();
+			pendingScreenAttachments.clear();
+			controller.disconnect();
 		});
 		void controller.connect(config).catch(() => undefined);
-		const currentUser = { currentUser: computed(() => ({ user_id: "recorder", name: "Recorder" })), userInitials: computed(() => "R"), userAvatar: computed(() => ""), setCurrentUser: () => undefined, resetCurrentUser: () => undefined };
-		const meetingContext = {
-			mediaState, participantStore, currentUser, chatStore, gridLayout, raiseHandStore, reactionStore, lobbyStore,
-			sfuManager: null, processedStream: ref<MediaStream | null>(null), isInMeeting: computed(() => true), onBackgroundEffectsChanged: () => undefined, networkQuality: ref<"good" | "poor" | "critical">("good"),
+		const currentUser = {
+			currentUser: computed(() => ({ user_id: "recorder", name: "Recorder" })),
+			userInitials: computed(() => "R"),
+			userAvatar: computed(() => ""),
+			setCurrentUser: () => undefined,
+			resetCurrentUser: () => undefined,
 		};
-		return () => h(RecorderRenderer, { startedAt: config.startedAt, interruption: controller.interruption.value, messages: messages.value, meetingContext, videoManager: controller.videoManager, onPlaybackFailure: (reason: string) => controller.reportPlaybackFailure(reason), onScreenAttachment: (consumerId: string, attachment: Promise<void>) => { const pending = pendingScreenAttachments.get(consumerId); const settle = (error?: unknown) => { if (!pending || pendingScreenAttachments.get(consumerId) !== pending) return; pendingScreenAttachments.delete(consumerId); error ? pending.reject(error instanceof Error ? error : new Error("Screen attachment failed")) : pending.resolve(); }; void attachment.then(() => settle(), settle); } });
+		const meetingContext = {
+			mediaState,
+			participantStore,
+			currentUser,
+			chatStore,
+			gridLayout,
+			raiseHandStore,
+			reactionStore,
+			lobbyStore,
+			sfuManager: null,
+			processedStream: ref<MediaStream | null>(null),
+			isInMeeting: computed(() => true),
+			onBackgroundEffectsChanged: () => undefined,
+			networkQuality: ref<"good" | "poor" | "critical">("good"),
+		};
+		return () =>
+			h(RecorderRenderer, {
+				startedAt: captureStartedAt.value,
+				interruption: controller.interruption.value,
+				messages: messages.value,
+				meetingContext,
+				videoManager: controller.videoManager,
+				onPlaybackFailure: (reason: string) =>
+					controller.reportPlaybackFailure(reason),
+				onScreenAttachment: (consumerId: string, attachment: Promise<void>) => {
+					const pending = pendingScreenAttachments.get(consumerId);
+					const settle = (error?: unknown) => {
+						if (
+							!pending ||
+							pendingScreenAttachments.get(consumerId) !== pending
+						)
+							return;
+						pendingScreenAttachments.delete(consumerId);
+						error
+							? pending.reject(
+									error instanceof Error
+										? error
+										: new Error("Screen attachment failed"),
+								)
+							: pending.resolve();
+					};
+					void attachment.then(() => settle(), settle);
+				},
+			});
 	},
 });
 app.use(pinia).mount("#app");

--- a/frontend/recorder/protocol.test.ts
+++ b/frontend/recorder/protocol.test.ts
@@ -1,8 +1,52 @@
 import { describe, expect, it } from "vitest";
 import {
+	parseRecorderStageProjectionEvent,
+	parseRecorderStageSnapshot,
+	parseRecordingProjectionSnapshotResponse,
 	parseRecordingChallenge,
 	parseRecordingProofResponse,
 } from "./protocol";
+
+const observedAt = "2026-08-30T12:00:00.000Z";
+const stageSnapshot = {
+	protocol_version: 1,
+	room_id: "room",
+	cursor: 0,
+	observed_at: observedAt,
+	participants: [
+		{
+			participant_id: "alice",
+			name: "Alice",
+			audio_enabled: true,
+			video_enabled: false,
+		},
+	],
+	producers: [
+		{
+			producer_id: "producer",
+			participant_id: "alice",
+			kind: "video",
+			paused: false,
+			is_screen: true,
+			observed_at: observedAt,
+		},
+	],
+	raised_hands: { alice: observedAt },
+	active_speaker_ids: ["alice"],
+};
+const stageEvent = {
+	protocol_version: 1,
+	room_id: "room",
+	cursor: 1,
+	observed_at: observedAt,
+	payload: {
+		type: "chat_message",
+		message_id: "message",
+		message: "Hello",
+		from_user: "alice",
+		from_name: "Alice",
+	},
+};
 
 const challenge = {
 	protocol_version: 1,
@@ -48,5 +92,57 @@ describe("recording proof protocol", () => {
 		{ protocol_version: 1, success: false, error: "", extra: true },
 	])("rejects a non-contract proof response %#", (value) => {
 		expect(parseRecordingProofResponse(value)).toBeNull();
+	});
+});
+
+describe("recorder stage projection protocol", () => {
+	it("accepts exact snapshots, responses, and finite payload events", () => {
+		expect(parseRecorderStageSnapshot(stageSnapshot)).toEqual(stageSnapshot);
+		expect(
+			parseRecordingProjectionSnapshotResponse({
+				success: true,
+				snapshot: stageSnapshot,
+			}),
+		).toEqual({ success: true, snapshot: stageSnapshot });
+		expect(parseRecorderStageProjectionEvent(stageEvent)).toEqual(stageEvent);
+	});
+
+	it.each([
+		{ ...stageSnapshot, protocol_version: 2 },
+		{ ...stageSnapshot, cursor: -1 },
+		{ ...stageSnapshot, cursor: 1.5 },
+		{ ...stageSnapshot, observed_at: "2026-08-30T12:00:00Z" },
+		{ ...stageSnapshot, observed_at: "2026-13-30T12:00:00.000Z" },
+		{ ...stageSnapshot, raised_hands: { alice: "yesterday" } },
+		{
+			...stageSnapshot,
+			participants: [{ ...stageSnapshot.participants[0], extra: true }],
+		},
+		{
+			...stageSnapshot,
+			producers: [{ ...stageSnapshot.producers[0], kind: "data" }],
+		},
+		{ ...stageSnapshot, extra: true },
+	])("rejects invalid or unknown snapshot data %#", (value) => {
+		expect(parseRecorderStageSnapshot(value)).toBeNull();
+	});
+
+	it.each([
+		{ ...stageEvent, cursor: 0 },
+		{ ...stageEvent, cursor: Number.MAX_SAFE_INTEGER + 1 },
+		{ ...stageEvent, observed_at: "2026-08-30T12:00:00+00:00" },
+		{ ...stageEvent, payload: { type: "unknown" } },
+		{ ...stageEvent, payload: { ...stageEvent.payload, extra: true } },
+		{ ...stageEvent, extra: true },
+	])("rejects invalid, unknown, or inexact projection events %#", (value) => {
+		expect(parseRecorderStageProjectionEvent(value)).toBeNull();
+	});
+
+	it.each([
+		{ success: true, snapshot: stageSnapshot, extra: true },
+		{ success: false, error: "failed", extra: true },
+		{ success: false, error: "" },
+	])("rejects inexact snapshot responses %#", (value) => {
+		expect(parseRecordingProjectionSnapshotResponse(value)).toBeNull();
 	});
 });

--- a/frontend/recorder/protocol.ts
+++ b/frontend/recorder/protocol.ts
@@ -1,4 +1,10 @@
 import type {
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionEvent,
+	RecorderStageProjectionPayload,
+	RecorderStageSnapshot,
+	RecordingProjectionSnapshotResponse,
 	RecordingProofChallenge,
 	RecordingProofResponse,
 } from "../../suite/meet/types";
@@ -52,14 +58,10 @@ export type ProducerMessage =
 	| { type: "producer-closed"; value: ProducerEvent };
 
 export type LegacyMediaControlAction =
-	| "mute"
-	| "unmute"
-	| "video_off"
-	| "video_on";
+	"mute" | "unmute" | "video_off" | "video_on";
 
 export type MediaControlAction =
-	| LegacyMediaControlAction
-	| { type: "audio" | "video"; enabled: boolean };
+	LegacyMediaControlAction | { type: "audio" | "video"; enabled: boolean };
 
 export type MediaControlMessage =
 	| { participantId: string; action: LegacyMediaControlAction }
@@ -107,6 +109,330 @@ const optionalBoolean = (value: unknown): value is boolean | undefined =>
 	value === undefined || typeof value === "boolean";
 const optionalAvatar = (value: unknown): value is string | null | undefined =>
 	value === undefined || value === null || typeof value === "string";
+
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+type JsonObject = Record<string, JsonValue>;
+const jsonValue = (value: unknown): value is JsonValue => {
+	if (
+		value === null ||
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	)
+		return true;
+	if (Array.isArray(value)) return value.every(jsonValue);
+	return record(value);
+};
+const record = (value: unknown): value is JsonObject =>
+	typeof value === "object" &&
+	value !== null &&
+	!Array.isArray(value) &&
+	Object.values(value).every(jsonValue);
+const nonemptyString = (value: unknown): value is string =>
+	typeof value === "string" && value.length > 0;
+const canonicalTimestamp = (value: unknown): value is string => {
+	if (
+		typeof value !== "string" ||
+		!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value)
+	)
+		return false;
+	const parsed = new Date(value);
+	return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
+const stringArray = (value: unknown): value is string[] =>
+	Array.isArray(value) && value.every(nonemptyString);
+
+const parseStageParticipant = (
+	value: unknown,
+): RecorderStageParticipant | null => {
+	if (
+		!record(value) ||
+		!exactKeys(
+			value,
+			["participant_id", "name", "audio_enabled", "video_enabled"],
+			["avatar"],
+		) ||
+		!nonemptyString(value.participant_id) ||
+		!nonemptyString(value.name) ||
+		(typeof value.avatar !== "undefined" && !nonemptyString(value.avatar)) ||
+		typeof value.audio_enabled !== "boolean" ||
+		typeof value.video_enabled !== "boolean"
+	)
+		return null;
+	return {
+		participant_id: value.participant_id,
+		name: value.name,
+		...(typeof value.avatar === "string" ? { avatar: value.avatar } : {}),
+		audio_enabled: value.audio_enabled,
+		video_enabled: value.video_enabled,
+	};
+};
+
+const parseStageProducer = (value: unknown): RecorderStageProducer | null => {
+	if (
+		!record(value) ||
+		!exactKeys(value, [
+			"producer_id",
+			"participant_id",
+			"kind",
+			"paused",
+			"is_screen",
+			"observed_at",
+		]) ||
+		!nonemptyString(value.producer_id) ||
+		!nonemptyString(value.participant_id) ||
+		(value.kind !== "audio" && value.kind !== "video") ||
+		typeof value.paused !== "boolean" ||
+		typeof value.is_screen !== "boolean" ||
+		(value.is_screen === true && value.kind !== "video") ||
+		!canonicalTimestamp(value.observed_at)
+	)
+		return null;
+	return {
+		producer_id: value.producer_id,
+		participant_id: value.participant_id,
+		kind: value.kind,
+		paused: value.paused,
+		is_screen: value.is_screen,
+		observed_at: value.observed_at,
+	};
+};
+
+const parseProjectionPayload = (
+	value: unknown,
+): RecorderStageProjectionPayload | null => {
+	if (!record(value) || !nonemptyString(value.type)) return null;
+	switch (value.type) {
+		case "participant_joined":
+		case "participant_updated": {
+			if (!exactKeys(value, ["type", "participant"])) return null;
+			const participant = parseStageParticipant(value.participant);
+			return participant ? { type: value.type, participant } : null;
+		}
+		case "participant_left":
+			return exactKeys(value, ["type", "participant_id"]) &&
+				nonemptyString(value.participant_id)
+				? { type: value.type, participant_id: value.participant_id }
+				: null;
+		case "producer_created": {
+			if (!exactKeys(value, ["type", "producer"])) return null;
+			const producer = parseStageProducer(value.producer);
+			return producer ? { type: value.type, producer } : null;
+		}
+		case "producer_updated":
+			return exactKeys(value, ["type", "producer_id", "paused"]) &&
+				nonemptyString(value.producer_id) &&
+				typeof value.paused === "boolean"
+				? {
+						type: value.type,
+						producer_id: value.producer_id,
+						paused: value.paused,
+					}
+				: null;
+		case "producer_closed":
+			return exactKeys(value, [
+				"type",
+				"producer_id",
+				"participant_id",
+				"is_screen",
+			]) &&
+				nonemptyString(value.producer_id) &&
+				nonemptyString(value.participant_id) &&
+				typeof value.is_screen === "boolean"
+				? {
+						type: value.type,
+						producer_id: value.producer_id,
+						participant_id: value.participant_id,
+						is_screen: value.is_screen,
+					}
+				: null;
+		case "media_control":
+			return exactKeys(value, ["type", "participant_id", "action"]) &&
+				nonemptyString(value.participant_id) &&
+				(value.action === "mute" ||
+					value.action === "unmute" ||
+					value.action === "video_off" ||
+					value.action === "video_on")
+				? {
+						type: value.type,
+						participant_id: value.participant_id,
+						action: value.action,
+					}
+				: null;
+		case "active_speaker":
+			return exactKeys(value, ["type", "participant_ids"]) &&
+				stringArray(value.participant_ids)
+				? { type: value.type, participant_ids: value.participant_ids }
+				: null;
+		case "hand_raised":
+			return exactKeys(value, ["type", "participant_id", "raised"]) &&
+				nonemptyString(value.participant_id) &&
+				typeof value.raised === "boolean"
+				? {
+						type: value.type,
+						participant_id: value.participant_id,
+						raised: value.raised,
+					}
+				: null;
+		case "reaction":
+			return exactKeys(value, ["type", "from_user", "reaction"]) &&
+				nonemptyString(value.from_user) &&
+				nonemptyString(value.reaction)
+				? {
+						type: value.type,
+						from_user: value.from_user,
+						reaction: value.reaction,
+					}
+				: null;
+		case "chat_message":
+			return exactKeys(value, [
+				"type",
+				"message_id",
+				"message",
+				"from_user",
+				"from_name",
+			]) &&
+				nonemptyString(value.message_id) &&
+				nonemptyString(value.message) &&
+				nonemptyString(value.from_user) &&
+				nonemptyString(value.from_name)
+				? {
+						type: value.type,
+						message_id: value.message_id,
+						message: value.message,
+						from_user: value.from_user,
+						from_name: value.from_name,
+					}
+				: null;
+		default:
+			return null;
+	}
+};
+
+export const parseRecorderStageSnapshot = (
+	value: unknown,
+): RecorderStageSnapshot | null => {
+	if (
+		!record(value) ||
+		!exactKeys(value, [
+			"protocol_version",
+			"room_id",
+			"cursor",
+			"observed_at",
+			"participants",
+			"producers",
+			"raised_hands",
+			"active_speaker_ids",
+		]) ||
+		value.protocol_version !== 1 ||
+		!nonemptyString(value.room_id) ||
+		!Number.isSafeInteger(value.cursor) ||
+		(value.cursor as number) < 0 ||
+		!canonicalTimestamp(value.observed_at) ||
+		!Array.isArray(value.participants) ||
+		!Array.isArray(value.producers) ||
+		!record(value.raised_hands) ||
+		!stringArray(value.active_speaker_ids)
+	)
+		return null;
+	const participants: RecorderStageParticipant[] = [];
+	for (const participantValue of value.participants) {
+		const participant = parseStageParticipant(participantValue);
+		if (!participant) return null;
+		participants.push(participant);
+	}
+	const producers: RecorderStageProducer[] = [];
+	for (const producerValue of value.producers) {
+		const producer = parseStageProducer(producerValue);
+		if (!producer) return null;
+		producers.push(producer);
+	}
+	const observedAt = value.observed_at;
+	const participantIds = new Set(
+		participants.flatMap((participant) =>
+			participant ? [participant.participant_id] : [],
+		),
+	);
+	const producerIds = new Set(
+		producers.flatMap((producer) => (producer ? [producer.producer_id] : [])),
+	);
+	if (
+		participantIds.size !== participants.length ||
+		producerIds.size !== producers.length ||
+		producers.some(
+			(producer) =>
+				!participantIds.has(producer.participant_id) ||
+				producer.observed_at > observedAt,
+		) ||
+		Object.entries(value.raised_hands).some(
+			([participantId, timestamp]) =>
+				!participantIds.has(participantId) || !canonicalTimestamp(timestamp),
+		) ||
+		new Set(value.active_speaker_ids).size !== value.active_speaker_ids.length ||
+		value.active_speaker_ids.some((id) => !participantIds.has(id))
+	)
+		return null;
+	return {
+		protocol_version: 1,
+		room_id: value.room_id,
+		cursor: Number(value.cursor),
+		observed_at: observedAt,
+		participants,
+		producers,
+		raised_hands: Object.fromEntries(
+			Object.entries(value.raised_hands).map(([participantId, timestamp]) => [
+				participantId,
+				String(timestamp),
+			]),
+		),
+		active_speaker_ids: value.active_speaker_ids,
+	};
+};
+
+export const parseRecordingProjectionSnapshotResponse = (
+	value: unknown,
+): RecordingProjectionSnapshotResponse | null => {
+	if (!record(value) || typeof value.success !== "boolean") return null;
+	if (value.success) {
+		if (!exactKeys(value, ["success", "snapshot"])) return null;
+		const snapshot = parseRecorderStageSnapshot(value.snapshot);
+		return snapshot ? { success: true, snapshot } : null;
+	}
+	return exactKeys(value, ["success", "error"]) && nonemptyString(value.error)
+		? { success: false, error: value.error }
+		: null;
+};
+
+export const parseRecorderStageProjectionEvent = (
+	value: unknown,
+): RecorderStageProjectionEvent | null => {
+	if (
+		!record(value) ||
+		!exactKeys(value, [
+			"protocol_version",
+			"room_id",
+			"cursor",
+			"observed_at",
+			"payload",
+		]) ||
+		value.protocol_version !== 1 ||
+		!nonemptyString(value.room_id) ||
+		!Number.isSafeInteger(value.cursor) ||
+		(value.cursor as number) <= 0 ||
+		!canonicalTimestamp(value.observed_at)
+	)
+		return null;
+	const payload = parseProjectionPayload(value.payload);
+	return payload
+		? {
+				protocol_version: 1,
+				room_id: value.room_id,
+				cursor: value.cursor as number,
+				observed_at: value.observed_at,
+				payload,
+			}
+		: null;
+};
 
 const parseParticipantUserData = (
 	value: unknown,

--- a/frontend/recorder/protocolContract.test.ts
+++ b/frontend/recorder/protocolContract.test.ts
@@ -2,10 +2,18 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	parseRecorderStageProjectionEvent,
+	parseRecorderStageSnapshot,
 	parseRecordingChallenge,
 	parseRecordingProofResponse,
 } from "./protocol";
-import { parseConfigureMessage } from "./rendererBridge";
+import {
+	parseCaptureStartedMessage,
+	parseConfigureMessage,
+	parsePrepareCaptureMessage,
+} from "./rendererBridge";
+
+type VectorSet = { accepted: unknown[]; rejected: unknown[] };
 
 const contract = JSON.parse(
 	readFileSync(
@@ -13,6 +21,7 @@ const contract = JSON.parse(
 		"utf8",
 	),
 ) as {
+	vocabularies: { recorder_stage_projection_payload_types: string[] };
 	vectors: {
 		proof_challenges: {
 			accepted: unknown[];
@@ -20,6 +29,10 @@ const contract = JSON.parse(
 		};
 		proof_responses: { accepted: unknown[]; rejected: unknown[] };
 		renderer_configure: { accepted: unknown[]; rejected: unknown[] };
+		recorder_stage_snapshots: VectorSet;
+		recorder_stage_projection_events: VectorSet;
+		renderer_prepare_capture: VectorSet;
+		renderer_capture_started: VectorSet;
 	};
 };
 
@@ -36,6 +49,35 @@ describe("recording protocol contract v1", () => {
 			expect(parseConfigureMessage(value)).not.toBeNull();
 		for (const value of contract.vectors.renderer_configure.rejected)
 			expect(parseConfigureMessage(value)).toBeNull();
+	});
+
+	it("runs shared recorder stage vectors through the production parsers", () => {
+		for (const value of contract.vectors.recorder_stage_snapshots.accepted)
+			expect(parseRecorderStageSnapshot(value)).toEqual(value);
+		for (const value of contract.vectors.recorder_stage_snapshots.rejected)
+			expect(parseRecorderStageSnapshot(value)).toBeNull();
+		for (const value of contract.vectors.recorder_stage_projection_events
+			.accepted)
+			expect(parseRecorderStageProjectionEvent(value)).toEqual(value);
+		for (const value of contract.vectors.recorder_stage_projection_events
+			.rejected)
+			expect(parseRecorderStageProjectionEvent(value)).toBeNull();
+		expect(
+			contract.vectors.recorder_stage_projection_events.accepted.map(
+				(value) => (value as { payload: { type: string } }).payload.type,
+			),
+		).toEqual(contract.vocabularies.recorder_stage_projection_payload_types);
+	});
+
+	it("runs shared capture command vectors through the production parsers", () => {
+		for (const value of contract.vectors.renderer_prepare_capture.accepted)
+			expect(parsePrepareCaptureMessage(value)).toEqual(value);
+		for (const value of contract.vectors.renderer_prepare_capture.rejected)
+			expect(parsePrepareCaptureMessage(value)).toBeNull();
+		for (const value of contract.vectors.renderer_capture_started.accepted)
+			expect(parseCaptureStartedMessage(value)).toEqual(value);
+		for (const value of contract.vectors.renderer_capture_started.rejected)
+			expect(parseCaptureStartedMessage(value)).toBeNull();
 	});
 
 	it("runs shared proof response vectors through the production parser", () => {

--- a/frontend/recorder/recordingClock.test.ts
+++ b/frontend/recorder/recordingClock.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { firstCaptureStartedAt } from "./recordingClock";
+
+describe("firstCaptureStartedAt", () => {
+	it("keeps the Recording Session start across recovery epochs", () => {
+		const initial = firstCaptureStartedAt(null, "2026-08-30T12:00:01.000Z");
+		expect(
+			firstCaptureStartedAt(initial, "2026-08-30T12:01:01.000Z"),
+		).toBe(initial);
+	});
+});

--- a/frontend/recorder/recordingClock.ts
+++ b/frontend/recorder/recordingClock.ts
@@ -1,0 +1,4 @@
+export const firstCaptureStartedAt = (
+	current: number | null,
+	timestamp: string,
+): number => current ?? Date.parse(timestamp);

--- a/frontend/recorder/rendererBridge.test.ts
+++ b/frontend/recorder/rendererBridge.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	CaptureCommandSupersededError,
 	canonicalChallenge,
+	parseCaptureStartedMessage,
+	parsePrepareCaptureMessage,
 	type RecorderConfig,
 	RecorderRendererBridge,
 } from "./rendererBridge";
@@ -15,6 +18,68 @@ const challenge = {
 };
 
 describe("RecorderRendererBridge", () => {
+	it("strictly parses capture commands", () => {
+		 expect(
+			parsePrepareCaptureMessage({
+				type: "suite-recorder:prepare-capture",
+				protocol_version: 1,
+				job: "job",
+				epoch: 0,
+			}),
+		).toEqual({
+			type: "suite-recorder:prepare-capture",
+			protocol_version: 1,
+			job: "job",
+			epoch: 0,
+		});
+		expect(
+			parseCaptureStartedMessage({
+				type: "suite-recorder:capture-started",
+				protocol_version: 1,
+				job: "job",
+				epoch: 0,
+				capture_started_at: "2026-08-30T12:00:00.000Z",
+			}),
+		).toEqual({
+			type: "suite-recorder:capture-started",
+			protocol_version: 1,
+			job: "job",
+			epoch: 0,
+			capture_started_at: "2026-08-30T12:00:00.000Z",
+		});
+		for (const invalid of [
+			{ epoch: -1 },
+			{ epoch: Number.MAX_SAFE_INTEGER + 1 },
+			{ epoch: 0, extra: true },
+		])
+			expect(
+				parsePrepareCaptureMessage({
+					type: "suite-recorder:prepare-capture",
+					protocol_version: 1,
+					job: "job",
+					...invalid,
+				}),
+			).toBeNull();
+		expect(
+			parseCaptureStartedMessage({
+				type: "suite-recorder:capture-started",
+				protocol_version: 1,
+				job: "job",
+				epoch: 0,
+				capture_started_at: "2026-08-30T12:00:00Z",
+			}),
+		).toBeNull();
+		expect(
+			parseCaptureStartedMessage({
+				type: "suite-recorder:capture-started",
+				protocol_version: 1,
+				job: "job",
+				epoch: 0,
+				capture_started_at: "9999-99-99T99:99:99.999Z",
+			}),
+		).toBeNull();
+	});
+
 	it("canonicalizes and signs a server-compatible P1363 proof", async () => {
 		expect(new TextDecoder().decode(canonicalChallenge(challenge))).toBe(
 			"meet-recording-proof-v1\njti-vector\nsocket-vector\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n1700000000\n1700000010",
@@ -178,5 +243,227 @@ describe("RecorderRendererBridge", () => {
 			},
 		]);
 		postMessage.mockRestore();
+	});
+
+	it("acknowledges capture commands only after controller acceptance", async () => {
+		const postMessage = vi
+			.spyOn(window, "postMessage")
+			.mockImplementation(() => undefined);
+		const listeners: EventListener[] = [];
+		const source = {
+			addEventListener: (_name: string, listener: EventListener) =>
+				listeners.push(listener),
+			removeEventListener: (_name: string, listener: EventListener) =>
+				listeners.splice(listeners.indexOf(listener), 1),
+		};
+		const bridge = new RecorderRendererBridge();
+		const configured = bridge.waitForConfig(source);
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:configure",
+					protocol_version: 1,
+					config: {
+						job: "job",
+						grant: "grant",
+						meetingId: "room",
+						sfuOrigin: "https://sfu.test",
+						frappeOrigin: "https://frappe.test",
+						socketPath: "/socket.io",
+						acceptedAt: "2026-08-30T12:00:00.000Z",
+					},
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await configured;
+		let release!: () => void;
+		const prepareCapture = vi.fn(
+			() => new Promise<void>((resolve) => (release = resolve)),
+		);
+		const captureStarted = vi.fn(async () => undefined);
+		const failCaptureCommand = vi.fn();
+		const unbind = bridge.bindCaptureCommands(
+			{ prepareCapture, captureStarted, failCaptureCommand },
+			source,
+		);
+		postMessage.mockClear();
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:prepare-capture",
+					protocol_version: 1,
+					job: "job",
+					epoch: 2,
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		expect(postMessage).not.toHaveBeenCalled();
+		release();
+		await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce());
+		expect(postMessage.mock.calls[0]?.[0]).toEqual({
+			type: "suite-recorder:capture-prepared",
+			protocol_version: 1,
+			occurred_at: expect.any(String),
+			job: "job",
+			epoch: 2,
+		});
+
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:capture-started",
+					protocol_version: 1,
+					job: "job",
+					epoch: 2,
+					capture_started_at: "2026-08-30T12:00:02.000Z",
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await vi.waitFor(() => expect(postMessage).toHaveBeenCalledTimes(2));
+		expect(postMessage.mock.calls[1]?.[0]).toEqual({
+			type: "suite-recorder:capture-started-accepted",
+			protocol_version: 1,
+			occurred_at: expect.any(String),
+			job: "job",
+			epoch: 2,
+			capture_started_at: "2026-08-30T12:00:02.000Z",
+		});
+		unbind();
+		expect(listeners).toHaveLength(0);
+		postMessage.mockRestore();
+	});
+
+	it.each([
+		{
+			type: "suite-recorder:prepare-capture",
+			protocol_version: 1,
+			job: "other-job",
+			epoch: 0,
+		},
+		{
+			type: "suite-recorder:prepare-capture",
+			protocol_version: 1,
+			job: "job",
+			epoch: -1,
+		},
+	])("fails closed locally and unbinds invalid commands", async (command) => {
+		const listeners: EventListener[] = [];
+		const source = {
+			addEventListener: (_name: string, listener: EventListener) =>
+				listeners.push(listener),
+			removeEventListener: (_name: string, listener: EventListener) =>
+				listeners.splice(listeners.indexOf(listener), 1),
+		};
+		const bridge = new RecorderRendererBridge();
+		const configured = bridge.waitForConfig(source);
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:configure",
+					protocol_version: 1,
+					config: {
+						job: "job",
+						grant: "grant",
+						meetingId: "room",
+						sfuOrigin: "https://sfu.test",
+						frappeOrigin: "https://frappe.test",
+						socketPath: "/socket.io",
+						acceptedAt: "2026-08-30T12:00:00.000Z",
+					},
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await configured;
+		const failCaptureCommand = vi.fn();
+		bridge.bindCaptureCommands(
+			{
+				prepareCapture: vi.fn(async () => undefined),
+				captureStarted: vi.fn(async () => undefined),
+				failCaptureCommand,
+			},
+			source,
+		);
+		listeners[0](
+			new MessageEvent("message", {
+				data: command,
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		expect(failCaptureCommand).toHaveBeenCalledWith(
+			"Invalid recorder capture command",
+		);
+		expect(listeners).toHaveLength(0);
+	});
+
+	it.each([
+		["fails closed", new Error("rejected"), true],
+		["ignores superseded", new CaptureCommandSupersededError(), false],
+	] as const)("%s when the controller rejects a command", async (_label, rejection, failsClosed) => {
+		const listeners: EventListener[] = [];
+		const source = {
+			addEventListener: (_name: string, listener: EventListener) =>
+				listeners.push(listener),
+			removeEventListener: (_name: string, listener: EventListener) =>
+				listeners.splice(listeners.indexOf(listener), 1),
+		};
+		const bridge = new RecorderRendererBridge();
+		const configured = bridge.waitForConfig(source);
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:configure",
+					protocol_version: 1,
+					config: {
+						job: "job",
+						grant: "grant",
+						meetingId: "room",
+						sfuOrigin: "https://sfu.test",
+						frappeOrigin: "https://frappe.test",
+						socketPath: "/socket.io",
+						acceptedAt: "2026-08-30T12:00:00.000Z",
+					},
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await configured;
+		const failCaptureCommand = vi.fn();
+		bridge.bindCaptureCommands(
+			{
+				prepareCapture: vi.fn(async () => {
+					throw rejection;
+				}),
+				captureStarted: vi.fn(async () => undefined),
+				failCaptureCommand,
+			},
+			source,
+		);
+		listeners[0](
+			new MessageEvent("message", {
+				data: {
+					type: "suite-recorder:prepare-capture",
+					protocol_version: 1,
+					job: "job",
+					epoch: 0,
+				},
+				origin: window.location.origin,
+				source: window,
+			}),
+		);
+		await new Promise<void>((resolve) => setTimeout(resolve, 0));
+		if (failsClosed)
+			expect(failCaptureCommand).toHaveBeenCalledWith("rejected");
+		else expect(failCaptureCommand).not.toHaveBeenCalled();
+		expect(listeners).toHaveLength(failsClosed ? 0 : 1);
 	});
 });

--- a/frontend/recorder/rendererBridge.ts
+++ b/frontend/recorder/rendererBridge.ts
@@ -20,6 +20,7 @@ export type RendererReasonCode =
 	| "media_attachment_failed"
 	| "media_subscription_failed"
 	| "receive_transport_failed"
+	| "projection_invalid"
 	| "configuration_failed"
 	| "browser_disconnected"
 	| "page_crashed";
@@ -40,6 +41,34 @@ type RendererReport =
 			diagnostic?: string;
 	  };
 
+export type PrepareCaptureCommand = {
+	type: "suite-recorder:prepare-capture";
+	protocol_version: 1;
+	job: string;
+	epoch: number;
+};
+
+export type CaptureStartedCommand = {
+	type: "suite-recorder:capture-started";
+	protocol_version: 1;
+	job: string;
+	epoch: number;
+	capture_started_at: string;
+};
+
+export interface CaptureCommandController {
+	prepareCapture(epoch: number): Promise<void>;
+	captureStarted(epoch: number, timestamp: string): Promise<void>;
+	failCaptureCommand(reason: string): void;
+}
+
+export class CaptureCommandSupersededError extends Error {
+	constructor() {
+		super("Capture command superseded");
+		this.name = "CaptureCommandSupersededError";
+	}
+}
+
 export type OutboundRendererMessage =
 	| {
 			type: "suite-recorder:public-key-ready";
@@ -53,11 +82,26 @@ export type OutboundRendererMessage =
 			occurred_at: string;
 			job: string;
 	  }
-	| (RendererReport & {
+	  | (RendererReport & {
 			protocol_version: 1;
 			occurred_at: string;
 			job: string;
-	  });
+	  })
+	| {
+			type: "suite-recorder:capture-prepared";
+			protocol_version: 1;
+			occurred_at: string;
+			job: string;
+			epoch: number;
+	  }
+	| {
+			type: "suite-recorder:capture-started-accepted";
+			protocol_version: 1;
+			occurred_at: string;
+			job: string;
+			epoch: number;
+			capture_started_at: string;
+	  };
 
 export const canonicalChallenge = (
 	challenge: RecordingChallenge,
@@ -143,6 +187,65 @@ export class RecorderRendererBridge {
 		});
 	}
 
+	bindCaptureCommands(
+		controller: CaptureCommandController,
+		source: Pick<Window, "addEventListener" | "removeEventListener"> = window,
+	): () => void {
+		let bound = true;
+		const receive = (event: MessageEvent) => {
+			if (
+				event.source !== window ||
+				event.origin !== window.location.origin ||
+				!this.job
+			)
+				return;
+			const type =
+				event.data && typeof event.data === "object" && "type" in event.data
+					? event.data.type
+					: undefined;
+			if (
+				type !== "suite-recorder:prepare-capture" &&
+				type !== "suite-recorder:capture-started"
+			)
+				return;
+			const prepare = parsePrepareCaptureMessage(event.data);
+			const started = parseCaptureStartedMessage(event.data);
+			if ((!prepare && !started) || (prepare ?? started)?.job !== this.job) {
+				failClosed("Invalid recorder capture command");
+				return;
+			}
+			const operation = prepare
+				? controller.prepareCapture(prepare.epoch).then(() => {
+						this.reportCapturePrepared(prepare.epoch);
+					})
+				: controller
+						.captureStarted(started.epoch, started.capture_started_at)
+						.then(() => {
+							this.reportCaptureStartedAccepted(
+								started.epoch,
+								started.capture_started_at,
+							);
+						});
+			void operation.catch((error: unknown) => {
+				if (error instanceof CaptureCommandSupersededError) return;
+				failClosed(
+					error instanceof Error ? error.message : "Capture command failed",
+				);
+			});
+		};
+		const unbind = () => {
+			if (!bound) return;
+			bound = false;
+			source.removeEventListener("message", receive as EventListener);
+		};
+		const failClosed = (diagnostic: string) => {
+			unbind();
+			controller.failCaptureCommand(diagnostic);
+		};
+		source.addEventListener("message", receive as EventListener);
+		return unbind;
+	}
+
 	async sign(challenge: RecordingChallenge): Promise<string> {
 		if (!this.privateKey) throw new Error("Recorder bridge is not initialized");
 		const signature = await crypto.subtle.sign(
@@ -199,6 +302,32 @@ export class RecorderRendererBridge {
 		);
 	}
 
+	private reportCapturePrepared(epoch: number): void {
+		if (!this.job) return;
+		this.post({
+			type: "suite-recorder:capture-prepared",
+			protocol_version: RECORDER_PROTOCOL_VERSION,
+			occurred_at: new Date().toISOString(),
+			job: this.job,
+			epoch,
+		});
+	}
+
+	private reportCaptureStartedAccepted(
+		epoch: number,
+		captureStartedAt: string,
+	): void {
+		if (!this.job) return;
+		this.post({
+			type: "suite-recorder:capture-started-accepted",
+			protocol_version: RECORDER_PROTOCOL_VERSION,
+			occurred_at: new Date().toISOString(),
+			job: this.job,
+			epoch,
+			capture_started_at: captureStartedAt,
+		});
+	}
+
 	private report(
 		message: RendererReport,
 		target: Pick<Window, "postMessage">,
@@ -239,10 +368,15 @@ const isHttpUrl = (value: string): boolean => {
 	}
 };
 
-const isUtcTimestamp = (value: unknown): value is string =>
-	typeof value === "string" &&
-	/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value) &&
-	new Date(value).toISOString() === value;
+const isUtcTimestamp = (value: unknown): value is string => {
+	if (
+		typeof value !== "string" ||
+		!/^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z$/.test(value)
+	)
+		return false;
+	const parsed = new Date(value);
+	return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value;
+};
 
 const parseConfig = (value: unknown): RecorderConfig | null => {
 	if (
@@ -319,4 +453,69 @@ export const parseConfigureMessage = (
 		return null;
 	const config = parseConfig(value.config);
 	return config ? { type: value.type, config } : null;
+};
+
+export const parsePrepareCaptureMessage = (
+	value: unknown,
+): PrepareCaptureCommand | null => {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		Array.isArray(value) ||
+		!hasExactKeys(value, ["type", "protocol_version", "job", "epoch"]) ||
+		!("type" in value) ||
+		value.type !== "suite-recorder:prepare-capture" ||
+		!("protocol_version" in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!("job" in value) ||
+		typeof value.job !== "string" ||
+		!value.job ||
+		!("epoch" in value) ||
+		!Number.isSafeInteger(value.epoch) ||
+		Number(value.epoch) < 0
+	)
+		return null;
+	return {
+		type: value.type,
+		protocol_version: RECORDER_PROTOCOL_VERSION,
+		job: value.job,
+		epoch: value.epoch as number,
+	};
+};
+
+export const parseCaptureStartedMessage = (
+	value: unknown,
+): CaptureStartedCommand | null => {
+	if (
+		!value ||
+		typeof value !== "object" ||
+		Array.isArray(value) ||
+		!hasExactKeys(value, [
+			"type",
+			"protocol_version",
+			"job",
+			"epoch",
+			"capture_started_at",
+		]) ||
+		!("type" in value) ||
+		value.type !== "suite-recorder:capture-started" ||
+		!("protocol_version" in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!("job" in value) ||
+		typeof value.job !== "string" ||
+		!value.job ||
+		!("epoch" in value) ||
+		!Number.isSafeInteger(value.epoch) ||
+		Number(value.epoch) < 0 ||
+		!("capture_started_at" in value) ||
+		!isUtcTimestamp(value.capture_started_at)
+	)
+		return null;
+	return {
+		type: value.type,
+		protocol_version: RECORDER_PROTOCOL_VERSION,
+		job: value.job,
+		epoch: value.epoch as number,
+		capture_started_at: value.capture_started_at,
+	};
 };

--- a/suite/meet/CONTEXT.md
+++ b/suite/meet/CONTEXT.md
@@ -13,7 +13,7 @@ One browser endpoint's live connection to a Meet Room, from join setup through c
 _Avoid_: Meeting Session, SFU Session
 
 **Recording Session**:
-One continuous interval beginning when an authorized start is accepted and ending when recording stops.
+One continuous interval beginning when the Recorder Endpoint is ready to capture the Shared Stage and ending when recording stops.
 _Avoid_: Recording Job, Recording File
 
 **Recording Artifact**:
@@ -81,7 +81,7 @@ _Avoid_: Server-side Encryption
 - A **Recording Session** produces at most one **Recording Artifact**.
 - A **Recording Session** may exist without a **Recording Artifact** while it is active or processing, or after an unrecoverable failure.
 - A failed **Recording Session** with no Recording Artifact is retained for 30 days and then deleted automatically.
-- A **Recording Artifact** may begin after its Recording Session when recorder startup takes time.
+- Recorder startup happens before the **Recording Session** and is not part of the Recording Artifact.
 - A Recording Session with one or more known capture gaps produces one **Partial Artifact**, not multiple artifacts.
 - A **Partial Artifact** omits known gaps from playback and records their session timestamps as metadata; it does not synthesize filler media.
 - A recorder service restart ends the active Recording Session and does not resume capture automatically. The Room Owner receives a Partial Artifact when valid captured media exists; otherwise the session fails without an artifact. A host or co-host may start a new Recording Session after the recorder becomes ready.
@@ -95,12 +95,18 @@ _Avoid_: Server-side Encryption
 - A **Recording Initiator** controls a **Recording Session** but does not thereby own its **Recording Artifact**.
 - A **Recorder Endpoint** observes the **Shared Stage** but does not count as a participant or keep the room human-occupied.
 - A **Recording Artifact** contains the **Shared Stage**, including public chat messages sent after artifact capture begins but not earlier chat or messages sent during recorder startup.
+- The SFU supplies the Recorder Endpoint with one recorder-safe Shared Stage snapshot and monotonic room-event cursor; subsequent recorder projection events carry ordered cursors and SFU-observed timestamps.
+- The Recorder Endpoint is ready to capture only after it proves its Recording Grant, joins the Meet Room, reconciles the recorder-safe snapshot with buffered events, attaches every current producer for playback, and commits one rendered Shared Stage frame.
+- Before each capture epoch, the Recorder Endpoint clears and buffers transient Shared Stage overlays and commits a clean frame. After capture launches, it releases only public chat and reactions observed at or after that epoch's capture start.
+- Persistent Shared Stage state, including participants, media, screen shares, and raised hands, survives the capture-start reset.
+- Recovery from a Recording Interruption repeats Shared Stage reconciliation, media attachment, transient reset, and rendered-frame readiness before capture resumes.
+- Unknown or invalid recorder projection data causes a Recording Interruption and fresh snapshot recovery rather than being silently omitted from the Recording Artifact.
 - The recorded **Shared Stage** uses the current desktop Meet layout at 1920x1080: screen shares auto-pin with the standard sidebar, otherwise participants use the standard grid and overflow priorities.
 - The **Recorder Endpoint** never appears as a tile in the recorded Shared Stage.
 - The recorded **Shared Stage** includes names, avatars, active-speaker treatment, reactions, raised hands, timed public-chat overlays, and a small recording timer.
 - The recorded **Shared Stage** excludes meeting controls, sidebars, polls, menus, private notifications, and personalized participant state.
 - A **Recording Notice** informs participants but does not represent explicit individual consent.
-- A **Recording Notice** and live recording indicator appear immediately when the Recording Session begins; there is no countdown.
+- A **Recording Notice** and live recording indicator appear immediately when the Recorder Endpoint is ready to capture and the Recording Session begins; there is no countdown.
 - A late joiner's media may enter an active **Recording Session** immediately; a **Recording Notice** does not gate publication.
 - A scheduled **Recording Estimate** uses the time remaining in the Calendar event plus a 15-minute overrun allowance.
 - A recurring scheduled **Recording Estimate** uses one occurrence's full event duration plus a 15-minute overrun allowance.

--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -71,6 +71,7 @@ INTERRUPTION_REASON_CODES = {
     "media_attachment_failed",
     "media_subscription_failed",
     "page_crashed",
+    "projection_invalid",
     "receive_transport_failed",
     "sfu_disconnected",
 }

--- a/suite/meet/docs/adr/0011-project-the-recorded-shared-stage.md
+++ b/suite/meet/docs/adr/0011-project-the-recorded-shared-stage.md
@@ -1,0 +1,13 @@
+# Project the recorded Shared Stage in the recorder browser
+
+The recorder browser owns recorded Shared Stage policy: the SFU supplies an authenticated recorder-safe projection, and one browser Module applies it to the standard Meet stores and `MeetingLayout`. SFU-owned layout and recorder branches inside the shared participant layout were rejected because they would spread recording policy away from the rendered capture and reduce reuse.
+
+## Consequences
+
+- The SFU returns one recorder-specific snapshot with a monotonic room-event cursor and sends subsequent projection events with ordered cursors and canonical SFU-observed timestamps.
+- Initial capture readiness requires Recording Grant proof, Meet Room join, receive transport connection, snapshot and buffered-event reconciliation, playback attachment for every current producer, and one committed layout frame.
+- Capture launch uses a two-step handshake. `prepare_capture` clears and buffers transient overlays and commits a clean frame; after FFmpeg launches and durably records its timestamp, `capture_started` releases only qualifying public chat and reactions.
+- Persistent participant, media, screen-share, and raised-hand state survives the capture-start reset. Startup and interruption-period transient overlays do not enter the Recording Artifact.
+- Recovery after a Recording Interruption repeats snapshot reconciliation, media attachment, transient reset, and rendered-frame readiness before a new capture epoch launches.
+- Unknown or invalid recorder projection data fails closed into a Recording Interruption and fresh snapshot recovery within the existing deadline.
+- Most tests drive snapshots, ordered events, synthetic media, and capture handshakes through the projection Module's Interface. One real SFU-to-browser-to-FFmpeg test decodes representative video frames and audio to verify the complete path.

--- a/suite/meet/recorder-server/Dockerfile
+++ b/suite/meet/recorder-server/Dockerfile
@@ -44,6 +44,12 @@ CMD ["node", "dist/server.js"]
 
 FROM runtime AS integration
 ENV NODE_ENV=integration
+USER root
+COPY suite/meet/recorder-server/yarn.lock ./yarn.lock
+RUN corepack enable && corepack prepare yarn@1.22.22 --activate \
+  && yarn install --frozen-lockfile --production=false --ignore-scripts --prefer-offline \
+  && chown -R node:node /app/recorder-server
+USER node
 CMD ["node", "dist/integration/CaptureWorker.integration.js"]
 
 FROM runtime AS production

--- a/suite/meet/recorder-server/integration/docker-compose.yml
+++ b/suite/meet/recorder-server/integration/docker-compose.yml
@@ -1,4 +1,42 @@
 services:
+  grant-store-init:
+    image: suite-sfu-integration:local
+    user: root
+    build:
+      context: ../..
+      dockerfile: sfu-server/Dockerfile
+    volumes:
+      - sfu-grants:/data
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - >-
+        node --input-type=module -e "import { RecordingGrantPersistenceFile } from
+        './dist/sfu-server/src/server/RecordingGrantPersistenceFile.js';
+        await RecordingGrantPersistenceFile.bootstrap('/data/recording-grants.json');"
+        && chown node:node /data/recording-grants.json
+
+  sfu:
+    image: suite-sfu-integration:local
+    depends_on:
+      grant-store-init:
+        condition: service_completed_successfully
+    environment:
+      JWT_SECRET: integration-secret
+      # Plain RTP is development-only test ingress for deterministic FFmpeg media.
+      # Production participants and recorder playback continue to use WebRTC.
+      NODE_ENV: development
+      MEDIASOUP_NUM_WORKERS: 1
+      MEDIASOUP_WORKER_LOGLEVEL: warn
+      RECORDING_GRANT_PERSISTENCE_FILE: /data/recording-grants.json
+      WEBRTC_LISTEN_IP: 0.0.0.0
+    volumes:
+      - sfu-grants:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:3000/health"]
+      interval: 1s
+      timeout: 2s
+      retries: 30
+
   recorder-integration:
     image: suite-recorder-integration:local
     build:
@@ -6,5 +44,15 @@ services:
       dockerfile: suite/meet/recorder-server/Dockerfile
       target: integration
     shm_size: 1gb
+    depends_on:
+      sfu:
+        condition: service_healthy
+    environment:
+      SFU_ORIGIN: http://sfu:3000
+      SFU_MEDIA_HOST: sfu
+      JWT_SECRET: integration-secret
     volumes:
       - ./output:/output
+
+volumes:
+  sfu-grants:

--- a/suite/meet/recorder-server/integration/run.sh
+++ b/suite/meet/recorder-server/integration/run.sh
@@ -12,9 +12,22 @@ chmod o+rwx "$output"
 make_output_readable() {
 	docker compose -f "$compose" run --rm --no-deps --user root \
 		--entrypoint chmod recorder-integration -R a+rX /output || true
+	docker compose -f "$compose" down --volumes --remove-orphans || true
 }
 trap make_output_readable EXIT
 
-docker compose -f "$compose" build recorder-integration
-docker compose -f "$compose" run --rm recorder-integration node dist/integration/CaptureWorker.integration.js clean
-docker compose -f "$compose" run --rm recorder-integration node dist/integration/CaptureWorker.integration.js recovery
+run_scenario() {
+	docker compose -f "$compose" run --rm recorder-integration \
+		timeout --signal=TERM --kill-after=15s "${SCENARIO_TIMEOUT_SECONDS:-180}s" \
+		node "$@"
+}
+
+# Build both current source trees instead of allowing Compose to reuse a stale SFU tag.
+docker compose -f "$compose" build sfu recorder-integration
+if [ "${1:-all}" = "shared-stage" ]; then
+	run_scenario dist/integration/RecorderSharedStage.integration.js
+else
+	run_scenario dist/integration/CaptureWorker.integration.js clean
+	run_scenario dist/integration/CaptureWorker.integration.js recovery
+	run_scenario dist/integration/RecorderSharedStage.integration.js
+fi

--- a/suite/meet/recorder-server/package.json
+++ b/suite/meet/recorder-server/package.json
@@ -12,7 +12,8 @@
 		"lint:fix": "biome check --write .",
 		"test": "vitest run",
 		"test:ci": "vitest run --coverage --reporter=default --reporter=junit --reporter=github-actions --outputFile=test-results/junit.xml",
-		"test:integration": "./integration/run.sh"
+		"test:integration": "./integration/run.sh",
+		"test:integration:shared-stage": "./integration/run.sh shared-stage"
 	},
 	"packageManager": "yarn@1.22.22",
 	"license": "AGPL-3.0",
@@ -29,6 +30,7 @@
 		"@types/node": "^20.11.24",
 		"@vitest/coverage-v8": "4.1.10",
 		"socket.io": "^4.8.3",
+		"socket.io-client": "^4.8.3",
 		"typescript": "^5.3.3",
 		"vitest": "^4.1.6"
 	}

--- a/suite/meet/recorder-server/src/CallbackClient.test.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.test.ts
@@ -273,6 +273,16 @@ describe('CallbackClient', () => {
 			interruption_deadline: '2026-08-30T12:01:00.000Z',
 			omission_started_at: '2026-08-30T11:59:30.000Z',
 		});
+		job.health_reason = 'projection_invalid';
+		await new CallbackClient({
+			origin: 'https://site.test',
+			site: 'site.test',
+			secret: 's'.repeat(32),
+			dataRoot: '/tmp',
+		}).interrupted(job);
+		expect(JSON.parse(String(fetch.mock.calls[1]?.[1]?.body)).reason_code).toBe(
+			'projection_invalid',
+		);
 	});
 
 	it('publishes recovery for the active interruption sequence', async () => {

--- a/suite/meet/recorder-server/src/CallbackClient.ts
+++ b/suite/meet/recorder-server/src/CallbackClient.ts
@@ -700,6 +700,7 @@ export class CallbackClient {
 			'media_attachment_failed',
 			'media_subscription_failed',
 			'page_crashed',
+			'projection_invalid',
 			'receive_transport_failed',
 			'sfu_disconnected',
 		]);

--- a/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
+++ b/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
@@ -54,6 +54,397 @@ afterEach(async () => {
 });
 
 describe('capture lifecycle', () => {
+	it('orders prepare, spawn, durable commit, startup publication, then browser command', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const order: string[] = [];
+		const now = Date.parse('2026-08-30T12:00:00.123Z');
+		const supervisor = {
+			start: vi.fn(async (name: string) => {
+				if (name === 'ffmpeg') order.push('spawn');
+				return name === 'pactl' ? process(0) : process();
+			}),
+		};
+		let worker!: CaptureWorker;
+		worker = new CaptureWorker(
+			'ordered-launch',
+			{
+				...options(root),
+				onCapturePreparing: async (epoch) => order.push(`prepare:${epoch}`),
+				onCaptureCommitted: async (launch) => {
+					order.push(
+						worker.manifest.get().capture_epochs?.[launch.epoch]
+							?.capture_started_at === launch.capture_started_at
+							? 'published-after-durable'
+							: 'published-before-durable',
+					);
+				},
+				onCaptureLaunched: async () => order.push('capture-started'),
+			},
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				now: () => now,
+				sleep: async () => undefined,
+				watcher: () => ({
+					start: () => order.push('watch'),
+					stopAndAdoptFinal: async () => 'none' as const,
+				}),
+			},
+		);
+		await worker.initialize();
+
+		await expect(worker.startCapture()).resolves.toEqual({
+			epoch: 0,
+			capture_started_at: '2026-08-30T12:00:00.123Z',
+		});
+		expect(order.filter((event) => event !== 'watch')).toEqual([
+			'prepare:0',
+			'spawn',
+			'published-after-durable',
+			'capture-started',
+		]);
+		expect(worker.manifest.get().capture_epochs).toEqual([
+			{
+				epoch: 0,
+				capture_started_at: '2026-08-30T12:00:00.123Z',
+			},
+		]);
+		await worker.stop();
+	});
+
+	it('does not spawn when capture preparation fails', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const supervisor = {
+			start: vi.fn(async (name: string) =>
+				name === 'pactl' ? process(0) : process(),
+			),
+		};
+		const worker = new CaptureWorker(
+			'prepare-failure',
+			{
+				...options(root),
+				onCapturePreparing: async () => {
+					throw new Error('prepare failed');
+				},
+			},
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				sleep: async () => undefined,
+			},
+		);
+		await worker.initialize();
+		await expect(worker.startCapture()).rejects.toThrow('prepare failed');
+		expect(
+			supervisor.start.mock.calls.some(([name]) => name === 'ffmpeg'),
+		).toBe(false);
+		await worker.stop();
+	});
+
+	it.each(['durable write', 'browser acknowledgement'] as const)(
+		'stops a spawned epoch when %s fails',
+		async (failure) => {
+			const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+			roots.push(root);
+			const ffmpeg = process();
+			const supervisor = {
+				start: vi.fn(async (name: string) => {
+					if (name === 'ffmpeg') return ffmpeg;
+					return name === 'pactl' ? process(0) : process();
+				}),
+			};
+			const aborted = vi.fn(async () => undefined);
+			const launched = vi.fn(async () => {
+				if (
+					failure === 'browser acknowledgement' &&
+					launched.mock.calls.length === 1
+				)
+					throw new Error('start acknowledgement failed');
+			});
+			const watcherStart = vi.fn();
+			const worker = new CaptureWorker(
+				`launch-failure-${failure}`,
+				{
+					...options(root),
+					onCaptureLaunched: launched,
+					onCaptureAborted: aborted,
+				},
+				{
+					supervisor: supervisor as unknown as ProcessSupervisor,
+					sleep: async () => undefined,
+					watcher: () => ({
+						start: watcherStart,
+						stopAndAdoptFinal: async () => 'none' as const,
+					}),
+				},
+			);
+			await worker.initialize();
+			if (failure === 'durable write') {
+				const update = worker.manifest.update.bind(worker.manifest);
+				vi.spyOn(worker.manifest, 'update')
+					.mockImplementationOnce(update)
+					.mockRejectedValueOnce(new Error('durable write failed'));
+			}
+
+			await expect(worker.startCapture()).rejects.toThrow(
+				failure === 'durable write' ? 'durable' : 'acknowledgement',
+			);
+			expect(ffmpeg.stop).toHaveBeenCalledOnce();
+			expect(aborted).toHaveBeenCalledWith(0);
+			expect(watcherStart).toHaveBeenCalledTimes(
+				failure === 'durable write' ? 0 : 1,
+			);
+			if (failure === 'durable write') expect(launched).not.toHaveBeenCalled();
+
+			if (failure === 'durable write')
+				await expect(worker.startCapture()).resolves.toMatchObject({
+					epoch: 1,
+				});
+			expect(watcherStart).toHaveBeenCalledOnce();
+			await worker.stop();
+		},
+	);
+
+	it('cancels renderer preparation and permits retry when FFmpeg spawn fails', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const supervisor = {
+			start: vi.fn(async (name: string) => {
+				if (
+					name === 'ffmpeg' &&
+					supervisor.start.mock.calls.filter(([value]) => value === 'ffmpeg')
+						.length === 1
+				)
+					throw new Error('spawn failed');
+				return name === 'pactl' ? process(0) : process();
+			}),
+		};
+		const aborted = vi.fn(async () => undefined);
+		const worker = new CaptureWorker(
+			'spawn-failure',
+			{ ...options(root), onCaptureAborted: aborted },
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				sleep: async () => undefined,
+				watcher: () => ({
+					start: () => undefined,
+					stopAndAdoptFinal: async () => 'none' as const,
+				}),
+			},
+		);
+		await worker.initialize();
+
+		await expect(worker.startCapture()).rejects.toThrow('spawn failed');
+		expect(aborted).toHaveBeenCalledWith(0);
+		await expect(worker.startCapture()).resolves.toMatchObject({ epoch: 1 });
+		await worker.stop();
+	});
+
+	it('keeps a durable commit when renderer acknowledgement fails', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const ffmpeg = process();
+		const supervisor = {
+			start: vi.fn(async (name: string) =>
+				name === 'pactl' ? process(0) : name === 'ffmpeg' ? ffmpeg : process(),
+			),
+		};
+		const aborted = vi.fn(async () => undefined);
+		const worker = new CaptureWorker(
+			'acceptance-write-failure',
+			{
+				...options(root),
+				onCaptureAborted: aborted,
+				onCaptureLaunched: async () => {
+					throw new Error('acknowledgement failed');
+				},
+			},
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				sleep: async () => undefined,
+				watcher: () => ({
+					start: () => undefined,
+					stopAndAdoptFinal: async () => 'none' as const,
+				}),
+			},
+		);
+		await worker.initialize();
+
+		await expect(worker.startCapture()).rejects.toThrow(
+			'acknowledgement failed',
+		);
+		expect(worker.manifest.get().capture_epochs).toEqual([
+			expect.objectContaining({ epoch: 0 }),
+		]);
+		expect(aborted).toHaveBeenCalledWith(0);
+		await worker.stop();
+	});
+
+	it('keeps the durable commit when stop races startup publication', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const ffmpeg = process();
+		const supervisor = {
+			start: vi.fn(async (name: string) =>
+				name === 'pactl' ? process(0) : name === 'ffmpeg' ? ffmpeg : process(),
+			),
+		};
+		const adoptFinal = vi.fn(async () => 'none' as const);
+		const aborted = vi.fn(async () => undefined);
+		const finalize = vi.fn(async () => 'failed' as const);
+		const worker = new CaptureWorker(
+			'accepted-stop-race',
+			{ ...options(root), onCaptureAborted: aborted },
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				sleep: async () => undefined,
+				watcher: () => ({
+					start: () => undefined,
+					stopAndAdoptFinal: adoptFinal,
+				}),
+				finalizer: () => ({ finalize }),
+			},
+		);
+		await worker.initialize();
+		let releaseAcceptance!: () => void;
+		const acceptanceBlocked = new Promise<void>((resolve) => {
+			releaseAcceptance = resolve;
+		});
+		let commitReached!: () => void;
+		const reachedCommit = new Promise<void>((resolve) => {
+			commitReached = resolve;
+		});
+		Reflect.get(worker, 'options').onCaptureCommitted = async () => {
+			commitReached();
+			await acceptanceBlocked;
+		};
+
+		const launching = worker.startCapture();
+		await reachedCommit;
+		expect(worker.manifest.get().capture_epochs).toHaveLength(1);
+		const stopping = worker.stop(false, 'host_stop');
+		await vi.waitFor(() => expect(ffmpeg.stop).toHaveBeenCalledOnce());
+		await vi.waitFor(() => expect(adoptFinal).toHaveBeenCalledOnce());
+		expect(finalize).not.toHaveBeenCalled();
+		releaseAcceptance();
+
+		await expect(launching).rejects.toThrow('stopped');
+		await expect(stopping).resolves.toBe('failed');
+		expect(finalize).toHaveBeenCalledOnce();
+		expect(adoptFinal).toHaveBeenCalledOnce();
+		expect(aborted).toHaveBeenCalledWith(0);
+	});
+
+	it('does not commit FFmpeg after an asynchronous launch error', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const supervisor = {
+			start: vi.fn(async (name: string, _args, processOptions) => {
+				if (name === 'ffmpeg') {
+					queueMicrotask(() =>
+						processOptions.onUnexpectedExit?.({ code: null, signal: null }),
+					);
+					return process();
+				}
+				return name === 'pactl' ? process(0) : process();
+			}),
+		};
+		const worker = new CaptureWorker('dead-launch', options(root), {
+			supervisor: supervisor as unknown as ProcessSupervisor,
+			sleep: async () => undefined,
+		});
+		await worker.initialize();
+
+		await expect(worker.startCapture()).rejects.toThrow('ffmpeg exited');
+		expect(worker.manifest.get().capture_epochs).toEqual([]);
+		await worker.stop();
+	});
+
+	it.each(['allocated', 'committed'] as const)(
+		'adopts only a committed %s crash window after restart',
+		async (phase) => {
+			const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+			roots.push(root);
+			const makeWatcher = vi.fn(() => ({
+				start: () => undefined,
+				stopAndAdoptFinal: async () => 'adopted' as const,
+			}));
+			const worker = new CaptureWorker(`crash-${phase}`, options(root), {
+				watcher: makeWatcher,
+				finalizer: () => ({ finalize: async () => 'failed' as const }),
+			});
+			await worker.manifest.initialize();
+			await worker.manifest.update((manifest) => {
+				manifest.epochs = 1;
+				if (phase === 'committed')
+					manifest.capture_epochs?.push({
+						epoch: 0,
+						capture_started_at: '2026-08-30T12:00:00.000Z',
+					});
+			});
+			await expect(worker.recoverStopped()).resolves.toBe('failed');
+			expect(makeWatcher).toHaveBeenCalledTimes(phase === 'committed' ? 1 : 0);
+			expect(worker.captureResult()).toMatchObject({
+				artifact: undefined,
+				captureStartedAt:
+					phase === 'committed' ? '2026-08-30T12:00:00.000Z' : undefined,
+			});
+		},
+	);
+
+	it('serializes FFmpeg exit recovery behind initial startup publication', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		let unexpectedExit!: () => void;
+		const ffmpeg = process();
+		const supervisor = {
+			start: vi.fn(async (name: string, _args, processOptions) => {
+				if (name === 'ffmpeg') {
+					unexpectedExit = processOptions.onUnexpectedExit;
+					return ffmpeg;
+				}
+				return name === 'pactl' ? process(0) : process();
+			}),
+		};
+		let releasePublication!: () => void;
+		const publicationBlocked = new Promise<void>((resolve) => {
+			releasePublication = resolve;
+		});
+		const watcherStart = vi.fn();
+		const onInterrupted = vi.fn();
+		const worker = new CaptureWorker(
+			'exit-during-startup-publication',
+			{
+				...options(root),
+				onInterrupted,
+				onCaptureCommitted: async () => publicationBlocked,
+			},
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				sleep: async () => undefined,
+				watcher: () => ({
+					start: watcherStart,
+					stopAndAdoptFinal: async () => 'none' as const,
+				}),
+			},
+		);
+		await worker.initialize();
+
+		const launching = worker.startCapture();
+		await vi.waitFor(() => expect(unexpectedExit).toBeTypeOf('function'));
+		await vi.waitFor(() =>
+			expect(worker.manifest.get().capture_epochs).toHaveLength(1),
+		);
+		unexpectedExit();
+		expect(onInterrupted).not.toHaveBeenCalled();
+		releasePublication();
+
+		await expect(launching).resolves.toMatchObject({ epoch: 0 });
+		await vi.waitFor(() => expect(onInterrupted).toHaveBeenCalledOnce());
+		expect(watcherStart).toHaveBeenCalled();
+		await worker.stop();
+	});
+
 	it('applies refreshed budget before deciding whether the next segment fits', async () => {
 		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
 		roots.push(root);
@@ -362,9 +753,17 @@ describe('capture lifecycle', () => {
 		};
 		const onInterrupted = vi.fn();
 		const onRecovered = vi.fn();
+		const onCapturePreparing = vi.fn(async () => undefined);
+		const onCaptureLaunched = vi.fn(async () => undefined);
 		const worker = new CaptureWorker(
 			'ffmpeg-recovery',
-			{ ...options(root), onInterrupted, onRecovered },
+			{
+				...options(root),
+				onInterrupted,
+				onRecovered,
+				onCapturePreparing,
+				onCaptureLaunched,
+			},
 			{
 				supervisor: supervisor as unknown as ProcessSupervisor,
 				now: () => now,
@@ -418,6 +817,15 @@ describe('capture lifecycle', () => {
 				recovered_at: '2026-08-30T12:00:32.000Z',
 			}),
 		);
+		expect(onCapturePreparing.mock.calls.map(([epoch]) => epoch)).toEqual([
+			0, 1, 2,
+		]);
+		expect([
+			[0, 2],
+			[0, 1, 2],
+		]).toContainEqual(
+			onCaptureLaunched.mock.calls.map(([launch]) => launch.epoch),
+		);
 		expect(worker.manifest.get().gaps).toEqual([
 			{
 				started_at: '2026-08-30T12:00:30.000Z',
@@ -427,6 +835,123 @@ describe('capture lifecycle', () => {
 		]);
 		await worker.stop();
 	});
+
+	it('keeps recovery launch timestamps nondecreasing when the clock regresses', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		let now = Date.parse('2026-08-30T12:00:30.000Z');
+		const exits: Array<() => void> = [];
+		const launches: string[] = [];
+		const supervisor = {
+			start: vi.fn(async (name: string, _args, processOptions) => {
+				if (name === 'ffmpeg') exits.push(processOptions.onUnexpectedExit);
+				return name === 'pactl' ? process(0) : process();
+			}),
+		};
+		const worker = new CaptureWorker(
+			'clock-regression',
+			{
+				...options(root),
+				onCaptureLaunched: async (launch) =>
+					launches.push(launch.capture_started_at),
+			},
+			{
+				supervisor: supervisor as unknown as ProcessSupervisor,
+				now: () => now,
+				sleep: async (delay) => {
+					if (delay > 5_000) await new Promise(() => undefined);
+				},
+				watcher: () => ({
+					start: () => undefined,
+					stopAndAdoptFinal: async () => 'none' as const,
+				}),
+			},
+		);
+		await worker.initialize();
+		await worker.startCapture();
+		now -= 60_000;
+		exits[0]?.();
+		await vi.waitFor(() => expect(launches).toHaveLength(2));
+
+		expect(launches).toEqual([
+			'2026-08-30T12:00:30.000Z',
+			'2026-08-30T12:00:30.000Z',
+		]);
+		await worker.stop();
+	});
+
+	it.each(['deadline', 'host stop'] as const)(
+		'does not publish recovery when %s wins after health resolution',
+		async (boundary) => {
+			const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+			roots.push(root);
+			const startedAt = Date.parse('2026-08-30T12:00:30.000Z');
+			let now = startedAt;
+			const exits: Array<() => void> = [];
+			const adopted: Array<(segment: never) => void | Promise<void>> = [];
+			const onRecovered = vi.fn();
+			const onStopRequested = vi.fn();
+			const supervisor = {
+				start: vi.fn(async (name: string, _args, processOptions) => {
+					if (name === 'ffmpeg') exits.push(processOptions.onUnexpectedExit);
+					return name === 'pactl' ? process(0) : process();
+				}),
+			};
+			const worker = new CaptureWorker(
+				`recovery-${boundary}`,
+				{ ...options(root), onRecovered, onStopRequested },
+				{
+					supervisor: supervisor as unknown as ProcessSupervisor,
+					now: () => now,
+					sleep: async (delay) => {
+						if (delay > 5_000) await new Promise(() => undefined);
+					},
+					watcher: (_manifest, _tools, _epoch, onAdopt) => {
+						adopted.push(onAdopt as (segment: never) => void | Promise<void>);
+						return {
+							start: () => undefined,
+							stopAndAdoptFinal: async () => 'none' as const,
+						};
+					},
+					finalizer: () => ({ finalize: async () => 'partial' as const }),
+				},
+			);
+			await worker.initialize();
+			await worker.startCapture();
+			await worker.manifest.update((manifest) => {
+				manifest.segments.push({
+					epoch: 0,
+					index: 0,
+					file: 'epoch-000-segment-000000.ts',
+					bytes: 1,
+					sha256: 'a'.repeat(64),
+					duration_ms: 30_000,
+					started_at: '2026-08-30T12:00:00.000Z',
+				});
+			});
+			exits[0]?.();
+			await vi.waitFor(() => expect(adopted).toHaveLength(2));
+			if (boundary === 'deadline') now = startedAt + 60_000;
+			const health = adopted[1]?.({} as never);
+			const stopping =
+				boundary === 'host stop'
+					? worker.stop(true, 'host_stop')
+					: Promise.resolve(undefined);
+			await health;
+			if (boundary === 'deadline')
+				await vi.waitFor(() =>
+					expect(onStopRequested).toHaveBeenCalledWith(
+						true,
+						'capture_recovery_timeout',
+					),
+				);
+			else await stopping;
+
+			expect(onRecovered).not.toHaveBeenCalled();
+			expect(worker.manifest.get().gaps.at(-1)?.ended_at).toBeUndefined();
+			await worker.stop(true, 'test_cleanup');
+		},
+	);
 
 	it('synchronizes audio and video capture to the wall clock', async () => {
 		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
@@ -569,6 +1094,249 @@ describe('capture lifecycle', () => {
 			gaps: [],
 		});
 		expect(worker.recoverStopped).toHaveBeenCalledOnce();
+	});
+
+	it('closes an initializing reservation without leaking capture services', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const renderer = new FakeRendererBridge();
+		const xvfb = process();
+		const pulse = process();
+		let releaseXvfb!: () => void;
+		const xvfbStarted = new Promise<void>((resolve) => {
+			releaseXvfb = resolve;
+		});
+		let xvfbPending = true;
+		const supervisor = {
+			start: vi.fn(async (name: string) => {
+				if (name === 'xvfb' && xvfbPending) {
+					xvfbPending = false;
+					await xvfbStarted;
+					return xvfb;
+				}
+				if (name === 'pulse') return pulse;
+				return process(0);
+			}),
+		};
+		const manager = new CaptureWorkerManager(
+			renderer,
+			{ ...options(root), maxConcurrent: 1 },
+			(job, createdOptions) =>
+				new CaptureWorker(job, createdOptions, {
+					supervisor: supervisor as unknown as ProcessSupervisor,
+					sleep: async () => undefined,
+				}),
+		);
+
+		const reserving = manager.reserve(command('initializing'));
+		await vi.waitFor(() =>
+			expect(supervisor.start).toHaveBeenCalledWith(
+				'xvfb',
+				expect.any(Array),
+				expect.any(Object),
+			),
+		);
+		const closing = manager.close();
+		await expect(manager.reserve(command('late'))).rejects.toThrow('closing');
+		releaseXvfb();
+
+		await expect(reserving).rejects.toThrow('closing');
+		await expect(closing).resolves.toBeUndefined();
+		expect(xvfb.stop).toHaveBeenCalledOnce();
+		expect(pulse.stop).toHaveBeenCalledOnce();
+		expect(renderer.hasWorker('initializing')).toBe(false);
+		expect(manager.hasWorker('initializing')).toBe(false);
+	});
+
+	it('stops workers and renderers before waiting for a blocked job queue', async () => {
+		const renderer = new FakeRendererBridge();
+		let releaseStart!: () => void;
+		const startBlocked = new Promise<void>((resolve) => {
+			releaseStart = resolve;
+		});
+		const stop = vi.fn(async () => 'partial' as const);
+		const worker = {
+			env: {},
+			initialize: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => startBlocked),
+			rendererFailed: vi.fn(async () => undefined),
+			recoverRenderer: vi.fn(),
+			stop,
+			recoverStopped: vi.fn(async () => 'partial' as const),
+			captureResult: vi.fn(() => ({ artifact: undefined, gaps: [] })),
+		};
+		const manager = new CaptureWorkerManager(
+			renderer,
+			{ ...options('/tmp'), maxConcurrent: 1 },
+			() => worker,
+		);
+		manager.onLifecycle(async () => undefined);
+		await manager.reserve(command('blocked-close'));
+		const starting = renderer.emit({
+			job: 'blocked-close',
+			generation: 0,
+			type: 'capture_ready',
+		});
+		await vi.waitFor(() => expect(worker.startCapture).toHaveBeenCalledOnce());
+
+		const closing = manager.close();
+		await vi.waitFor(() =>
+			expect(stop).toHaveBeenCalledWith(true, 'service_shutdown'),
+		);
+		expect(renderer.hasWorker('blocked-close')).toBe(false);
+		releaseStart();
+
+		await expect(Promise.all([starting, closing])).resolves.toBeDefined();
+	});
+
+	it('publishes the exact persisted launch timestamp after both handshakes', async () => {
+		const renderer = new FakeRendererBridge();
+		let workerOptions: CaptureWorkerOptions | undefined;
+		const timestamp = '2026-08-30T12:00:00.321Z';
+		const worker = {
+			env: {},
+			initialize: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				await workerOptions?.onCapturePreparing?.(0);
+				await workerOptions?.onCaptureCommitted?.({
+					epoch: 0,
+					capture_started_at: timestamp,
+				});
+				await workerOptions?.onCaptureLaunched?.({
+					epoch: 0,
+					capture_started_at: timestamp,
+				});
+				return { epoch: 0, capture_started_at: timestamp };
+			}),
+			rendererFailed: vi.fn(async () => undefined),
+			recoverRenderer: vi.fn(),
+			stop: vi.fn(async () => 'complete' as const),
+			recoverStopped: vi.fn(async () => 'complete' as const),
+			captureResult: vi.fn(() => ({ artifact: undefined, gaps: [] })),
+		};
+		const manager = new CaptureWorkerManager(
+			renderer,
+			{ ...options('/tmp'), maxConcurrent: 1 },
+			(_job, createdOptions) => {
+				workerOptions = createdOptions;
+				return worker;
+			},
+		);
+		const lifecycle = vi.fn(async () => undefined);
+		manager.onLifecycle(lifecycle);
+		await manager.reserve(command('one'));
+
+		await renderer.emit({
+			job: 'one',
+			generation: 0,
+			type: 'capture_ready',
+			occurredAt: '2026-08-30T11:59:00.000Z',
+		});
+		await workerOptions?.onCaptureCommitted?.({
+			epoch: 1,
+			capture_started_at: '2026-08-30T12:00:30.000Z',
+		});
+
+		expect(renderer.prepared).toEqual([
+			{ job: 'one', generation: 0, epoch: 0 },
+		]);
+		expect(renderer.captureStarts).toEqual([
+			{ job: 'one', generation: 0, epoch: 0, timestamp },
+		]);
+		expect(lifecycle).toHaveBeenCalledWith({
+			job: 'one',
+			generation: 0,
+			type: 'capture_ready',
+			occurredAt: timestamp,
+		});
+		expect(lifecycle).toHaveBeenCalledTimes(1);
+		await manager.stop('one');
+	});
+
+	it('turns an initial capture handshake failure into terminal cleanup', async () => {
+		const renderer = new FakeRendererBridge();
+		const stop = vi.fn(async () => 'failed' as const);
+		const worker = {
+			env: {},
+			initialize: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				throw new Error('capture prepare failed');
+			}),
+			rendererFailed: vi.fn(async () => undefined),
+			recoverRenderer: vi.fn(),
+			stop,
+			recoverStopped: vi.fn(async () => 'failed' as const),
+			captureResult: vi.fn(() => ({ artifact: undefined, gaps: [] })),
+		};
+		const manager = new CaptureWorkerManager(
+			renderer,
+			{ ...options('/tmp'), maxConcurrent: 1 },
+			() => worker,
+		);
+		const lifecycle = vi.fn(async () => undefined);
+		manager.onLifecycle(lifecycle);
+		await manager.reserve(command('one'));
+
+		await renderer.emit({ job: 'one', generation: 0, type: 'capture_ready' });
+
+		expect(stop).toHaveBeenCalledWith(false, 'capture prepare failed');
+		expect(manager.hasWorker('one')).toBe(false);
+		expect(lifecycle).toHaveBeenCalledWith(
+			expect.objectContaining({
+				job: 'one',
+				type: 'failed',
+				reason: 'capture prepare failed',
+			}),
+		);
+	});
+
+	it('cancels a blocked initial prepare before worker launch on host stop', async () => {
+		const renderer = new FakeRendererBridge();
+		let rejectPrepare!: (error: Error) => void;
+		vi.spyOn(renderer, 'prepareCapture').mockImplementation(
+			() =>
+				new Promise<void>((_resolve, reject) => {
+					rejectPrepare = reject;
+				}),
+		);
+		vi.spyOn(renderer, 'stop').mockImplementation(async (job, generation) => {
+			rejectPrepare?.(new Error('renderer stopped'));
+			await FakeRendererBridge.prototype.stop.call(renderer, job, generation);
+		});
+		let workerOptions: CaptureWorkerOptions | undefined;
+		const launched = vi.fn();
+		const worker = {
+			env: {},
+			initialize: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				await workerOptions?.onCapturePreparing?.(0);
+				launched();
+			}),
+			rendererFailed: vi.fn(async () => undefined),
+			recoverRenderer: vi.fn(),
+			stop: vi.fn(async () => 'failed' as const),
+			recoverStopped: vi.fn(async () => 'failed' as const),
+			captureResult: vi.fn(() => ({ artifact: undefined, gaps: [] })),
+		};
+		const manager = new CaptureWorkerManager(
+			renderer,
+			{ ...options('/tmp'), maxConcurrent: 1 },
+			(_job, createdOptions) => {
+				workerOptions = createdOptions;
+				return worker;
+			},
+		);
+		manager.onLifecycle(async () => undefined);
+		await manager.reserve(command('one'));
+		const starting = renderer.emit({ job: 'one', type: 'capture_ready' });
+		await vi.waitFor(() =>
+			expect(renderer.prepareCapture).toHaveBeenCalledOnce(),
+		);
+
+		await expect(manager.stop('one', 0, 'host_stop')).resolves.toBeUndefined();
+		await starting;
+		expect(launched).not.toHaveBeenCalled();
+		expect(worker.stop).toHaveBeenCalledWith(false, 'host_stop');
 	});
 
 	it('marks service shutdown as a partial non-host stop', async () => {
@@ -739,7 +1507,12 @@ describe('capture lifecycle', () => {
 		const worker = {
 			env: {},
 			initialize: vi.fn(async () => undefined),
-			startCapture: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				await workerOptions?.onCaptureCommitted?.({
+					epoch: 0,
+					capture_started_at: '2026-08-30T12:00:00.000Z',
+				});
+			}),
 			rendererFailed: vi.fn(async () => {
 				if (interrupted) return;
 				interrupted = true;
@@ -806,6 +1579,22 @@ describe('capture lifecycle', () => {
 		await renderer.emit({ job: 'one', generation: 2, type: 'configured' });
 		await renderer.emit({ job: 'one', generation: 2, type: 'capture_ready' });
 		expect(recoverRenderer).toHaveBeenCalledOnce();
+		await workerOptions?.onCapturePreparing?.(1);
+		await workerOptions?.onCaptureLaunched?.({
+			epoch: 1,
+			capture_started_at: '2026-08-30T12:00:10.000Z',
+		});
+		expect(renderer.prepared.at(-1)).toEqual({
+			job: 'one',
+			generation: 2,
+			epoch: 1,
+		});
+		expect(renderer.captureStarts.at(-1)).toEqual({
+			job: 'one',
+			generation: 2,
+			epoch: 1,
+			timestamp: '2026-08-30T12:00:10.000Z',
+		});
 		await manager.stop('one');
 	});
 
@@ -816,7 +1605,12 @@ describe('capture lifecycle', () => {
 		const worker = {
 			env: {},
 			initialize: vi.fn(async () => undefined),
-			startCapture: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				await workerOptions?.onCaptureCommitted?.({
+					epoch: 0,
+					capture_started_at: '2026-08-30T12:00:00.000Z',
+				});
+			}),
 			rendererFailed: vi.fn(async () => {
 				workerOptions?.onInterrupted?.({
 					id: '11111111-1111-4111-8111-111111111111',
@@ -859,7 +1653,12 @@ describe('capture lifecycle', () => {
 		const worker = {
 			env: {},
 			initialize: vi.fn(async () => undefined),
-			startCapture: vi.fn(async () => undefined),
+			startCapture: vi.fn(async () => {
+				await workerOptions?.onCaptureCommitted?.({
+					epoch: 0,
+					capture_started_at: '2026-08-30T12:00:00.000Z',
+				});
+			}),
 			rendererFailed: vi.fn(async (reason: string) => {
 				workerOptions?.onInterrupted?.({
 					id: '4cad3218-a956-4dec-a522-18f0dd3b75a2',

--- a/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
+++ b/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { rm } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -391,6 +391,39 @@ describe('capture lifecycle', () => {
 			});
 		},
 	);
+
+	it('recovers an allocated epoch when a crash leaves a media candidate', async () => {
+		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);
+		roots.push(root);
+		const makeWatcher = vi.fn(() => ({
+			start: () => undefined,
+			stopAndAdoptFinal: async () => 'adopted' as const,
+		}));
+		const worker = new CaptureWorker('crash-after-spawn', options(root), {
+			watcher: makeWatcher,
+			finalizer: () => ({ finalize: async () => 'failed' as const }),
+		});
+		await worker.manifest.initialize();
+		await worker.manifest.update((manifest) => {
+			manifest.epochs = 1;
+		});
+		await writeFile(
+			join(worker.manifest.directory, 'epoch-000-segment-000000.ts'),
+			'captured media',
+		);
+
+		await expect(worker.recoverStopped()).resolves.toBe('failed');
+		expect(makeWatcher).toHaveBeenCalledWith(
+			worker.manifest,
+			expect.anything(),
+			0,
+			expect.any(Function),
+			expect.any(Function),
+		);
+		expect(worker.manifest.get().capture_epochs).toEqual([
+			{ epoch: 0, capture_started_at: expect.any(String) },
+		]);
+	});
 
 	it('serializes FFmpeg exit recovery behind initial startup publication', async () => {
 		const root = join(tmpdir(), `capture-lifecycle-${crypto.randomUUID()}`);

--- a/suite/meet/recorder-server/src/CapturePipeline.test.ts
+++ b/suite/meet/recorder-server/src/CapturePipeline.test.ts
@@ -9,9 +9,13 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { MediaProbe } from './captureTypes.js';
+import type { CaptureManifest, MediaProbe } from './captureTypes.js';
 import { Finalizer } from './Finalizer.js';
-import { ManifestStore, safeJobDirectory } from './ManifestStore.js';
+import {
+	ManifestStore,
+	safeJobDirectory,
+	validManifest,
+} from './ManifestStore.js';
 import { SegmentWatcher } from './SegmentWatcher.js';
 
 const roots: string[] = [];
@@ -33,6 +37,10 @@ async function watcherStore(): Promise<ManifestStore> {
 	const manifest = await store();
 	await manifest.update((m) => {
 		m.epochs = 1;
+		m.capture_epochs?.push({
+			epoch: 0,
+			capture_started_at: '2026-08-30T12:00:00.000Z',
+		});
 	});
 	return manifest;
 }
@@ -45,6 +53,90 @@ afterEach(async () => {
 });
 
 describe('capture pipeline', () => {
+	it('accepts legacy manifests and strictly validates capture epoch launches', async () => {
+		const legacy: CaptureManifest = {
+			version: 1,
+			revision: 0,
+			job: 'job',
+			state: 'capturing',
+			epochs: 2,
+			segments: [],
+			gaps: [],
+		};
+		expect(validManifest(legacy)).toBe(true);
+		expect(validManifest({ ...legacy, version: 2 })).toBe(false);
+		const current: CaptureManifest = {
+			...legacy,
+			version: 2,
+			capture_epochs: [
+				{
+					epoch: 0,
+					capture_started_at: '2026-08-30T12:00:00.000Z',
+				},
+				{
+					epoch: 1,
+					capture_started_at: '2026-08-30T12:00:01.000Z',
+				},
+			],
+		};
+		expect(validManifest(current)).toBe(true);
+		for (const capture_epochs of [
+			[
+				{ epoch: 0, capture_started_at: '2026-08-30T12:00:00.000Z' },
+				{ epoch: 0, capture_started_at: '2026-08-30T12:00:01.000Z' },
+			],
+			[{ epoch: 2, capture_started_at: '2026-08-30T12:00:00.000Z' }],
+			[{ epoch: 0, capture_started_at: '2026-08-30T12:00:00Z' }],
+			[
+				{ epoch: 0, capture_started_at: '2026-08-30T12:00:01.000Z' },
+				{ epoch: 1, capture_started_at: '2026-08-30T12:00:00.999Z' },
+			],
+		])
+			expect(validManifest({ ...legacy, capture_epochs })).toBe(false);
+
+		const manifest = await store();
+		expect(manifest.get().capture_epochs).toEqual([]);
+		await manifest.update((value) => {
+			value.epochs = 1;
+			value.capture_epochs?.push({
+				epoch: 0,
+				capture_started_at: '2026-08-30T12:00:00.000Z',
+			});
+		});
+		const disk = JSON.parse(await readFile(manifest.path, 'utf8'));
+		expect(disk.capture_epochs).toEqual([
+			{
+				epoch: 0,
+				capture_started_at: '2026-08-30T12:00:00.000Z',
+			},
+		]);
+	});
+
+	it('preserves a concrete legacy manifest without inferring commit records', async () => {
+		const root = join(tmpdir(), `capture-${crypto.randomUUID()}`);
+		roots.push(root);
+		const legacy = new ManifestStore(root, 'legacy');
+		await legacy.initialize();
+		const value = legacy.get();
+		value.version = 1;
+		value.epochs = 2;
+		delete value.capture_epochs;
+		value.segments.push({
+			epoch: 0,
+			index: 0,
+			file: 'epoch-000-segment-000000.ts',
+			bytes: 1,
+			sha256: 'a'.repeat(64),
+			duration_ms: 1_000,
+			started_at: '2026-08-30T12:00:00.000Z',
+		});
+		await writeFile(legacy.path, JSON.stringify(value));
+
+		const preserved = new ManifestStore(root, 'legacy');
+		expect(await preserved.initialize()).toEqual(value);
+		expect(JSON.parse(await readFile(legacy.path, 'utf8'))).toEqual(value);
+	});
+
 	it('uses a stable hashed job directory and atomically revisions valid manifests', async () => {
 		const manifest = await store();
 		expect(manifest.directory).toBe(

--- a/suite/meet/recorder-server/src/CaptureWorker.ts
+++ b/suite/meet/recorder-server/src/CaptureWorker.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises';
+import { mkdir, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type {
 	CaptureEpoch,
@@ -423,6 +423,40 @@ export class CaptureWorker {
 		let manifest = await this.manifest.initialize();
 		if (['complete', 'partial', 'failed'].includes(manifest.state))
 			return manifest.state as Outcome;
+		const allocatedEpoch = manifest.epochs - 1;
+		if (
+			manifest.state === 'capturing' &&
+			allocatedEpoch >= 0 &&
+			!manifest.capture_epochs?.some(
+				(record) => record.epoch === allocatedEpoch,
+			)
+		) {
+			const prefix = `epoch-${String(allocatedEpoch).padStart(3, '0')}-segment-`;
+			const candidate = (await readdir(this.manifest.directory))
+				.filter(
+					(file) =>
+						file.startsWith(prefix) &&
+						/^epoch-\d{3}-segment-\d{6}\.ts$/.test(file),
+				)
+				.sort()[0];
+			if (candidate) {
+				const info = await stat(join(this.manifest.directory, candidate));
+				const previousStartedAt =
+					manifest.capture_epochs?.at(-1)?.capture_started_at;
+				const startedAt = Math.max(
+					info.birthtimeMs > 0 ? info.birthtimeMs : info.mtimeMs,
+					previousStartedAt ? Date.parse(previousStartedAt) : 0,
+				);
+				await this.manifest.update((current) => {
+					current.capture_epochs ??= [];
+					current.capture_epochs.push({
+						epoch: allocatedEpoch,
+						capture_started_at: new Date(startedAt).toISOString(),
+					});
+				});
+				manifest = this.manifest.get();
+			}
+		}
 		const committedEpoch = manifest.capture_epochs?.at(-1)?.epoch;
 		if (manifest.state === 'capturing' && committedEpoch !== undefined) {
 			await this.makeWatcher(

--- a/suite/meet/recorder-server/src/CaptureWorker.ts
+++ b/suite/meet/recorder-server/src/CaptureWorker.ts
@@ -1,6 +1,7 @@
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import type {
+	CaptureEpoch,
 	CaptureInterruption,
 	CaptureRecovery,
 	CaptureSegment,
@@ -31,6 +32,10 @@ export interface CaptureWorkerOptions {
 	onInterrupted?: (interruption: CaptureInterruption) => void;
 	onRecovered?: (recovery: CaptureRecovery) => void;
 	onProgress?: (capturedBytes: number) => Promise<number>;
+	onCapturePreparing?: (epoch: number) => Promise<void>;
+	onCaptureCommitted?: (launch: CaptureEpoch) => Promise<void>;
+	onCaptureLaunched?: (launch: CaptureEpoch) => Promise<void>;
+	onCaptureAborted?: (epoch: number) => Promise<void>;
 }
 
 export interface CaptureWorkerDependencies {
@@ -76,6 +81,10 @@ export class CaptureWorker {
 		reject: (error: Error) => void;
 		promise: Promise<string>;
 	};
+	private launchPromise: Promise<CaptureEpoch | undefined> | undefined;
+	private initializePromise: Promise<void> | undefined;
+	private initialStartupPublication: Promise<void> | undefined;
+	private stopping = false;
 
 	constructor(
 		readonly job: string,
@@ -130,8 +139,14 @@ export class CaptureWorker {
 		CaptureWorkerDependencies['finalizer']
 	>;
 
-	async initialize(): Promise<void> {
-		await this.manifest.initialize();
+	initialize(): Promise<void> {
+		this.initializePromise ??= this.initializeWorker();
+		return this.initializePromise;
+	}
+
+	private async initializeWorker(): Promise<void> {
+		const manifest = await this.manifest.initialize();
+		this.epoch = manifest.epochs;
 		await mkdir(join(this.manifest.directory, 'pulse'), {
 			recursive: true,
 			mode: 0o700,
@@ -191,17 +206,38 @@ export class CaptureWorker {
 		}
 	}
 
-	async startCapture(): Promise<void> {
-		if (this.ffmpeg || this.stopPromise) return;
+	startCapture(): Promise<CaptureEpoch | undefined> {
+		if (this.launchPromise) return this.launchPromise;
+		const launch = this.launchCapture().finally(() => {
+			if (this.launchPromise === launch) this.launchPromise = undefined;
+		});
+		this.launchPromise = launch;
+		return launch;
+	}
+
+	private async launchCapture(): Promise<CaptureEpoch | undefined> {
+		if (this.ffmpeg || this.stopping) return;
 		if (this.limitReached()) {
 			this.requestStop(false, 'capture_limit_reached');
 			return;
 		}
-		const epoch = this.epoch++;
+		const epoch = this.epoch;
+		let prepareAttempted = false;
+		let process: ManagedProcess | undefined;
+		try {
+			prepareAttempted = true;
+			await this.options.onCapturePreparing?.(epoch);
+			if (this.stopping) throw new Error('capture launch stopped');
+			await this.manifest.update((m) => {
+				m.epochs = epoch + 1;
+			});
+			this.epoch = epoch + 1;
+		} catch (error) {
+			if (prepareAttempted)
+				await this.options.onCaptureAborted?.(epoch).catch(() => undefined);
+			throw error;
+		}
 		this.captureFailed = false;
-		await this.manifest.update((m) => {
-			m.epochs = this.epoch;
-		});
 		let resolveHealth!: (adoptedAt: string) => void;
 		let rejectHealth!: (error: Error) => void;
 		const health = new Promise<string>((resolve, reject) => {
@@ -214,7 +250,7 @@ export class CaptureWorker {
 			reject: rejectHealth,
 			promise: health,
 		};
-		this.watcher = this.makeWatcher(
+		const watcher = this.makeWatcher(
 			this.manifest,
 			this.tools,
 			epoch,
@@ -225,76 +261,125 @@ export class CaptureWorker {
 			this.manifest.directory,
 			`epoch-${String(epoch).padStart(3, '0')}-segment-%06d.ts`,
 		);
-		this.ffmpeg = await this.supervisor.start(
-			this.options.ffmpeg,
-			[
-				'-hide_banner',
-				'-y',
-				'-use_wallclock_as_timestamps',
-				'1',
-				'-f',
-				'x11grab',
-				'-draw_mouse',
-				'0',
-				'-video_size',
-				'1920x1080',
-				'-framerate',
-				'30',
-				'-i',
-				`${this.env.DISPLAY}.0`,
-				'-use_wallclock_as_timestamps',
-				'1',
-				'-f',
-				'pulse',
-				'-sample_rate',
-				'48000',
-				'-channels',
-				'2',
-				'-i',
-				'recorder.monitor',
-				'-c:v',
-				'libx264',
-				'-preset',
-				'veryfast',
-				'-pix_fmt',
-				'yuv420p',
-				'-g',
-				String(this.options.segmentSeconds * 30),
-				'-keyint_min',
-				String(this.options.segmentSeconds * 30),
-				'-sc_threshold',
-				'0',
-				'-maxrate',
-				'5M',
-				'-bufsize',
-				'10M',
-				'-c:a',
-				'aac',
-				'-af',
-				'aresample=async=1000:first_pts=0',
-				'-b:a',
-				'128k',
-				'-ar',
-				'48000',
-				'-ac',
-				'2',
-				'-f',
-				'segment',
-				'-segment_time',
-				String(this.options.segmentSeconds),
-				'-reset_timestamps',
-				'1',
-				pattern,
-			],
-			{
-				env: this.env,
-				logPath: join(this.manifest.directory, `logs/ffmpeg-${epoch}.log`),
-				onUnexpectedExit: () => this.queueRecovery(),
-			},
-		);
-		this.captureLaunchedAt = new Date(this.now()).toISOString();
-		this.watcher.start();
-		this.armEndLimit();
+		let committed = false;
+		let exitError: Error | undefined;
+		try {
+			process = await this.supervisor.start(
+				this.options.ffmpeg,
+				[
+					'-hide_banner',
+					'-y',
+					'-use_wallclock_as_timestamps',
+					'1',
+					'-f',
+					'x11grab',
+					'-draw_mouse',
+					'0',
+					'-video_size',
+					'1920x1080',
+					'-framerate',
+					'30',
+					'-i',
+					`${this.env.DISPLAY}.0`,
+					'-use_wallclock_as_timestamps',
+					'1',
+					'-f',
+					'pulse',
+					'-sample_rate',
+					'48000',
+					'-channels',
+					'2',
+					'-i',
+					'recorder.monitor',
+					'-c:v',
+					'libx264',
+					'-preset',
+					'veryfast',
+					'-pix_fmt',
+					'yuv420p',
+					'-g',
+					String(this.options.segmentSeconds * 30),
+					'-keyint_min',
+					String(this.options.segmentSeconds * 30),
+					'-sc_threshold',
+					'0',
+					'-maxrate',
+					'5M',
+					'-bufsize',
+					'10M',
+					'-c:a',
+					'aac',
+					'-af',
+					'aresample=async=1000:first_pts=0',
+					'-b:a',
+					'128k',
+					'-ar',
+					'48000',
+					'-ac',
+					'2',
+					'-f',
+					'segment',
+					'-segment_time',
+					String(this.options.segmentSeconds),
+					'-reset_timestamps',
+					'1',
+					pattern,
+				],
+				{
+					env: this.env,
+					logPath: join(this.manifest.directory, `logs/ffmpeg-${epoch}.log`),
+					onUnexpectedExit: () => {
+						if (committed) this.queueRecovery();
+						else exitError = new Error('ffmpeg exited during capture launch');
+					},
+				},
+			);
+			if (exitError) throw exitError;
+			const launch: CaptureEpoch = {
+				epoch,
+				capture_started_at: this.nextLaunchTimestamp(),
+			};
+			if (this.stopping || exitError)
+				throw exitError ?? new Error('capture launch stopped');
+			await this.manifest.update((manifest) => {
+				manifest.capture_epochs ??= [];
+				const existing = manifest.capture_epochs.find(
+					(record) => record.epoch === epoch,
+				);
+				if (existing) {
+					if (existing.capture_started_at !== launch.capture_started_at)
+						throw new Error('conflicting capture epoch launch');
+					return;
+				}
+				manifest.capture_epochs.push(launch);
+			});
+			this.ffmpeg = process;
+			this.watcher = watcher;
+			this.captureLaunchedAt = launch.capture_started_at;
+			committed = true;
+			watcher.start();
+			this.armEndLimit();
+			const initial = this.manifest.get().capture_epochs?.[0]?.epoch === epoch;
+			const publication = initial
+				? (this.options.onCaptureCommitted?.(launch) ?? Promise.resolve())
+				: Promise.resolve();
+			if (initial) this.initialStartupPublication = publication;
+			if (exitError) this.queueRecovery();
+			await publication;
+			if (this.stopping) throw new Error('capture launch stopped');
+			await (this.options.onCaptureLaunched?.(launch) ?? Promise.resolve());
+			if (this.stopping) throw new Error('capture launch stopped');
+			return launch;
+		} catch (error) {
+			if (committed) await this.stopCaptureProcess().catch(() => undefined);
+			else
+				await process
+					?.stop(this.options.gracefulTimeoutMs)
+					.catch(() => undefined);
+			await this.options.onCaptureAborted?.(epoch).catch(() => undefined);
+			if (this.healthyEpoch?.epoch === epoch) delete this.healthyEpoch;
+			throw error;
+		}
 	}
 
 	async rendererFailed(reason: string): Promise<void> {
@@ -303,7 +388,9 @@ export class CaptureWorker {
 		this.rendererUnavailable = true;
 		if (this.recoveryPromise)
 			this.healthyEpoch?.reject(new Error('renderer unavailable'));
-		await this.beginInterruption(`renderer:${reason}`);
+		await this.beginInterruption(
+			reason === 'projection_invalid' ? reason : `renderer:${reason}`,
+		);
 		await this.stopCaptureProcess();
 	}
 
@@ -324,7 +411,11 @@ export class CaptureWorker {
 
 	stop(forcePartial = false, reason?: string): Promise<Outcome> {
 		this.partial ||= forcePartial;
-		if (!this.stopPromise) this.stopPromise = this.performStop(reason);
+		if (!this.stopPromise) {
+			this.stopping = true;
+			const captureStop = this.stopCaptureProcess();
+			this.stopPromise = this.performStop(reason, captureStop);
+		}
 		return this.stopPromise;
 	}
 
@@ -332,11 +423,12 @@ export class CaptureWorker {
 		let manifest = await this.manifest.initialize();
 		if (['complete', 'partial', 'failed'].includes(manifest.state))
 			return manifest.state as Outcome;
-		if (manifest.state === 'capturing' && manifest.epochs > 0) {
+		const committedEpoch = manifest.capture_epochs?.at(-1)?.epoch;
+		if (manifest.state === 'capturing' && committedEpoch !== undefined) {
 			await this.makeWatcher(
 				this.manifest,
 				this.tools,
-				manifest.epochs - 1,
+				committedEpoch,
 				() => undefined,
 				() => undefined,
 			).stopAndAdoptFinal();
@@ -353,6 +445,7 @@ export class CaptureWorker {
 		return {
 			artifact: manifest.artifact,
 			gaps: manifest.gaps,
+			captureStartedAt: manifest.capture_epochs?.[0]?.capture_started_at,
 			capturedBytes: manifest.segments.reduce(
 				(total, segment) => total + segment.bytes,
 				0,
@@ -360,11 +453,17 @@ export class CaptureWorker {
 		};
 	}
 
-	private async performStop(reason?: string): Promise<Outcome> {
+	private async performStop(
+		reason: string | undefined,
+		captureStop: Promise<void>,
+	): Promise<Outcome> {
 		if (this.limitTimer) clearTimeout(this.limitTimer);
 		if (this.interruptionTimer) clearTimeout(this.interruptionTimer);
 		let outcome: Outcome = 'failed';
 		try {
+			await captureStop;
+			await this.initializePromise?.catch(() => undefined);
+			await this.launchPromise?.catch(() => undefined);
 			if (reason === 'service_shutdown' && !this.interruption)
 				await this.openGap(reason);
 			await this.stopCaptureProcess();
@@ -401,9 +500,14 @@ export class CaptureWorker {
 			);
 			return;
 		}
-		this.recoveryPromise = this.recover().finally(() => {
-			this.recoveryPromise = undefined;
-		});
+		this.recoveryPromise = (this.initialStartupPublication ?? Promise.resolve())
+			.catch(() => undefined)
+			.then(() => {
+				if (!this.stopPromise) return this.recover();
+			})
+			.finally(() => {
+				this.recoveryPromise = undefined;
+			});
 	}
 
 	private async recover(): Promise<void> {
@@ -430,20 +534,21 @@ export class CaptureWorker {
 						throw new Error('recovery timeout');
 					}),
 				]);
-				if (this.rendererUnavailable || this.captureFailed)
+				if (this.stopPromise || this.rendererUnavailable || this.captureFailed)
 					throw new Error('capture unavailable');
-				if (this.now() > deadline || Date.parse(recoveredAt) > deadline)
+				if (this.now() >= deadline || Date.parse(recoveredAt) >= deadline)
 					throw new Error('recovery timeout');
 				const captureStartedAt = this.captureLaunchedAt;
 				if (!captureStartedAt)
 					throw new Error('capture launch time unavailable');
 				await this.closeGap(captureStartedAt);
 				if (
+					this.stopPromise ||
 					this.rendererUnavailable ||
 					this.captureFailed ||
-					this.now() > deadline
+					this.now() >= deadline
 				)
-					throw new Error('capture unavailable');
+					throw new Error('capture unavailable after gap close');
 				this.options.onRecovered?.({
 					id: interruption.id,
 					capture_started_at: captureStartedAt,
@@ -453,8 +558,12 @@ export class CaptureWorker {
 				delete this.interruptionTimer;
 				this.interruption = undefined;
 				return;
-			} catch {
-				if (this.captureFailed) await this.reopenGap();
+			} catch (error) {
+				if (
+					this.captureFailed ||
+					(error instanceof Error && error.message.includes('after gap close'))
+				)
+					await this.reopenGap();
 				await this.stopCaptureProcess().catch(() => undefined);
 				const remaining = deadline - this.now();
 				if (remaining > 0) await this.sleep(Math.min(backoff, remaining));
@@ -586,6 +695,17 @@ export class CaptureWorker {
 			const gap = m.gaps.at(-1);
 			if (gap) delete gap.ended_at;
 		});
+	}
+
+	private nextLaunchTimestamp(): string {
+		const manifest = this.manifest.get();
+		const previousLaunch = manifest.capture_epochs?.at(-1)?.capture_started_at;
+		const gapStart = manifest.gaps.at(-1)?.started_at;
+		const floor = Math.max(
+			previousLaunch ? Date.parse(previousLaunch) : 0,
+			gapStart ? Date.parse(gapStart) : 0,
+		);
+		return new Date(Math.max(this.now(), floor)).toISOString();
 	}
 
 	private async startService(

--- a/suite/meet/recorder-server/src/CaptureWorkerManager.ts
+++ b/suite/meet/recorder-server/src/CaptureWorkerManager.ts
@@ -30,6 +30,8 @@ interface ManagedWorker {
 	interruption?: CaptureInterruption;
 	replacement?: Promise<void>;
 	captureStop?: Promise<'complete' | 'partial' | 'failed'>;
+	stopReason?: string;
+	stopPartial?: boolean;
 	deadlineTimer?: NodeJS.Timeout;
 }
 
@@ -49,6 +51,7 @@ export class CaptureWorkerManager implements RendererBridge {
 		capturedBytes: number,
 	) => Promise<number>;
 	private nextDisplay = 100;
+	private closing = false;
 	constructor(
 		private readonly renderer: RendererBridge,
 		private readonly options: CaptureWorkerManagerOptions,
@@ -79,6 +82,7 @@ export class CaptureWorkerManager implements RendererBridge {
 		return this.workers.get(job)?.worker.env;
 	}
 	async reserve(command: CommandClaims, generation = 0): Promise<PublicJwk> {
+		if (this.closing) throw new Error('capture worker manager is closing');
 		if (this.workers.has(command.job))
 			throw new Error('capture worker already exists');
 		if (this.workers.size >= this.options.maxConcurrent)
@@ -88,6 +92,27 @@ export class CaptureWorkerManager implements RendererBridge {
 			...this.options,
 			display: this.nextDisplay++,
 			limits: command.limits,
+			onCapturePreparing: (epoch) =>
+				this.renderer.prepareCapture(command.job, managed.generation, epoch),
+			onCaptureCommitted: async (launch) => {
+				if (managed.active) return;
+				managed.active = true;
+				await this.handler({
+					job: command.job,
+					generation: managed.generation,
+					type: 'capture_ready',
+					occurredAt: launch.capture_started_at,
+				});
+			},
+			onCaptureLaunched: (launch) =>
+				this.renderer.captureStarted(
+					command.job,
+					managed.generation,
+					launch.epoch,
+					launch.capture_started_at,
+				),
+			onCaptureAborted: (epoch) =>
+				this.renderer.cancelCapture(command.job, managed.generation, epoch),
 			onProgress: async (capturedBytes) => {
 				if (!this.progressHandler)
 					throw new Error('recording budget callback is unavailable');
@@ -116,7 +141,12 @@ export class CaptureWorkerManager implements RendererBridge {
 				});
 			},
 			onStopRequested: (partial, reason) => {
+				managed.stopReason ??= reason;
+				managed.stopPartial ||= partial;
 				managed.captureStop ??= worker.stop(partial, reason);
+				void this.renderer
+					.stop(command.job, managed.generation)
+					.catch(() => undefined);
 				void this.enqueue(command.job, async () => {
 					await this.stopWorker(command.job, partial, reason);
 				});
@@ -127,6 +157,8 @@ export class CaptureWorkerManager implements RendererBridge {
 		this.workers.set(command.job, managed);
 		try {
 			await worker.initialize();
+			if (this.closing || this.workers.get(command.job) !== managed)
+				throw new Error('capture worker manager is closing');
 			return await this.renderer.reserve(command, generation);
 		} catch (error) {
 			this.workers.delete(command.job);
@@ -148,9 +180,33 @@ export class CaptureWorkerManager implements RendererBridge {
 			return Promise.reject(new Error('capture generation is unavailable'));
 		return this.renderer.deliverGrant(job, grant, acceptedAt, generation);
 	}
+	prepareCapture(
+		job: string,
+		generation: number,
+		epoch: number,
+	): Promise<void> {
+		return this.renderer.prepareCapture(job, generation, epoch);
+	}
+	captureStarted(
+		job: string,
+		generation: number,
+		epoch: number,
+		timestamp: string,
+	): Promise<void> {
+		return this.renderer.captureStarted(job, generation, epoch, timestamp);
+	}
+	cancelCapture(job: string, generation: number, epoch: number): Promise<void> {
+		return this.renderer.cancelCapture(job, generation, epoch);
+	}
 	stop(job: string, _generation?: number, reason?: string): Promise<void> {
 		const existing = this.stopping.get(job);
 		if (existing) return existing;
+		const managed = this.workers.get(job);
+		if (managed) {
+			if (reason) managed.stopReason ??= reason;
+			managed.captureStop ??= managed.worker.stop(false, reason);
+			void this.renderer.stop(job, managed.generation).catch(() => undefined);
+		}
 		const promise = this.enqueue(job, () =>
 			this.stopWorker(job, false, reason),
 		);
@@ -178,14 +234,29 @@ export class CaptureWorkerManager implements RendererBridge {
 			...(result.artifact ? { artifact: result.artifact } : {}),
 			gaps: result.gaps,
 			capturedBytes: result.capturedBytes,
+			...(result.captureStartedAt
+				? { captureStartedAt: result.captureStartedAt }
+				: {}),
 		};
 	}
 	async close(): Promise<void> {
-		await Promise.all(
-			[...this.workers.keys()].map((job) =>
+		this.closing = true;
+		const rendererStops: Promise<void>[] = [];
+		for (const [job, managed] of this.workers) {
+			managed.active = false;
+			managed.stopReason ??= 'service_shutdown';
+			managed.stopPartial = true;
+			managed.captureStop ??= managed.worker.stop(true, 'service_shutdown');
+			rendererStops.push(
+				this.renderer.stop(job, managed.generation).catch(() => undefined),
+			);
+		}
+		await Promise.all([
+			...rendererStops,
+			...[...this.workers.keys()].map((job) =>
 				this.enqueue(job, () => this.stopWorker(job, true, 'service_shutdown')),
 			),
-		);
+		]);
 		await this.renderer.close?.();
 	}
 	private enqueue(job: string, operation: () => Promise<void>): Promise<void> {
@@ -206,6 +277,8 @@ export class CaptureWorkerManager implements RendererBridge {
 		const managed = this.workers.get(job);
 		if (!managed) return;
 		const { worker } = managed;
+		partial ||= managed.stopPartial ?? false;
+		reason = managed.stopReason ?? reason;
 		if (managed.deadlineTimer) clearTimeout(managed.deadlineTimer);
 		let outcome: 'complete' | 'partial' | 'failed' = 'failed';
 		let rendererError: unknown;
@@ -222,12 +295,22 @@ export class CaptureWorkerManager implements RendererBridge {
 		}
 		if (rendererError) throw rendererError;
 		const result = worker.captureResult();
+		if (
+			(outcome === 'complete' || outcome === 'partial') &&
+			result.artifact &&
+			!result.captureStartedAt
+		) {
+			outcome = 'failed';
+			reason = 'capture_not_committed';
+		}
 		await this.handler({
 			job,
 			generation: managed.generation,
 			type: outcome,
 			...(reason ? { reason } : {}),
-			...(result.artifact ? { artifact: result.artifact } : {}),
+			...(result.artifact && outcome !== 'failed'
+				? { artifact: result.artifact }
+				: {}),
 			gaps: result.gaps,
 			capturedBytes: result.capturedBytes,
 			...(outcome === 'partial' && !reason
@@ -244,9 +327,19 @@ export class CaptureWorkerManager implements RendererBridge {
 				worker.recoverRenderer();
 				return;
 			}
-			await worker.startCapture();
-			managed.active = true;
-			event = { ...event, occurredAt: new Date().toISOString() };
+			try {
+				const launch = await worker.startCapture();
+				if (!launch) return;
+			} catch (error) {
+				if (managed.captureStop) return;
+				await this.stopWorker(
+					event.job,
+					false,
+					error instanceof Error ? error.message : 'capture_start_failed',
+				);
+				return;
+			}
+			return;
 		}
 		if (event.type === 'room_empty') {
 			await this.stopWorker(event.job, false, 'room_empty');

--- a/suite/meet/recorder-server/src/JobManager.ts
+++ b/suite/meet/recorder-server/src/JobManager.ts
@@ -111,6 +111,22 @@ export class JobManager {
 				const outcome = await this.bridge.recoverStopping?.(job.job);
 				if (outcome?.capturedBytes !== undefined)
 					await this.recordTerminalProgress(job.job, outcome.capturedBytes);
+				const captureStartedAt =
+					outcome?.captureStartedAt ?? job.capture_started_at;
+				if (captureStartedAt) {
+					await this.store.update((jobs) => {
+						const current = jobs[job.job];
+						if (!current || current.capture_started_at) return;
+						current.capture_started_at = captureStartedAt;
+						current.event_sequence = Math.max(current.event_sequence ?? 1, 5);
+					});
+					const adopted = this.store.get(job.job);
+					if (adopted && this.onStartup)
+						await this.scheduleHealth(
+							{ ...adopted, state: 'capture_ready' },
+							this.onStartup,
+						);
+				}
 				const type =
 					job.state !== 'stopping' && outcome?.type === 'complete'
 						? 'partial'
@@ -519,6 +535,15 @@ export class JobManager {
 			const current = this.store.get(job);
 			if (current?.endpoint_generation !== generation) return;
 			if (!current || !ACTIVE_TRANSITIONS[current.state].includes(type)) return;
+			if (
+				(type === 'complete' || type === 'partial') &&
+				!current.capture_started_at
+			) {
+				type = 'failed';
+				reason = 'capture_not_committed';
+				artifact = undefined;
+				gaps = undefined;
+			}
 			const recovered =
 				current.state === 'interrupted' && type === 'capture_ready';
 			const startupMilestone =

--- a/suite/meet/recorder-server/src/ManifestStore.ts
+++ b/suite/meet/recorder-server/src/ManifestStore.ts
@@ -40,7 +40,7 @@ export function validManifest(value: unknown): value is CaptureManifest {
 	if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
 	const m = value as CaptureManifest;
 	return (
-		m.version === 1 &&
+		(m.version === 1 || m.version === 2) &&
 		Number.isSafeInteger(m.revision) &&
 		m.revision >= 0 &&
 		typeof m.job === 'string' &&
@@ -49,6 +49,25 @@ export function validManifest(value: unknown): value is CaptureManifest {
 		) &&
 		Number.isSafeInteger(m.epochs) &&
 		m.epochs >= 0 &&
+		((m.version === 1 && m.capture_epochs === undefined) ||
+			(Array.isArray(m.capture_epochs) &&
+				m.capture_epochs.every(
+					(record, index) =>
+						record !== null &&
+						typeof record === 'object' &&
+						!Array.isArray(record) &&
+						Object.keys(record).length === 2 &&
+						Object.hasOwn(record, 'epoch') &&
+						Object.hasOwn(record, 'capture_started_at') &&
+						Number.isSafeInteger(record.epoch) &&
+						record.epoch >= 0 &&
+						record.epoch < m.epochs &&
+						(index === 0 ||
+							(record.epoch > (m.capture_epochs?.[index - 1]?.epoch ?? -1) &&
+								record.capture_started_at >=
+									(m.capture_epochs?.[index - 1]?.capture_started_at ?? ''))) &&
+						timestamp(record.capture_started_at),
+				))) &&
 		Array.isArray(m.segments) &&
 		Array.isArray(m.gaps) &&
 		(m.reason === undefined ||
@@ -67,7 +86,10 @@ export function validManifest(value: unknown): value is CaptureManifest {
 				typeof s.sha256 === 'string' &&
 				/^[a-f0-9]{64}$/.test(s.sha256) &&
 				positiveInteger(s.duration_ms) &&
-				timestamp(s.started_at),
+				timestamp(s.started_at) &&
+				(m.version === 1 ||
+					m.capture_epochs?.some((record) => record.epoch === s.epoch) ===
+						true),
 		) &&
 		m.gaps.every(
 			(g) =>
@@ -132,11 +154,12 @@ export class ManifestStore {
 					cause: currentError,
 				});
 			this.current = {
-				version: 1,
+				version: 2,
 				revision: 0,
 				job: this.job,
 				state: 'capturing',
 				epochs: 0,
+				capture_epochs: [],
 				segments: [],
 				gaps: [],
 			};

--- a/suite/meet/recorder-server/src/ProcessSupervisor.test.ts
+++ b/suite/meet/recorder-server/src/ProcessSupervisor.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { rm, stat } from 'node:fs/promises';
+import { readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -63,5 +63,35 @@ describe('ProcessSupervisor', () => {
 		paths.push(logPath);
 		const managed = await supervisor.start('command', [], { logPath });
 		await expect(managed.stop()).rejects.toThrow('denied');
+	});
+
+	it('handles an asynchronous child error as one unexpected termination', async () => {
+		const child = new EventEmitter() as EventEmitter & {
+			pid: number;
+			stdout: PassThrough;
+			stderr: PassThrough;
+		};
+		child.pid = 42;
+		child.stdout = new PassThrough();
+		child.stderr = new PassThrough();
+		const logPath = join(tmpdir(), `supervisor-${crypto.randomUUID()}.log`);
+		paths.push(logPath);
+		const unexpected = vi.fn();
+		const supervisor = new ProcessSupervisor(
+			vi.fn(() => child) as unknown as ProcessSpawner,
+		);
+		const managed = await supervisor.start('command', [], {
+			logPath,
+			onUnexpectedExit: unexpected,
+		});
+		child.stderr.write('failed to start');
+		child.emit('error', new Error('spawn failed'));
+		child.emit('exit', 1, null);
+
+		await expect(managed.exited).resolves.toEqual({ code: null, signal: null });
+		expect(unexpected).toHaveBeenCalledOnce();
+		await vi.waitFor(async () =>
+			expect(await readFile(logPath, 'utf8')).toBe('failed to start'),
+		);
 	});
 });

--- a/suite/meet/recorder-server/src/ProcessSupervisor.ts
+++ b/suite/meet/recorder-server/src/ProcessSupervisor.ts
@@ -65,14 +65,21 @@ export class ProcessSupervisor {
 		const exited = new Promise<{
 			code: number | null;
 			signal: NodeJS.Signals | null;
-		}>((resolve, reject) => {
-			child.once('error', reject);
-			child.once('exit', (code, signal) => {
+		}>((resolve) => {
+			let terminated = false;
+			const terminate = (
+				code: number | null,
+				signal: NodeJS.Signals | null,
+			) => {
+				if (terminated) return;
+				terminated = true;
 				const result = { code, signal };
 				log.end();
 				resolve(result);
 				if (!stopping) options.onUnexpectedExit?.(result);
-			});
+			};
+			child.once('error', () => terminate(null, null));
+			child.once('exit', terminate);
 		});
 		return {
 			pid: child.pid,

--- a/suite/meet/recorder-server/src/ProtocolContract.test.ts
+++ b/suite/meet/recorder-server/src/ProtocolContract.test.ts
@@ -8,6 +8,8 @@ import {
 	parseStatusResponse,
 } from './CallbackClient.js';
 import {
+	parseCapturePrepared,
+	parseCaptureStartedAccepted,
 	parseRendererLifecycle,
 	parseRendererPublicKeyReady,
 } from './RendererBridge.js';
@@ -35,6 +37,14 @@ const contract = JSON.parse(
 			rejected: JsonObject[];
 		};
 		renderer_public_key_ready: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		renderer_capture_prepared: {
+			accepted: JsonObject[];
+			rejected: JsonObject[];
+		};
+		renderer_capture_started_accepted: {
 			accepted: JsonObject[];
 			rejected: JsonObject[];
 		};
@@ -91,6 +101,19 @@ describe('recording protocol contract v1', () => {
 			expect(parseRendererPublicKeyReady(value)).not.toBeNull();
 		for (const value of contract.vectors.renderer_public_key_ready.rejected)
 			expect(parseRendererPublicKeyReady(value)).toBeNull();
+	});
+
+	it('runs shared capture acknowledgement vectors through production parsers', () => {
+		for (const value of contract.vectors.renderer_capture_prepared.accepted)
+			expect(parseCapturePrepared(value)).toBeDefined();
+		for (const value of contract.vectors.renderer_capture_prepared.rejected)
+			expect(parseCapturePrepared(value)).toBeUndefined();
+		for (const value of contract.vectors.renderer_capture_started_accepted
+			.accepted)
+			expect(parseCaptureStartedAccepted(value)).toBeDefined();
+		for (const value of contract.vectors.renderer_capture_started_accepted
+			.rejected)
+			expect(parseCaptureStartedAccepted(value)).toBeUndefined();
 	});
 
 	it('covers every finite renderer reason code', () => {

--- a/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
+++ b/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
@@ -154,6 +154,21 @@ describe('recorder vertical chain', () => {
 						},
 					});
 				});
+				socket.on('recording:get_projection_snapshot', (_data, callback) => {
+					callback({
+						success: true,
+						snapshot: {
+							protocol_version: 1,
+							room_id: command.room,
+							cursor: 0,
+							observed_at: new Date().toISOString(),
+							participants: [],
+							producers: [],
+							raised_hands: {},
+							active_speaker_ids: [],
+						},
+					});
+				});
 				query('get_room_participants', { participants: [] });
 				query('get_existing_producers', { producers: [] });
 				socket.emit('recording:challenge', challenge);
@@ -200,6 +215,13 @@ describe('recorder vertical chain', () => {
 								occurredAt: expect.any(String),
 							}),
 					),
+				);
+				await bridge.prepareCapture(command.job, 0, 0);
+				await bridge.captureStarted(
+					command.job,
+					0,
+					0,
+					'2026-08-30T12:00:00.000Z',
 				);
 
 				expect(proofAccepted).toBe(true);

--- a/suite/meet/recorder-server/src/RendererBridge.test.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it, vi } from 'vitest';
 import {
 	type BrowserAdapter,
 	ChromiumRendererBridge,
+	parseCapturePrepared,
+	parseCaptureStartedAccepted,
 	TEST_PUBLIC_JWK,
 } from './RendererBridge.js';
 import { COMMAND_AUDIENCE, type CommandClaims } from './types.js';
@@ -36,6 +38,46 @@ const command: CommandClaims = {
 };
 
 describe('ChromiumRendererBridge', () => {
+	it('strictly parses capture acknowledgements', () => {
+		expect(
+			parseCapturePrepared({
+				type: 'suite-recorder:capture-prepared',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:00.000Z',
+				job: 'job-1',
+				epoch: 0,
+			}),
+		).toEqual({
+			job: 'job-1',
+			epoch: 0,
+			occurredAt: '2026-08-30T12:00:00.000Z',
+		});
+		expect(
+			parseCaptureStartedAccepted({
+				type: 'suite-recorder:capture-started-accepted',
+				protocol_version: 1,
+				occurred_at: '2026-08-30T12:00:01.000Z',
+				job: 'job-1',
+				epoch: 0,
+				capture_started_at: '2026-08-30T12:00:00.000Z',
+			})?.captureStartedAt,
+		).toBe('2026-08-30T12:00:00.000Z');
+		for (const invalid of [
+			{ epoch: -1 },
+			{ epoch: 0, extra: true },
+			{ epoch: 0, occurred_at: '2026-08-30T12:00:00Z' },
+		])
+			expect(
+				parseCapturePrepared({
+					type: 'suite-recorder:capture-prepared',
+					protocol_version: 1,
+					occurred_at: '2026-08-30T12:00:00.000Z',
+					job: 'job-1',
+					...invalid,
+				}),
+			).toBeUndefined();
+	});
+
 	it.each([
 		{
 			type: 'suite-recorder:public-key-ready',
@@ -110,28 +152,225 @@ describe('ChromiumRendererBridge', () => {
 		);
 		await bridge.initialize();
 		const reservation = bridge.reserve(command);
+		const rejectedReservation =
+			expect(reservation).rejects.toThrow('cancelled');
 		await vi.waitFor(() => expect(launch).toHaveBeenCalledOnce());
 		const shutdown = bridge.close();
 
-		resolveLaunch(browser);
-		await expect(reservation).rejects.toThrow('cancelled');
 		await shutdown;
+		await rejectedReservation;
+		resolveLaunch(browser);
+		await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
 		expect(close).toHaveBeenCalledOnce();
 		expect(bridge.hasWorker(command.job)).toBe(false);
+	});
+
+	it('bounds the Chromium adapter launch with the reservation timeout', async () => {
+		const assets = await mkdtemp(join(tmpdir(), 'renderer-assets-'));
+		await writeFile(join(assets, 'recorder.html'), '<!doctype html>');
+		const bridge = new ChromiumRendererBridge(
+			{
+				executablePath: process.execPath,
+				assetDirectory: assets,
+				sfuOrigin: 'https://sfu.test',
+				sfuSocketPath: '/socket.io',
+				trustedCommandOrigin: 'https://site.test',
+				listenerPort: 0,
+				noSandbox: false,
+				reserveTimeoutMs: 10,
+				configureTimeoutMs: 1_000,
+			},
+			{ launch: vi.fn(() => new Promise<Browser>(() => undefined)) },
+		);
+		await bridge.initialize();
+
+		await expect(bridge.reserve(command)).rejects.toThrow('launch timed out');
+		await bridge.close();
+	});
+
+	it('times out and rejects pending capture handshakes on stop', async () => {
+		const close = vi.fn(async () => undefined);
+		const bridge = new ChromiumRendererBridge({
+			configureTimeoutMs: 10,
+		} as never);
+		const jobs = Reflect.get(bridge, 'jobs') as Map<string, unknown>;
+		jobs.set('job-1', {
+			browser: { close },
+			page: { evaluate: vi.fn(async () => undefined) },
+			command,
+			generation: 0,
+		});
+		await expect(bridge.prepareCapture('job-1', 0, 0)).rejects.toThrow(
+			'timed out',
+		);
+
+		jobs.set('job-1', {
+			browser: { close },
+			page: { evaluate: vi.fn(async () => undefined) },
+			command,
+			generation: 0,
+		});
+		const pending = bridge.prepareCapture('job-1', 0, 0);
+		await bridge.stop('job-1', 0);
+		await expect(pending).rejects.toThrow('renderer stopped');
+	});
+
+	it('ignores valid stale acknowledgements without rejecting the current epoch', () => {
+		const bridge = new ChromiumRendererBridge({} as never);
+		const rejectPrepared = vi.fn();
+		const rejectStarted = vi.fn();
+		const jobs = Reflect.get(bridge, 'jobs') as Map<string, unknown>;
+		jobs.set('job-1', {
+			generation: 0,
+			capture: {
+				epoch: 2,
+				prepared: Promise.resolve(),
+				preparedAccepted: true,
+				resolvePrepared: vi.fn(),
+				rejectPrepared,
+				started: {
+					timestamp: '2026-08-30T12:00:02.000Z',
+					accepted: Promise.resolve(),
+					acceptedByRenderer: false,
+					resolve: vi.fn(),
+					reject: rejectStarted,
+				},
+			},
+		});
+		const receive = Reflect.get(bridge, 'receiveCaptureAcknowledgement').bind(
+			bridge,
+		) as (job: string, generation: number, value: object) => void;
+		receive('job-1', 0, {
+			type: 'suite-recorder:capture-prepared',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:00.000Z',
+			job: 'job-1',
+			epoch: 1,
+		});
+		receive('job-1', 0, {
+			type: 'suite-recorder:capture-started-accepted',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:00.000Z',
+			job: 'job-1',
+			epoch: 1,
+			capture_started_at: '2026-08-30T12:00:01.000Z',
+		});
+		expect(rejectPrepared).not.toHaveBeenCalled();
+		expect(rejectStarted).not.toHaveBeenCalled();
+
+		receive('job-1', 0, {
+			type: 'suite-recorder:capture-started-accepted',
+			protocol_version: 1,
+			occurred_at: '2026-08-30T12:00:02.001Z',
+			job: 'job-1',
+			epoch: 2,
+			capture_started_at: '2026-08-30T12:00:02.001Z',
+		});
+		expect(rejectStarted).toHaveBeenCalledOnce();
+	});
+
+	it('allows the next epoch after a capture-start acknowledgement timeout', async () => {
+		const bridge = new ChromiumRendererBridge({
+			configureTimeoutMs: 5,
+		} as never);
+		const jobs = Reflect.get(bridge, 'jobs') as Map<string, unknown>;
+		const receive = Reflect.get(bridge, 'receiveCaptureAcknowledgement').bind(
+			bridge,
+		) as (job: string, generation: number, value: object) => void;
+		const page = {
+			evaluate: vi.fn(
+				async (_callback, value: { type: string; epoch: number }) => {
+					if (value.type === 'suite-recorder:prepare-capture')
+						receive('job-1', 0, {
+							type: 'suite-recorder:capture-prepared',
+							protocol_version: 1,
+							occurred_at: '2026-08-30T12:00:00.000Z',
+							job: 'job-1',
+							epoch: value.epoch,
+						});
+				},
+			),
+		};
+		jobs.set('job-1', {
+			browser: { close: vi.fn() },
+			page,
+			command,
+			generation: 0,
+		});
+		await bridge.prepareCapture('job-1', 0, 0);
+		await expect(
+			bridge.captureStarted('job-1', 0, 0, '2026-08-30T12:00:00.000Z'),
+		).rejects.toThrow('timed out');
+
+		await expect(bridge.prepareCapture('job-1', 0, 1)).resolves.toBeUndefined();
+	});
+
+	it('allows a newer epoch to supersede an acknowledged prepare with no start', async () => {
+		const bridge = new ChromiumRendererBridge({
+			configureTimeoutMs: 100,
+		} as never);
+		const jobs = Reflect.get(bridge, 'jobs') as Map<string, unknown>;
+		const receive = Reflect.get(bridge, 'receiveCaptureAcknowledgement').bind(
+			bridge,
+		) as (job: string, generation: number, value: object) => void;
+		const page = {
+			evaluate: vi.fn(async (_callback, value: { epoch: number }) => {
+				receive('job-1', 0, {
+					type: 'suite-recorder:capture-prepared',
+					protocol_version: 1,
+					occurred_at: '2026-08-30T12:00:00.000Z',
+					job: 'job-1',
+					epoch: value.epoch,
+				});
+			}),
+		};
+		jobs.set('job-1', {
+			browser: { close: vi.fn() },
+			page,
+			command,
+			generation: 0,
+		});
+
+		await bridge.prepareCapture('job-1', 0, 0);
+		await expect(bridge.prepareCapture('job-1', 0, 1)).resolves.toBeUndefined();
+		expect(page.evaluate).toHaveBeenCalledTimes(2);
 	});
 
 	it('reserves one isolated page, delivers trusted config, and stops idempotently', async () => {
 		const assets = await mkdtemp(join(tmpdir(), 'renderer-assets-'));
 		await writeFile(join(assets, 'recorder.html'), '<!doctype html>');
 		let exposed: ((value: unknown) => void) | undefined;
-		const evaluate = vi.fn(async () => {
-			exposed?.({
-				type: 'suite-recorder:configuration-accepted',
-				protocol_version: 1,
-				occurred_at: '2026-08-30T12:00:01.000Z',
-				job: 'job-1',
-			});
-		});
+		const evaluate = vi.fn(
+			async (
+				_callback,
+				value: { type: string; epoch?: number; capture_started_at?: string },
+			) => {
+				if (value.type === 'suite-recorder:configure')
+					exposed?.({
+						type: 'suite-recorder:configuration-accepted',
+						protocol_version: 1,
+						occurred_at: '2026-08-30T12:00:01.000Z',
+						job: 'job-1',
+					});
+				if (value.type === 'suite-recorder:prepare-capture')
+					exposed?.({
+						type: 'suite-recorder:capture-prepared',
+						protocol_version: 1,
+						occurred_at: '2026-08-30T12:00:02.000Z',
+						job: 'job-1',
+						epoch: value.epoch,
+					});
+				if (value.type === 'suite-recorder:capture-started')
+					exposed?.({
+						type: 'suite-recorder:capture-started-accepted',
+						protocol_version: 1,
+						occurred_at: '2026-08-30T12:00:03.000Z',
+						job: 'job-1',
+						epoch: value.epoch,
+						capture_started_at: value.capture_started_at,
+					});
+			},
+		);
 		const page = {
 			setViewport: vi.fn(),
 			setRequestInterception: vi.fn(),
@@ -207,6 +446,30 @@ describe('ChromiumRendererBridge', () => {
 			},
 		});
 		expect(lifecycle).toHaveBeenCalledTimes(1);
+		await bridge.prepareCapture('job-1', 0, 0);
+		await bridge.prepareCapture('job-1', 0, 0);
+		await bridge.captureStarted('job-1', 0, 0, '2026-08-30T12:00:02.500Z');
+		await expect(
+			bridge.captureStarted('job-1', 0, 0, '2026-08-30T12:00:02.501Z'),
+		).rejects.toThrow('conflicting');
+		await bridge.captureStarted('job-1', 0, 0, '2026-08-30T12:00:02.500Z');
+		expect(evaluate.mock.calls.slice(1).map((call) => call[1])).toEqual([
+			{
+				type: 'suite-recorder:prepare-capture',
+				protocol_version: 1,
+				job: 'job-1',
+				epoch: 0,
+			},
+			{
+				type: 'suite-recorder:capture-started',
+				protocol_version: 1,
+				job: 'job-1',
+				epoch: 0,
+				capture_started_at: '2026-08-30T12:00:02.500Z',
+			},
+		]);
+		await expect(bridge.prepareCapture('job-1', 0, 1)).resolves.toBeUndefined();
+		await expect(bridge.prepareCapture('job-1', 0, 0)).rejects.toThrow('stale');
 		for (const message of [
 			{ type: 'suite-recorder:capture-ready', job: 'job-1' },
 			{
@@ -260,7 +523,7 @@ describe('ChromiumRendererBridge', () => {
 			'private-grant',
 			'2026-07-31T12:00:00.000Z',
 		);
-		expect(evaluate).toHaveBeenCalledOnce();
+		expect(evaluate).toHaveBeenCalledTimes(4);
 		await expect(
 			bridge.deliverGrant(
 				'job-1',

--- a/suite/meet/recorder-server/src/RendererBridge.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.ts
@@ -34,12 +34,21 @@ export interface RendererBridge {
 		acceptedAt: string,
 		generation: number,
 	): Promise<void>;
+	prepareCapture(job: string, generation: number, epoch: number): Promise<void>;
+	captureStarted(
+		job: string,
+		generation: number,
+		epoch: number,
+		timestamp: string,
+	): Promise<void>;
+	cancelCapture(job: string, generation: number, epoch: number): Promise<void>;
 	stop(job: string, generation?: number, reason?: string): Promise<void>;
 	recoverStopping?(job: string): Promise<{
 		type: 'complete' | 'partial' | 'failed';
 		artifact?: CaptureArtifact;
 		gaps?: CaptureGap[];
 		capturedBytes?: number;
+		captureStartedAt?: string;
 	}>;
 	close?(): Promise<void>;
 	hasWorker(job: string): boolean;
@@ -101,11 +110,27 @@ interface RendererJob {
 	configurationAccepted?: Promise<void>;
 	resolveConfiguration?: () => void;
 	rejectConfiguration?: (error: Error) => void;
+	capture?: {
+		epoch: number;
+		prepared: Promise<void>;
+		preparedAccepted: boolean;
+		resolvePrepared: () => void;
+		rejectPrepared: (error: Error) => void;
+		started?: {
+			timestamp: string;
+			accepted: Promise<void>;
+			acceptedByRenderer: boolean;
+			resolve: () => void;
+			reject: (error: Error) => void;
+		};
+	};
 }
 
 interface PendingRenderer {
 	generation: number;
 	cancelled: boolean;
+	cancelledPromise: Promise<never>;
+	cancel: (error: Error) => void;
 	browser?: Browser;
 	settled: Promise<void>;
 	resolveSettled: () => void;
@@ -138,6 +163,7 @@ const RENDERER_REASON_CODES = new Set([
 	'media_attachment_failed',
 	'media_subscription_failed',
 	'receive_transport_failed',
+	'projection_invalid',
 	'configuration_failed',
 	'browser_disconnected',
 	'page_crashed',
@@ -235,9 +261,18 @@ export class ChromiumRendererBridge implements RendererBridge {
 		if (this.options.noSandbox)
 			args.push('--no-sandbox', '--disable-setuid-sandbox');
 		let resolveSettled!: () => void;
+		let rejectCancelled!: (error: Error) => void;
 		const pending: PendingRenderer = {
 			generation,
 			cancelled: false,
+			cancelledPromise: new Promise<never>((_, reject) => {
+				rejectCancelled = reject;
+			}),
+			cancel: (error) => {
+				if (pending.cancelled) return;
+				pending.cancelled = true;
+				rejectCancelled(error);
+			},
 			settled: new Promise<void>((resolve) => {
 				resolveSettled = resolve;
 			}),
@@ -247,7 +282,7 @@ export class ChromiumRendererBridge implements RendererBridge {
 		let browser: Browser | undefined;
 		try {
 			const workerEnvironment = this.options.workerEnvironment?.(command.job);
-			browser = await this.adapter.launch({
+			const launching = this.adapter.launch({
 				executablePath: this.options.executablePath,
 				headless: false,
 				...(workerEnvironment ? { env: workerEnvironment } : {}),
@@ -261,6 +296,25 @@ export class ChromiumRendererBridge implements RendererBridge {
 					'--force-device-scale-factor=1',
 				],
 			});
+			void launching.then(
+				(lateBrowser) => {
+					if (pending.cancelled)
+						void lateBrowser.close().catch(() => undefined);
+				},
+				() => undefined,
+			);
+			let launchTimeout: NodeJS.Timeout | undefined;
+			browser = await Promise.race([
+				launching,
+				pending.cancelledPromise,
+				new Promise<never>((_, reject) => {
+					launchTimeout = setTimeout(() => {
+						const error = new Error('renderer launch timed out');
+						pending.cancel(error);
+						reject(error);
+					}, this.options.reserveTimeoutMs);
+				}),
+			]).finally(() => clearTimeout(launchTimeout));
 			pending.browser = browser;
 			if (pending.cancelled || !this.available)
 				throw new Error('renderer reservation was cancelled');
@@ -423,6 +477,148 @@ export class ChromiumRendererBridge implements RendererBridge {
 		}
 	}
 
+	async prepareCapture(
+		job: string,
+		generation: number,
+		epoch: number,
+	): Promise<void> {
+		if (!Number.isSafeInteger(epoch) || epoch < 0)
+			throw new Error('invalid capture epoch');
+		const renderer = this.jobs.get(job);
+		if (!renderer || renderer.generation !== generation)
+			throw new Error('renderer generation is unavailable');
+		const current = renderer.capture;
+		if (current) {
+			if (epoch === current.epoch) return current.prepared;
+			if (epoch < current.epoch) throw new Error('stale capture epoch');
+			if (current.started && !current.started.acceptedByRenderer)
+				throw new Error('conflicting capture epoch');
+		}
+		let resolvePrepared!: () => void;
+		let rejectPrepared!: (error: Error) => void;
+		const prepared = new Promise<void>((resolve, reject) => {
+			resolvePrepared = resolve;
+			rejectPrepared = reject;
+		});
+		void prepared.catch(() => undefined);
+		renderer.capture = {
+			epoch,
+			prepared,
+			preparedAccepted: false,
+			resolvePrepared,
+			rejectPrepared,
+		};
+		try {
+			await renderer.page.evaluate(
+				(value) => window.postMessage(value, window.location.origin),
+				{
+					type: 'suite-recorder:prepare-capture',
+					protocol_version: RECORDER_PROTOCOL_VERSION,
+					job,
+					epoch,
+				},
+			);
+			await this.withConfigureTimeout(
+				prepared,
+				'renderer capture prepare timed out',
+			);
+		} catch (error) {
+			const failure =
+				error instanceof Error ? error : new Error('capture prepare failed');
+			rejectPrepared(failure);
+			if (
+				renderer.capture?.epoch === epoch &&
+				!renderer.capture.preparedAccepted
+			)
+				delete renderer.capture;
+			throw failure;
+		}
+	}
+
+	async captureStarted(
+		job: string,
+		generation: number,
+		epoch: number,
+		timestamp: string,
+	): Promise<void> {
+		if (!Number.isSafeInteger(epoch) || epoch < 0)
+			throw new Error('invalid capture epoch');
+		if (!validUtcTimestamp(timestamp))
+			throw new Error('invalid capture start timestamp');
+		const renderer = this.jobs.get(job);
+		if (!renderer || renderer.generation !== generation)
+			throw new Error('renderer generation is unavailable');
+		const capture = renderer.capture;
+		if (!capture || epoch < capture.epoch)
+			throw new Error('stale capture epoch');
+		if (epoch > capture.epoch || !capture.preparedAccepted)
+			throw new Error('conflicting capture epoch');
+		if (capture.started) {
+			if (capture.started.timestamp !== timestamp)
+				throw new Error('conflicting capture timestamp');
+			return capture.started.accepted;
+		}
+		let resolve!: () => void;
+		let reject!: (error: Error) => void;
+		const accepted = new Promise<void>((accept, fail) => {
+			resolve = accept;
+			reject = fail;
+		});
+		void accepted.catch(() => undefined);
+		capture.started = {
+			timestamp,
+			accepted,
+			acceptedByRenderer: false,
+			resolve,
+			reject,
+		};
+		try {
+			await renderer.page.evaluate(
+				(value) => window.postMessage(value, window.location.origin),
+				{
+					type: 'suite-recorder:capture-started',
+					protocol_version: RECORDER_PROTOCOL_VERSION,
+					job,
+					epoch,
+					capture_started_at: timestamp,
+				},
+			);
+			await this.withConfigureTimeout(
+				accepted,
+				'renderer capture start timed out',
+			);
+		} catch (error) {
+			const failure =
+				error instanceof Error ? error : new Error('capture start failed');
+			reject(failure);
+			if (
+				renderer.capture === capture &&
+				capture.started?.timestamp === timestamp &&
+				!capture.started.acceptedByRenderer
+			)
+				delete renderer.capture;
+			throw failure;
+		}
+	}
+
+	async cancelCapture(
+		job: string,
+		generation: number,
+		epoch: number,
+	): Promise<void> {
+		const renderer = this.jobs.get(job);
+		if (
+			!renderer ||
+			renderer.generation !== generation ||
+			renderer.capture?.epoch !== epoch
+		)
+			return;
+		const error = new Error('capture launch aborted');
+		renderer.capture.rejectPrepared(error);
+		renderer.capture.started?.reject(error);
+		delete renderer.capture;
+	}
+
 	async stop(job: string, generation?: number): Promise<void> {
 		const renderer = this.jobs.get(job);
 		if (
@@ -431,6 +627,8 @@ export class ChromiumRendererBridge implements RendererBridge {
 		) {
 			this.jobs.delete(job);
 			renderer.rejectConfiguration?.(new Error('renderer stopped'));
+			renderer.capture?.rejectPrepared(new Error('renderer stopped'));
+			renderer.capture?.started?.reject(new Error('renderer stopped'));
 			await renderer.browser.close().catch(() => undefined);
 		}
 		const pending = this.reservations.get(job);
@@ -438,7 +636,7 @@ export class ChromiumRendererBridge implements RendererBridge {
 			pending &&
 			(generation === undefined || pending.generation === generation)
 		) {
-			pending.cancelled = true;
+			pending.cancel(new Error('renderer reservation was cancelled'));
 			await pending.browser?.close().catch(() => undefined);
 			await pending.settled;
 		}
@@ -520,6 +718,14 @@ export class ChromiumRendererBridge implements RendererBridge {
 			else rejectReady(new Error('renderer returned an invalid public JWK'));
 			return;
 		}
+		if (
+			'type' in value &&
+			(value.type === 'suite-recorder:capture-prepared' ||
+				value.type === 'suite-recorder:capture-started-accepted')
+		) {
+			this.receiveCaptureAcknowledgement(job, generation, value);
+			return;
+		}
 		const lifecycle = parseRendererLifecycle(value);
 		if (!lifecycle || lifecycle.job !== job) return;
 		const renderer = this.jobs.get(job);
@@ -532,6 +738,74 @@ export class ChromiumRendererBridge implements RendererBridge {
 			occurredAt: lifecycle.occurredAt,
 			...(lifecycle.reasonCode ? { reason: lifecycle.reasonCode } : {}),
 		});
+	}
+
+	private receiveCaptureAcknowledgement(
+		job: string,
+		generation: number,
+		value: object,
+	): void {
+		const renderer = this.jobs.get(job);
+		if (!renderer || renderer.generation !== generation) return;
+		const capture = renderer.capture;
+		if ('type' in value && value.type === 'suite-recorder:capture-prepared') {
+			const acknowledgement = parseCapturePrepared(value);
+			if (
+				acknowledgement?.job === job &&
+				capture &&
+				acknowledgement.epoch < capture.epoch
+			)
+				return;
+			if (
+				!acknowledgement ||
+				acknowledgement.job !== job ||
+				acknowledgement.epoch !== capture?.epoch
+			) {
+				capture?.rejectPrepared(
+					new Error('invalid capture prepared acknowledgement'),
+				);
+				return;
+			}
+			capture.preparedAccepted = true;
+			capture.resolvePrepared();
+			return;
+		}
+		const acknowledgement = parseCaptureStartedAccepted(value);
+		if (
+			acknowledgement?.job === job &&
+			capture &&
+			acknowledgement.epoch < capture.epoch
+		)
+			return;
+		if (
+			!acknowledgement ||
+			acknowledgement.job !== job ||
+			acknowledgement.epoch !== capture?.epoch ||
+			acknowledgement.captureStartedAt !== capture.started?.timestamp
+		) {
+			capture?.started?.reject(
+				new Error('invalid capture started acknowledgement'),
+			);
+			return;
+		}
+		capture.started.acceptedByRenderer = true;
+		capture.started.resolve();
+	}
+
+	private async withConfigureTimeout(
+		operation: Promise<void>,
+		message: string,
+	): Promise<void> {
+		let timeout: NodeJS.Timeout | undefined;
+		await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(
+					() => reject(new Error(message)),
+					this.options.configureTimeoutMs,
+				);
+			}),
+		]).finally(() => clearTimeout(timeout));
 	}
 
 	private async workerFailed(
@@ -634,6 +908,79 @@ export function parseRendererLifecycle(value: object):
 	};
 }
 
+export function parseCapturePrepared(
+	value: object,
+): { job: string; epoch: number; occurredAt: string } | undefined {
+	if (
+		!hasExactKeys(value, [
+			'type',
+			'protocol_version',
+			'occurred_at',
+			'job',
+			'epoch',
+		]) ||
+		!('type' in value) ||
+		value.type !== 'suite-recorder:capture-prepared' ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!('occurred_at' in value) ||
+		!validUtcTimestamp(value.occurred_at) ||
+		!('job' in value) ||
+		typeof value.job !== 'string' ||
+		!value.job ||
+		!('epoch' in value) ||
+		!Number.isSafeInteger(value.epoch) ||
+		Number(value.epoch) < 0
+	)
+		return undefined;
+	return {
+		job: value.job,
+		epoch: value.epoch as number,
+		occurredAt: value.occurred_at,
+	};
+}
+
+export function parseCaptureStartedAccepted(value: object):
+	| {
+			job: string;
+			epoch: number;
+			occurredAt: string;
+			captureStartedAt: string;
+	  }
+	| undefined {
+	if (
+		!hasExactKeys(value, [
+			'type',
+			'protocol_version',
+			'occurred_at',
+			'job',
+			'epoch',
+			'capture_started_at',
+		]) ||
+		!('type' in value) ||
+		value.type !== 'suite-recorder:capture-started-accepted' ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== RECORDER_PROTOCOL_VERSION ||
+		!('occurred_at' in value) ||
+		!validUtcTimestamp(value.occurred_at) ||
+		!('job' in value) ||
+		typeof value.job !== 'string' ||
+		!value.job ||
+		!('epoch' in value) ||
+		!Number.isSafeInteger(value.epoch) ||
+		Number(value.epoch) < 0 ||
+		!('capture_started_at' in value) ||
+		!validUtcTimestamp(value.capture_started_at)
+	)
+		return undefined;
+	return {
+		job: value.job,
+		epoch: value.epoch as number,
+		occurredAt: value.occurred_at,
+		captureStartedAt: value.capture_started_at,
+	};
+}
+
 export const TEST_PUBLIC_JWK: PublicJwk = {
 	kty: 'EC',
 	crv: 'P-256',
@@ -650,6 +997,18 @@ export class FakeRendererBridge implements RendererBridge {
 		generation: number;
 	}> = [];
 	readonly stopped = new Set<string>();
+	readonly prepared: Array<{ job: string; generation: number; epoch: number }> =
+		[];
+	readonly captureStarts: Array<{
+		job: string;
+		generation: number;
+		epoch: number;
+		timestamp: string;
+	}> = [];
+	private readonly captures = new Map<
+		string,
+		{ generation: number; epoch: number; timestamp?: string }
+	>();
 	private readonly workers = new Map<string, number>();
 	private handler: (event: RendererLifecycleEvent) => Promise<void> =
 		async () => undefined;
@@ -688,10 +1047,56 @@ export class FakeRendererBridge implements RendererBridge {
 		this.grants.push({ job, grant, acceptedAt, generation });
 		void this.handler({ job, generation, type: 'configured' });
 	}
+	async prepareCapture(
+		job: string,
+		generation: number,
+		epoch: number,
+	): Promise<void> {
+		if (this.workers.get(job) !== generation)
+			throw new Error('renderer generation is unavailable');
+		const current = this.captures.get(job);
+		if (current) {
+			if (current.generation === generation && current.epoch === epoch) return;
+			if (current.generation === generation && epoch < current.epoch)
+				throw new Error('stale capture epoch');
+		}
+		this.captures.set(job, { generation, epoch });
+		this.prepared.push({ job, generation, epoch });
+	}
+	async captureStarted(
+		job: string,
+		generation: number,
+		epoch: number,
+		timestamp: string,
+	): Promise<void> {
+		const current = this.captures.get(job);
+		if (
+			this.workers.get(job) !== generation ||
+			current?.generation !== generation ||
+			current.epoch !== epoch
+		)
+			throw new Error('capture epoch is unavailable');
+		if (current.timestamp) {
+			if (current.timestamp === timestamp) return;
+			throw new Error('conflicting capture timestamp');
+		}
+		current.timestamp = timestamp;
+		this.captureStarts.push({ job, generation, epoch, timestamp });
+	}
+	async cancelCapture(
+		job: string,
+		generation: number,
+		epoch: number,
+	): Promise<void> {
+		const current = this.captures.get(job);
+		if (current?.generation === generation && current.epoch === epoch)
+			this.captures.delete(job);
+	}
 	async stop(job: string, generation?: number): Promise<void> {
 		if (generation !== undefined && this.workers.get(job) !== generation)
 			return;
 		this.stopped.add(job);
 		this.workers.delete(job);
+		this.captures.delete(job);
 	}
 }

--- a/suite/meet/recorder-server/src/app.ts
+++ b/suite/meet/recorder-server/src/app.ts
@@ -24,6 +24,7 @@ const HEALTH_REASON_CODES = new Set([
 	'media_attachment_failed',
 	'media_subscription_failed',
 	'page_crashed',
+	'projection_invalid',
 	'quota_limit',
 	'receive_transport_failed',
 	'room_empty',

--- a/suite/meet/recorder-server/src/captureTypes.ts
+++ b/suite/meet/recorder-server/src/captureTypes.ts
@@ -42,8 +42,12 @@ export interface CaptureArtifact {
 	duration_ms: number;
 }
 
-export interface CaptureManifest {
-	version: 1;
+export interface CaptureEpoch {
+	epoch: number;
+	capture_started_at: string;
+}
+
+interface CaptureManifestBase {
 	revision: number;
 	job: string;
 	state: CaptureState;
@@ -53,6 +57,10 @@ export interface CaptureManifest {
 	artifact?: CaptureArtifact;
 	reason?: string;
 }
+
+export type CaptureManifest =
+	| (CaptureManifestBase & { version: 1; capture_epochs?: CaptureEpoch[] })
+	| (CaptureManifestBase & { version: 2; capture_epochs: CaptureEpoch[] });
 
 export interface MediaProbe {
 	duration_ms: number;

--- a/suite/meet/recorder-server/src/core.test.ts
+++ b/suite/meet/recorder-server/src/core.test.ts
@@ -832,14 +832,166 @@ describe('JobStore and JobManager', () => {
 		expect(restartedBridge.recoverStopping).toHaveBeenCalledWith('job');
 		expect(restarted.activeCount).toBe(0);
 		expect(reloaded.get('job')).toMatchObject({
-			state: 'partial',
+			state: 'failed',
 			captured_bytes: 42,
-			health_reason: 'worker_missing_after_restart',
-			artifact: { state: 'partial', path: 'recording.mp4' },
+			health_reason: 'capture_not_committed',
 		});
-		expect(restarted.query(baseClaims)?.state).toBe('partial');
+		expect(restarted.query(baseClaims)?.state).toBe('failed');
 		expect(terminal).toHaveBeenCalledWith(
-			expect.objectContaining({ state: 'partial' }),
+			expect.objectContaining({ state: 'failed' }),
+		);
+		expect(terminal.mock.calls[0]?.[0]).not.toHaveProperty('artifact');
+	});
+
+	it('adopts a durable capture start before restart terminalization without duplication', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		const firstBridge = new FakeRendererBridge();
+		const first = new JobManager(store, firstBridge, 1);
+		await first.reserve(baseClaims);
+		await firstBridge.emit({
+			job: 'job',
+			type: 'configured',
+			occurredAt: '2026-08-30T11:59:57.000Z',
+		});
+		await firstBridge.emit({
+			job: 'job',
+			type: 'proof_complete',
+			occurredAt: '2026-08-30T11:59:58.000Z',
+		});
+		await firstBridge.emit({
+			job: 'job',
+			type: 'joined',
+			occurredAt: '2026-08-30T11:59:59.000Z',
+		});
+		const reloaded = new JobStore(path);
+		await reloaded.initialize();
+		const captureStartedAt = '2026-08-30T12:00:00.123Z';
+		const restartedBridge = Object.assign(new FakeRendererBridge(), {
+			recoverStopping: vi.fn(async () => ({
+				type: 'failed' as const,
+				gaps: [],
+				capturedBytes: 0,
+				captureStartedAt,
+			})),
+		});
+		const startup = vi.fn(async () => undefined);
+		const terminal = vi.fn(async () => undefined);
+		await new JobManager(
+			reloaded,
+			restartedBridge,
+			1,
+			terminal,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			startup,
+		).initialize();
+
+		expect(startup).toHaveBeenCalledOnce();
+		expect(startup).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: 'capture_ready',
+				capture_started_at: captureStartedAt,
+			}),
+		);
+		expect(startup).toHaveBeenCalledBefore(terminal);
+		expect(reloaded.get('job')).toMatchObject({
+			state: 'failed',
+			capture_started_at: captureStartedAt,
+		});
+
+		const again = new JobStore(path);
+		await again.initialize();
+		const duplicateStartup = vi.fn(async () => undefined);
+		await new JobManager(
+			again,
+			new FakeRendererBridge(),
+			1,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			duplicateStartup,
+		).initialize();
+		expect(duplicateStartup).not.toHaveBeenCalled();
+	});
+
+	it('replays a persisted capture startup before restart terminal publication', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		const firstBridge = new FakeRendererBridge();
+		const first = new JobManager(store, firstBridge, 1);
+		await first.reserve(baseClaims);
+		for (const type of ['configured', 'proof_complete', 'joined'] as const)
+			await firstBridge.emit({ job: 'job', type });
+		const captureStartedAt = '2026-08-30T12:00:00.123Z';
+		await firstBridge.emit({
+			job: 'job',
+			type: 'capture_ready',
+			occurredAt: captureStartedAt,
+		});
+
+		const reloaded = new JobStore(path);
+		await reloaded.initialize();
+		const restartedBridge = Object.assign(new FakeRendererBridge(), {
+			recoverStopping: vi.fn(async () => ({
+				type: 'failed' as const,
+				capturedBytes: 0,
+				captureStartedAt,
+			})),
+		});
+		const startup = vi.fn(async () => undefined);
+		const terminal = vi.fn(async () => undefined);
+		await new JobManager(
+			reloaded,
+			restartedBridge,
+			1,
+			terminal,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			startup,
+		).initialize();
+
+		expect(startup).toHaveBeenCalledWith(
+			expect.objectContaining({
+				state: 'capture_ready',
+				capture_started_at: captureStartedAt,
+			}),
+		);
+		expect(startup).toHaveBeenCalledBefore(terminal);
+	});
+
+	it('cannot publish a terminal artifact before capture commits', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		const bridge = new FakeRendererBridge();
+		const terminal = vi.fn(async () => undefined);
+		const manager = new JobManager(store, bridge, 1, terminal);
+		await manager.reserve(baseClaims);
+
+		await bridge.emit({
+			job: 'job',
+			type: 'complete',
+			artifact: {
+				file: 'recording.mp4',
+				bytes: 42,
+				sha256: 'a'.repeat(64),
+				duration_ms: 1_000,
+			},
+		});
+
+		expect(store.get('job')).toMatchObject({
+			state: 'failed',
+			health_reason: 'capture_not_committed',
+		});
+		expect(store.get('job')).not.toHaveProperty('artifact');
+		expect(terminal).toHaveBeenCalledWith(
+			expect.objectContaining({ state: 'failed' }),
 		);
 	});
 
@@ -1058,6 +1210,15 @@ describe('JobStore and JobManager', () => {
 			const bridge = new FakeRendererBridge();
 			const manager = new JobManager(store, bridge, 1);
 			await manager.reserve(baseClaims);
+			if (outcome !== 'failed') {
+				for (const type of [
+					'configured',
+					'proof_complete',
+					'joined',
+					'capture_ready',
+				] as const)
+					await bridge.emit({ job: 'job', type });
+			}
 			await bridge.emit({ job: 'job', type: outcome, reason: 'final' });
 			await bridge.emit({ job: 'job', type: 'configured', reason: 'delayed' });
 			await bridge.emit({ job: 'job', type: 'failed', reason: 'delayed' });
@@ -1077,6 +1238,13 @@ describe('JobStore and JobManager', () => {
 		const bridge = new FakeRendererBridge();
 		const manager = new JobManager(store, bridge, 1);
 		await manager.reserve(baseClaims);
+		for (const type of [
+			'configured',
+			'proof_complete',
+			'joined',
+			'capture_ready',
+		] as const)
+			await bridge.emit({ job: 'job', type });
 		await bridge.emit({ job: 'job', type: 'complete' });
 
 		const reloaded = new JobStore(path);
@@ -1108,6 +1276,13 @@ describe('JobStore and JobManager', () => {
 			async () => undefined,
 		);
 		await manager.reserve(baseClaims);
+		for (const type of [
+			'configured',
+			'proof_complete',
+			'joined',
+			'capture_ready',
+		] as const)
+			await bridge.emit({ job: 'job', type });
 
 		await bridge.emit({ job: 'job', type: 'complete' });
 
@@ -1176,6 +1351,13 @@ describe('JobStore and JobManager', () => {
 		const bridge = new FakeRendererBridge();
 		const manager = new JobManager(store, bridge, 1);
 		await manager.reserve(baseClaims);
+		for (const type of [
+			'configured',
+			'proof_complete',
+			'joined',
+			'capture_ready',
+		] as const)
+			await bridge.emit({ job: 'job', type });
 		await manager.stop(baseClaims, 'stop-1');
 
 		const reloaded = new JobStore(path);
@@ -1221,6 +1403,13 @@ describe('JobStore and JobManager', () => {
 		const bridge = new FakeRendererBridge();
 		const manager = new JobManager(store, bridge, 1);
 		await manager.reserve(baseClaims);
+		for (const type of [
+			'configured',
+			'proof_complete',
+			'joined',
+			'capture_ready',
+		] as const)
+			await bridge.emit({ job: 'job', type });
 		await bridge.emit({ job: 'job', type: 'partial', reason: 'capture_gap' });
 		await bridge.emit({ job: 'job', type: 'complete' });
 		expect(store.get('job')).toMatchObject({

--- a/suite/meet/recorder-server/src/integration/RecorderSharedStage.integration.ts
+++ b/suite/meet/recorder-server/src/integration/RecorderSharedStage.integration.ts
@@ -1,0 +1,564 @@
+import { type ChildProcess, spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import jwt from 'jsonwebtoken';
+import { io, type Socket } from 'socket.io-client';
+import { CaptureWorker } from '../CaptureWorker.js';
+import {
+	ChromiumRendererBridge,
+	type RendererLifecycleEvent,
+} from '../RendererBridge.js';
+import type { CommandClaims, PublicJwk } from '../types.js';
+
+const outputRoot = process.env.OUTPUT_ROOT ?? '/output';
+const scenarioRoot = join(outputRoot, 'shared-stage');
+const sfuOrigin = process.env.SFU_ORIGIN ?? 'http://sfu:3000';
+const mediaHost = process.env.SFU_MEDIA_HOST ?? 'sfu';
+const secret = process.env.JWT_SECRET ?? 'integration-secret';
+const site = 'integration.local';
+const room = 'adr-0011';
+const job = 'integration-shared-stage';
+const producerId = 'producer@example.com';
+const started = performance.now();
+const socketTimeoutMs = 10_000;
+
+type PlainTransport = { id: string; port: number };
+type Producer = { id: string };
+
+function waitForEvent(
+	events: RendererLifecycleEvent[],
+	type: RendererLifecycleEvent['type'],
+	timeoutMs = 30_000,
+): Promise<RendererLifecycleEvent> {
+	return new Promise((resolve, reject) => {
+		const deadline = Date.now() + timeoutMs;
+		const poll = () => {
+			const event = events.find((item) => item.type === type);
+			if (event) resolve(event);
+			else if (Date.now() >= deadline)
+				reject(new Error(`timed out waiting for renderer ${type}`));
+			else setTimeout(poll, 100);
+		};
+		poll();
+	});
+}
+
+function request<T>(socket: Socket, event: string, data: object): Promise<T> {
+	return new Promise((resolve, reject) => {
+		const timeout = setTimeout(
+			() => reject(new Error(`timed out waiting for ${event} acknowledgement`)),
+			socketTimeoutMs,
+		);
+		socket.emit(
+			event,
+			data,
+			(response: T & { success?: boolean; error?: string }) => {
+				clearTimeout(timeout);
+				response?.success === false
+					? reject(new Error(response.error || `${event} failed`))
+					: resolve(response);
+			},
+		);
+	});
+}
+
+function connect(socket: Socket): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const cleanup = () => {
+			clearTimeout(timeout);
+			socket.off('connect', connected);
+			socket.off('connect_error', failed);
+		};
+		const connected = () => {
+			cleanup();
+			resolve();
+		};
+		const failed = (error: Error) => {
+			cleanup();
+			reject(error);
+		};
+		const timeout = setTimeout(() => {
+			cleanup();
+			reject(new Error('timed out connecting producer to SFU'));
+		}, socketTimeoutMs);
+		socket.once('connect', connected);
+		socket.once('connect_error', failed);
+	});
+}
+
+function run(
+	program: string,
+	args: string[],
+): Promise<{ stdout: string; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(program, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		let stdout = '';
+		let stderr = '';
+		child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+		child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+		child.once('error', reject);
+		child.once('exit', (code) =>
+			code === 0
+				? resolve({ stdout, stderr })
+				: reject(
+						new Error(`${program} exited ${code}: ${stderr.slice(-2000)}`),
+					),
+		);
+	});
+}
+
+function runBuffer(
+	program: string,
+	args: string[],
+): Promise<{ stdout: Buffer; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(program, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+		const stdout: Buffer[] = [];
+		let stderr = '';
+		child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk));
+		child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+		child.once('error', reject);
+		child.once('exit', (code) =>
+			code === 0
+				? resolve({ stdout: Buffer.concat(stdout), stderr })
+				: reject(
+						new Error(`${program} exited ${code}: ${stderr.slice(-2000)}`),
+					),
+		);
+	});
+}
+
+function startFfmpeg(args: string[]): ChildProcess {
+	const child = spawn(
+		'/usr/bin/ffmpeg',
+		['-hide_banner', '-loglevel', 'warning', ...args],
+		{ stdio: ['ignore', 'ignore', 'pipe'] },
+	);
+	let diagnostics = '';
+	child.stderr?.on('data', (chunk) => (diagnostics += String(chunk)));
+	child.once('exit', (code) => {
+		if (code && code !== 255)
+			console.error(
+				`producer FFmpeg exited ${code}: ${diagnostics.slice(-1000)}`,
+			);
+	});
+	return child;
+}
+
+function assertProducerProcessesAlive(
+	processes: ChildProcess[],
+	phase: string,
+) {
+	for (const [index, process] of processes.entries()) {
+		if (process.exitCode !== null || process.signalCode !== null) {
+			throw new Error(
+				`producer FFmpeg ${index} exited before ${phase} ` +
+					`(code=${process.exitCode}, signal=${process.signalCode})`,
+			);
+		}
+	}
+}
+
+function waitForProcessExit(
+	process: ChildProcess,
+	timeoutMs: number,
+): Promise<boolean> {
+	if (process.exitCode !== null || process.signalCode !== null)
+		return Promise.resolve(true);
+	return new Promise((resolve) => {
+		const exited = () => {
+			clearTimeout(timeout);
+			resolve(true);
+		};
+		const timeout = setTimeout(() => {
+			process.off('exit', exited);
+			resolve(false);
+		}, timeoutMs);
+		process.once('exit', exited);
+		if (process.exitCode !== null || process.signalCode !== null) exited();
+	});
+}
+
+async function stopProducerProcess(process: ChildProcess): Promise<void> {
+	if (process.exitCode !== null || process.signalCode !== null) return;
+	process.kill('SIGTERM');
+	if (await waitForProcessExit(process, 5_000)) return;
+	process.kill('SIGKILL');
+	if (!(await waitForProcessExit(process, 5_000)))
+		throw new Error(`producer FFmpeg ${process.pid ?? 'unknown'} did not exit`);
+}
+
+function thumbprint(jwk: PublicJwk): string {
+	return createHash('sha256')
+		.update(JSON.stringify({ crv: 'P-256', kty: 'EC', x: jwk.x, y: jwk.y }))
+		.digest('base64url');
+}
+
+function recordingGrant(publicJwk: PublicJwk): string {
+	const now = Math.floor(Date.now() / 1000);
+	return jwt.sign(
+		{
+			protocol_version: 1,
+			iss: `frappe-site:${site}`,
+			aud: 'meet-sfu-recorder',
+			scope: 'recording',
+			jti: `grant-${Date.now()}`,
+			site,
+			meeting_id: room,
+			recording_id: 'recording-shared-stage',
+			recorder_job_id: job,
+			cnf: { jwk: publicJwk, jkt: thumbprint(publicJwk) },
+			iat: now,
+			exp: now + 300,
+			authorization_expires_at: now + 300,
+		},
+		secret,
+		{
+			algorithm: 'HS256',
+			header: { alg: 'HS256', typ: 'meet-recording-grant+jwt' },
+		},
+	);
+}
+
+async function startProducer(): Promise<{
+	socket: Socket;
+	processes: ChildProcess[];
+	producerIds: string[];
+}> {
+	const now = Math.floor(Date.now() / 1000);
+	const token = jwt.sign(
+		{
+			user_id: producerId,
+			user_name: 'Pattern Producer',
+			meeting_id: room,
+			is_host: true,
+			scope: 'full',
+			site,
+			iat: now,
+			exp: now + 600,
+		},
+		secret,
+	);
+	const socket = io(sfuOrigin, {
+		auth: { token },
+		transports: ['websocket'],
+		reconnection: false,
+		timeout: socketTimeoutMs,
+	});
+	await connect(socket);
+	await request(socket, 'join_room', {
+		roomId: room,
+		connectionId: 'producer-connection',
+		userData: { name: 'Pattern Producer', userId: producerId },
+		mediaState: { audio_enabled: true, video_enabled: true },
+	});
+	const audioTransport = await request<PlainTransport>(
+		socket,
+		'create_plain_transport',
+		{},
+	);
+	const videoTransport = await request<PlainTransport>(
+		socket,
+		'create_plain_transport',
+		{},
+	);
+	const audio = await request<Producer>(socket, 'create_producer', {
+		transportId: audioTransport.id,
+		kind: 'audio',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'audio/opus',
+					clockRate: 48000,
+					payloadType: 111,
+					channels: 2,
+				},
+			],
+			encodings: [{ ssrc: 111111 }],
+		},
+		appData: { source: 'mic' },
+	});
+	const video = await request<Producer>(socket, 'create_producer', {
+		transportId: videoTransport.id,
+		kind: 'video',
+		rtpParameters: {
+			codecs: [{ mimeType: 'video/VP8', clockRate: 90000, payloadType: 96 }],
+			encodings: [{ ssrc: 222222 }],
+		},
+		appData: { source: 'webcam' },
+	});
+	const processes = [
+		startFfmpeg([
+			'-re',
+			'-f',
+			'lavfi',
+			'-i',
+			'sine=frequency=997:sample_rate=48000',
+			'-ac',
+			'2',
+			'-c:a',
+			'libopus',
+			'-b:a',
+			'96k',
+			'-payload_type',
+			'111',
+			'-ssrc',
+			'111111',
+			'-f',
+			'rtp',
+			`rtp://${mediaHost}:${audioTransport.port}?pkt_size=1200`,
+		]),
+		startFfmpeg([
+			'-re',
+			'-f',
+			'lavfi',
+			'-i',
+			"color=c=red:size=640x360:rate=30,drawbox=color=blue:t=fill:enable='gte(mod(t\\,2)\\,1)'",
+			'-c:v',
+			'libvpx',
+			'-deadline',
+			'realtime',
+			'-cpu-used',
+			'8',
+			'-g',
+			'30',
+			'-b:v',
+			'800k',
+			'-payload_type',
+			'96',
+			'-ssrc',
+			'222222',
+			'-f',
+			'rtp',
+			`rtp://${mediaHost}:${videoTransport.port}?pkt_size=1200`,
+		]),
+	];
+	await new Promise((resolve) => setTimeout(resolve, 1500));
+	assertProducerProcessesAlive(processes, 'recorder startup');
+	return { socket, processes, producerIds: [audio.id, video.id] };
+}
+
+await rm(scenarioRoot, { recursive: true, force: true });
+await mkdir(scenarioRoot, { recursive: true });
+const events: RendererLifecycleEvent[] = [];
+let producer: Awaited<ReturnType<typeof startProducer>> | undefined;
+let bridge: ChromiumRendererBridge | undefined;
+let worker: CaptureWorker | undefined;
+const renderer = (): ChromiumRendererBridge => {
+	if (!bridge) throw new Error('renderer bridge is not initialized');
+	return bridge;
+};
+try {
+	producer = await startProducer();
+	worker = new CaptureWorker(job, {
+		dataRoot: scenarioRoot,
+		display: 93,
+		segmentSeconds: 2,
+		ffmpeg: '/usr/bin/ffmpeg',
+		xvfb: '/usr/bin/Xvfb',
+		pulseaudio: '/usr/bin/pulseaudio',
+		pactl: '/usr/bin/pactl',
+		gracefulTimeoutMs: 10_000,
+		recoveryTimeoutMs: 20_000,
+		onCapturePreparing: (epoch) => renderer().prepareCapture(job, 0, epoch),
+		onCaptureLaunched: (launch) =>
+			renderer().captureStarted(
+				job,
+				0,
+				launch.epoch,
+				launch.capture_started_at,
+			),
+		onCaptureAborted: (epoch) => renderer().cancelCapture(job, 0, epoch),
+	});
+	await worker.initialize();
+	const workerEnvironment = worker.env;
+	bridge = new ChromiumRendererBridge({
+		executablePath: '/usr/bin/chromium',
+		assetDirectory: '/app/renderer',
+		sfuOrigin,
+		sfuSocketPath: '/socket.io',
+		trustedCommandOrigin: 'http://integration.local',
+		listenerPort: 0,
+		noSandbox: true,
+		reserveTimeoutMs: 30_000,
+		configureTimeoutMs: 30_000,
+		workerEnvironment: () => workerEnvironment,
+	});
+	bridge.onLifecycle(async (event) => {
+		events.push(event);
+	});
+	await bridge.initialize();
+	const now = Math.floor(Date.now() / 1000);
+	const command: CommandClaims = {
+		protocol_version: 1,
+		iss: `frappe-site:${site}`,
+		aud: 'meet-recorder-control',
+		site,
+		origin: 'http://integration.local',
+		room,
+		recording: 'recording-shared-stage',
+		job,
+		operation: 'reserve',
+		limits: {
+			budget_bytes: 100_000_000,
+			max_ends_at: new Date(Date.now() + 300_000).toISOString(),
+			output: {
+				width: 1920,
+				height: 1080,
+				fps: 30,
+				video: 'h264',
+				audio: 'aac',
+			},
+		},
+		jti: 'command-shared-stage',
+		iat: now,
+		exp: now + 300,
+	};
+	const publicJwk = await bridge.reserve(command);
+	await bridge.deliverGrant(
+		job,
+		recordingGrant(publicJwk),
+		new Date().toISOString(),
+		0,
+	);
+	await waitForEvent(events, 'capture_ready');
+	await worker.startCapture();
+	const segmentDeadline = Date.now() + 30_000;
+	while (worker.manifest.get().segments.length < 3) {
+		if (Date.now() >= segmentDeadline)
+			throw new Error('timed out waiting for three captured segments');
+		await new Promise((resolve) => setTimeout(resolve, 200));
+	}
+	assertProducerProcessesAlive(producer.processes, 'artifact finalization');
+	const state = await worker.stop();
+	assertProducerProcessesAlive(producer.processes, 'capture completion');
+	if (state !== 'complete')
+		throw new Error(`expected complete artifact, got ${state}`);
+	const manifest = worker.manifest.get();
+	const artifact = join(
+		worker.manifest.directory,
+		manifest.artifact?.file ?? '',
+	);
+	const decoded = await run('/usr/bin/ffmpeg', [
+		'-v',
+		'warning',
+		'-i',
+		artifact,
+		'-f',
+		'null',
+		'-',
+	]);
+	if (decoded.stderr.trim())
+		throw new Error(`artifact decode warning: ${decoded.stderr.slice(-2000)}`);
+	const frames = await runBuffer('/usr/bin/ffmpeg', [
+		'-v',
+		'error',
+		'-i',
+		artifact,
+		'-vf',
+		'crop=64:64:(iw-64)/2:(ih-64)/2,fps=4,scale=1:1,format=rgb24',
+		'-f',
+		'rawvideo',
+		'-',
+	]);
+	const centerSamples = Array.from(
+		{ length: Math.floor(frames.stdout.length / 3) },
+		(_, index) => [...frames.stdout.subarray(index * 3, index * 3 + 3)],
+	);
+	const redFrames = centerSamples.filter(
+		([red = 0, green = 0, blue = 0]) =>
+			red > 120 && red > green * 1.5 && red > blue * 1.5,
+	).length;
+	const blueFrames = centerSamples.filter(
+		([red = 0, green = 0, blue = 0]) =>
+			blue > 120 && blue > green * 1.5 && blue > red * 1.5,
+	).length;
+	if (redFrames === 0 || blueFrames === 0)
+		throw new Error(
+			`central MeetingLayout samples did not contain both producer colors ` +
+				`(red=${redFrames}, blue=${blueFrames}, total=${centerSamples.length})`,
+		);
+	const frequencyEnergy = await run('/usr/bin/ffmpeg', [
+		'-v',
+		'error',
+		'-i',
+		artifact,
+		'-vn',
+		'-af',
+		'bandpass=f=997:width_type=h:w=120,asetnsamples=n=24000:pad=1,astats=metadata=1:reset=1,ametadata=print:file=-',
+		'-f',
+		'null',
+		'-',
+	]);
+	let sampleTime = 0;
+	const energySamples: Array<{ time: number; rms: number }> = [];
+	for (const line of frequencyEnergy.stdout.split('\n')) {
+		const timestamp = /pts_time:([\d.]+)/.exec(line)?.[1];
+		if (timestamp !== undefined) sampleTime = Number(timestamp);
+		const rms = /lavfi\.astats\.Overall\.RMS_level=(-?[\d.]+|-inf)/.exec(
+			line,
+		)?.[1];
+		if (rms !== undefined) {
+			energySamples.push({
+				time: sampleTime,
+				rms: rms === '-inf' ? Number.NEGATIVE_INFINITY : Number(rms),
+			});
+		}
+	}
+	const durationSeconds = (manifest.artifact?.duration_ms ?? 0) / 1000;
+	if (durationSeconds <= 0)
+		throw new Error('artifact duration is missing from the capture manifest');
+	const energeticSamples = energySamples.filter(({ rms }) => rms > -50);
+	const energeticRatio = energeticSamples.length / energySamples.length;
+	const coveredQuarters = Array.from({ length: 4 }, (_, quarter) =>
+		energeticSamples.some(
+			({ time }) =>
+				time >= (durationSeconds * quarter) / 4 &&
+				time <= (durationSeconds * (quarter + 1)) / 4,
+		),
+	).filter(Boolean).length;
+	if (energySamples.length < 4 || energeticRatio < 0.7 || coveredQuarters !== 4)
+		throw new Error(
+			`997 Hz energy was not sustained across the artifact ` +
+				`(energetic=${energeticSamples.length}/${energySamples.length}, quarters=${coveredQuarters}/4)`,
+		);
+	const result = {
+		state,
+		elapsed_ms: Math.round(performance.now() - started),
+		artifact,
+		artifact_bytes: manifest.artifact?.bytes,
+		duration_ms: manifest.artifact?.duration_ms,
+		segments: manifest.segments.length,
+		producer_ids: producer.producerIds,
+		producer_ingress:
+			'development-only plain RTP test injection; production media uses WebRTC',
+		center_samples: centerSamples.length,
+		red_dominant_samples: redFrames,
+		blue_dominant_samples: blueFrames,
+		frequency_hz: 997,
+		frequency_energy_samples: energySamples.length,
+		frequency_energetic_samples: energeticSamples.length,
+		frequency_covered_quarters: coveredQuarters,
+		decode_warnings: 0,
+	};
+	await writeFile(
+		join(scenarioRoot, 'result.json'),
+		`${JSON.stringify(result, null, 2)}\n`,
+	);
+	console.log(JSON.stringify(result));
+} finally {
+	await Promise.all(
+		(producer?.processes ?? []).map((process) => stopProducerProcess(process)),
+	).catch((error) => console.error('producer FFmpeg cleanup failed', error));
+	producer?.socket.disconnect();
+	await bridge?.stop(job).catch(() => undefined);
+	await bridge?.close().catch(() => undefined);
+	if (
+		worker &&
+		!['complete', 'partial', 'failed'].includes(worker.manifest.get().state)
+	)
+		await worker
+			.stop(true, 'integration_harness_failed')
+			.catch(() => undefined);
+}

--- a/suite/meet/recorder-server/yarn.lock
+++ b/suite/meet/recorder-server/yarn.lock
@@ -795,6 +795,17 @@ end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
+engine.io-client@~6.6.1:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.6.6.tgz#8a8f1e451b1f6d4acf413305445e42133d1cbe9a"
+  integrity sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.21.0"
+    xmlhttprequest-ssl "~2.1.1"
+
 engine.io-parser@~5.2.1:
   version "5.2.3"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.3.tgz#00dc5b97b1f233a23c9398d0209504cf5f94d92f"
@@ -1696,6 +1707,16 @@ socket.io-adapter@~2.5.2:
     debug "~4.4.1"
     ws "~8.21.0"
 
+socket.io-client@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.8.3.tgz#62717edd46a318c918125b57e92dc7f8bb71c34c"
+  integrity sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-client "~6.6.1"
+    socket.io-parser "~4.2.4"
+
 socket.io-parser@~4.2.4:
   version "4.2.7"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.7.tgz#679e51fe24d1c81df90fc5f7efe4a5f432fe99c0"
@@ -1979,6 +2000,11 @@ ws@^8.20.0, ws@~8.21.0:
   version "8.21.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
   integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
+
+xmlhttprequest-ssl@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz#e9e8023b3f29ef34b97a859f584c5e6c61418e23"
+  integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==
 
 y18n@^5.0.5:
   version "5.0.8"

--- a/suite/meet/recording/callback_auth.py
+++ b/suite/meet/recording/callback_auth.py
@@ -102,6 +102,7 @@ INTERRUPTION_REASON_CODES = {
     "media_attachment_failed",
     "media_subscription_failed",
     "page_crashed",
+    "projection_invalid",
     "receive_transport_failed",
     "sfu_disconnected",
 }

--- a/suite/meet/recording/contracts/v1.json
+++ b/suite/meet/recording/contracts/v1.json
@@ -29,6 +29,7 @@
       "media_attachment_failed",
       "media_subscription_failed",
       "page_crashed",
+      "projection_invalid",
       "quota_limit",
       "receive_transport_failed",
       "room_empty",
@@ -45,6 +46,7 @@
       "media_attachment_failed",
       "media_subscription_failed",
       "page_crashed",
+      "projection_invalid",
       "receive_transport_failed",
       "sfu_disconnected"
     ],
@@ -53,9 +55,23 @@
       "media_attachment_failed",
       "media_subscription_failed",
       "receive_transport_failed",
+      "projection_invalid",
       "configuration_failed",
       "browser_disconnected",
       "page_crashed"
+    ],
+    "recorder_stage_projection_payload_types": [
+      "participant_joined",
+      "participant_updated",
+      "participant_left",
+      "producer_created",
+      "producer_updated",
+      "producer_closed",
+      "media_control",
+      "active_speaker",
+      "hand_raised",
+      "reaction",
+      "chat_message"
     ],
     "callback_failure_reason_codes": [
       "capture_failed",
@@ -242,6 +258,39 @@
       "required": ["config", "protocol_version", "type"],
       "optional": []
     },
+    "recorder_stage_snapshot": {
+      "required": [
+        "active_speaker_ids",
+        "cursor",
+        "observed_at",
+        "participants",
+        "producers",
+        "protocol_version",
+        "raised_hands",
+        "room_id"
+      ],
+      "optional": []
+    },
+    "recorder_stage_projection_event": {
+      "required": ["cursor", "observed_at", "payload", "protocol_version", "room_id"],
+      "optional": []
+    },
+    "renderer_prepare_capture": {
+      "required": ["epoch", "job", "protocol_version", "type"],
+      "optional": []
+    },
+    "renderer_capture_started": {
+      "required": ["capture_started_at", "epoch", "job", "protocol_version", "type"],
+      "optional": []
+    },
+    "renderer_capture_prepared": {
+      "required": ["epoch", "job", "occurred_at", "protocol_version", "type"],
+      "optional": []
+    },
+    "renderer_capture_started_accepted": {
+      "required": ["capture_started_at", "epoch", "job", "occurred_at", "protocol_version", "type"],
+      "optional": []
+    },
     "renderer_lifecycle": {
       "required": ["job", "occurred_at", "protocol_version", "type"],
       "optional": []
@@ -378,6 +427,13 @@
           "job": "job-vector",
           "occurred_at": "2026-08-30T12:00:00.000Z",
           "reason_code": "receive_transport_failed"
+        },
+        {
+          "type": "suite-recorder:interruption",
+          "protocol_version": 1,
+          "job": "job-vector",
+          "occurred_at": "2026-08-30T12:00:00.000Z",
+          "reason_code": "projection_invalid"
         },
         {
           "type": "suite-recorder:failure",
@@ -607,6 +663,93 @@
         { "type": "suite-recorder:configure", "protocol_version": 1, "config": { "job": "job-vector" }, "unknown": true }
       ]
     },
+    "recorder_stage_snapshots": {
+      "accepted": [{
+        "protocol_version": 1,
+        "room_id": "room-vector",
+        "cursor": 0,
+        "observed_at": "2026-08-30T12:00:00.000Z",
+        "participants": [{ "participant_id": "participant-vector", "name": "Participant Vector", "avatar": "https://site.test/avatar.png", "audio_enabled": true, "video_enabled": false }],
+        "producers": [{ "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "video", "paused": false, "is_screen": true, "observed_at": "2026-08-30T12:00:00.000Z" }],
+        "raised_hands": { "participant-vector": "2026-08-30T12:00:00.000Z" },
+        "active_speaker_ids": ["participant-vector"]
+      }],
+      "rejected": [
+        { "protocol_version": 1, "room_id": "", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": -1, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00Z", "participants": [], "producers": [], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "", "name": "Participant Vector", "audio_enabled": true, "video_enabled": false }], "producers": [], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [{ "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "data", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.000Z" }], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [], "raised_hands": {}, "active_speaker_ids": [], "unknown": true },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "participant-vector", "name": "One", "audio_enabled": true, "video_enabled": true }, { "participant_id": "participant-vector", "name": "Two", "audio_enabled": true, "video_enabled": true }], "producers": [], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [{ "producer_id": "producer-vector", "participant_id": "missing", "kind": "video", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.000Z" }], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "participant-vector", "name": "Participant", "audio_enabled": true, "video_enabled": true }], "producers": [{ "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "audio", "paused": false, "is_screen": true, "observed_at": "2026-08-30T12:00:00.000Z" }], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "participant-vector", "name": "Participant", "audio_enabled": true, "video_enabled": true }], "producers": [{ "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "video", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.000Z" }, { "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "audio", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.000Z" }], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "participant-vector", "name": "Participant", "audio_enabled": true, "video_enabled": true }], "producers": [{ "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "video", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.001Z" }], "raised_hands": {}, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [], "raised_hands": { "missing": "2026-08-30T12:00:00.000Z" }, "active_speaker_ids": [] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [], "producers": [], "raised_hands": {}, "active_speaker_ids": ["missing"] },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "participants": [{ "participant_id": "participant-vector", "name": "Participant", "audio_enabled": true, "video_enabled": true }], "producers": [], "raised_hands": {}, "active_speaker_ids": ["participant-vector", "participant-vector"] }
+      ]
+    },
+    "recorder_stage_projection_events": {
+      "accepted": [
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "participant_joined", "participant": { "participant_id": "participant-vector", "name": "Participant Vector", "audio_enabled": true, "video_enabled": false } } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 2, "observed_at": "2026-08-30T12:00:00.001Z", "payload": { "type": "participant_updated", "participant": { "participant_id": "participant-vector", "name": "Participant Updated", "audio_enabled": false, "video_enabled": true } } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 2, "observed_at": "2026-08-30T12:00:00.001Z", "payload": { "type": "participant_left", "participant_id": "participant-vector" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 3, "observed_at": "2026-08-30T12:00:00.002Z", "payload": { "type": "producer_created", "producer": { "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "audio", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.002Z" } } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 4, "observed_at": "2026-08-30T12:00:00.003Z", "payload": { "type": "producer_updated", "producer_id": "producer-vector", "paused": true } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 4, "observed_at": "2026-08-30T12:00:00.003Z", "payload": { "type": "producer_closed", "producer_id": "producer-vector", "participant_id": "participant-vector", "is_screen": false } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 5, "observed_at": "2026-08-30T12:00:00.004Z", "payload": { "type": "media_control", "participant_id": "participant-vector", "action": "mute" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 6, "observed_at": "2026-08-30T12:00:00.005Z", "payload": { "type": "active_speaker", "participant_ids": ["participant-vector"] } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 7, "observed_at": "2026-08-30T12:00:00.006Z", "payload": { "type": "hand_raised", "participant_id": "participant-vector", "raised": true } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 8, "observed_at": "2026-08-30T12:00:00.007Z", "payload": { "type": "reaction", "from_user": "participant-vector", "reaction": "thumbs_up" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 9, "observed_at": "2026-08-30T12:00:00.008Z", "payload": { "type": "chat_message", "message_id": "message-vector", "message": "Hello", "from_user": "participant-vector", "from_name": "Participant Vector" } }
+      ],
+      "rejected": [
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "unknown" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "participant_left", "participant_id": "participant-vector" }, "unknown": true },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 0, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "participant_left", "participant_id": "participant-vector" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00Z", "payload": { "type": "participant_left", "participant_id": "participant-vector" } },
+        { "protocol_version": 1, "room_id": "", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "participant_left", "participant_id": "participant-vector" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "participant_joined", "participant": { "participant_id": "", "name": "Participant Vector", "audio_enabled": true, "video_enabled": false } } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "producer_created", "producer": { "producer_id": "", "participant_id": "participant-vector", "kind": "video", "paused": false, "is_screen": false, "observed_at": "2026-08-30T12:00:00.000Z" } } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "producer_updated", "producer_id": "producer-vector", "paused": "yes" } },
+        { "protocol_version": 1, "room_id": "room-vector", "cursor": 1, "observed_at": "2026-08-30T12:00:00.000Z", "payload": { "type": "producer_created", "producer": { "producer_id": "producer-vector", "participant_id": "participant-vector", "kind": "audio", "paused": false, "is_screen": true, "observed_at": "2026-08-30T12:00:00.000Z" } } }
+      ]
+    },
+    "renderer_prepare_capture": {
+      "accepted": [{ "type": "suite-recorder:prepare-capture", "protocol_version": 1, "job": "job-vector", "epoch": 0 }],
+      "rejected": [
+        { "type": "suite-recorder:prepare-capture", "protocol_version": 2, "job": "job-vector", "epoch": 0 },
+        { "type": "suite-recorder:prepare-capture", "protocol_version": 1, "job": "", "epoch": 0 },
+        { "type": "suite-recorder:prepare-capture", "protocol_version": 1, "job": "job-vector", "epoch": -1 },
+        { "type": "suite-recorder:prepare-capture", "protocol_version": 1, "job": "job-vector", "epoch": 0, "unknown": true }
+      ]
+    },
+    "renderer_capture_started": {
+      "accepted": [{ "type": "suite-recorder:capture-started", "protocol_version": 1, "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00.000Z" }],
+      "rejected": [
+        { "type": "suite-recorder:capture-started", "protocol_version": 1, "job": "job-vector", "epoch": -1, "capture_started_at": "2026-08-30T12:00:00.000Z" },
+        { "type": "suite-recorder:capture-started", "protocol_version": 1, "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00Z" },
+        { "type": "suite-recorder:capture-started", "protocol_version": 1, "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00.000Z", "unknown": true }
+      ]
+    },
+    "renderer_capture_prepared": {
+      "accepted": [{ "type": "suite-recorder:capture-prepared", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": 0 }],
+      "rejected": [
+        { "type": "suite-recorder:capture-prepared", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00Z", "job": "job-vector", "epoch": 0 },
+        { "type": "suite-recorder:capture-prepared", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": -1 },
+        { "type": "suite-recorder:capture-prepared", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": 0, "unknown": true }
+      ]
+    },
+    "renderer_capture_started_accepted": {
+      "accepted": [{ "type": "suite-recorder:capture-started-accepted", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00.000Z" }],
+      "rejected": [
+        { "type": "suite-recorder:capture-started-accepted", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00Z" },
+        { "type": "suite-recorder:capture-started-accepted", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": -1, "capture_started_at": "2026-08-30T12:00:00.000Z" },
+        { "type": "suite-recorder:capture-started-accepted", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.001Z", "job": "job-vector", "epoch": 0, "capture_started_at": "2026-08-30T12:00:00.000Z", "unknown": true }
+      ]
+    },
     "renderer_public_key_ready": {
       "accepted": [{ "type": "suite-recorder:public-key-ready", "protocol_version": 1, "occurred_at": "2026-08-30T12:00:00.000Z", "publicKey": { "kty": "EC", "crv": "P-256", "x": "axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpY", "y": "T-NC4v4af5uO5-tKfA-eFivOM1drMV7Oy7ZAaDe_UfU" } }],
       "rejected": [
@@ -659,10 +802,11 @@
       "command_operations": ["reserve", "query", "grant", "stop"],
       "command_states": ["reserved", "configured", "proof_complete", "joined", "capture_ready", "interrupted", "failed", "recovery_required", "stopping", "complete", "partial"],
       "command_rejection_reason_codes": ["capacity", "storage", "policy", "invalid_job"],
-      "health_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "duration_limit", "ffmpeg_exited", "interruption_timeout", "media_attachment_failed", "media_subscription_failed", "page_crashed", "quota_limit", "receive_transport_failed", "room_empty", "service_shutdown", "sfu_disconnected", "worker_missing_after_restart"],
+      "health_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "duration_limit", "ffmpeg_exited", "interruption_timeout", "media_attachment_failed", "media_subscription_failed", "page_crashed", "projection_invalid", "quota_limit", "receive_transport_failed", "room_empty", "service_shutdown", "sfu_disconnected", "worker_missing_after_restart"],
       "startup_milestones": ["configured", "proof_complete", "joined", "capture_started"],
-      "interruption_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "ffmpeg_exited", "media_attachment_failed", "media_subscription_failed", "page_crashed", "receive_transport_failed", "sfu_disconnected"],
-      "renderer_reason_codes": ["sfu_disconnected", "media_attachment_failed", "media_subscription_failed", "receive_transport_failed", "configuration_failed", "browser_disconnected", "page_crashed"],
+      "interruption_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "ffmpeg_exited", "media_attachment_failed", "media_subscription_failed", "page_crashed", "projection_invalid", "receive_transport_failed", "sfu_disconnected"],
+      "renderer_reason_codes": ["sfu_disconnected", "media_attachment_failed", "media_subscription_failed", "receive_transport_failed", "projection_invalid", "configuration_failed", "browser_disconnected", "page_crashed"],
+      "recorder_stage_projection_payload_types": ["participant_joined", "participant_updated", "participant_left", "producer_created", "producer_updated", "producer_closed", "media_control", "active_speaker", "hand_raised", "reaction", "chat_message"],
       "callback_failure_reason_codes": ["capture_failed", "processing_failed", "storage_unavailable", "quota_exhausted"],
       "end_reason_codes": ["duration_limit", "host_stop", "interruption_timeout", "quota_limit", "room_empty", "service_shutdown"],
       "gap_reason_codes": ["capture_interrupted", "ffmpeg_exited", "renderer_interrupted"],

--- a/suite/meet/recording/recorder_client.py
+++ b/suite/meet/recording/recorder_client.py
@@ -32,6 +32,7 @@ HEALTH_REASON_CODES = {
     "media_attachment_failed",
     "media_subscription_failed",
     "page_crashed",
+    "projection_invalid",
     "quota_limit",
     "receive_transport_failed",
     "room_empty",

--- a/suite/meet/sfu-server/src/server/RoomRegistry.ts
+++ b/suite/meet/sfu-server/src/server/RoomRegistry.ts
@@ -11,6 +11,10 @@ import type {
 	ProducerCloseReason,
 	ProducerCloseSource,
 	ReactionMessage,
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionPayload,
+	RecorderStageSnapshot,
 	ScreenShareStartedEvent,
 	ScreenShareStoppedEvent,
 	ServerToClientEvents,
@@ -25,6 +29,14 @@ type ServerSocket = Socket<
 	SocketData
 >;
 type ServerEventName = keyof ServerToClientEvents;
+
+interface RecorderProjectionState {
+	participants: Map<string, RecorderStageParticipant>;
+	producers: Map<string, RecorderStageProducer>;
+	activeSpeakerIds: string[];
+	cursor: number;
+	lastObservedAt?: string;
+}
 
 const fullRoom = (roomId: string) => `${roomId}:full`;
 const previewRoom = (roomId: string) => `${roomId}:preview`;
@@ -60,6 +72,7 @@ export class RoomRegistry {
 	private nextSenderIdByRoom: Map<string, number> = new Map();
 	private participantToSender: Map<string, Map<string, number>> = new Map();
 	private revokedParticipants = new Map<string, Set<string>>();
+	private recorderProjection = new Map<string, RecorderProjectionState>();
 
 	constructor(io: Server<ClientToServerEvents, ServerToClientEvents>) {
 		this.io = io;
@@ -130,20 +143,41 @@ export class RoomRegistry {
 	}
 
 	leaveRecorder(socket: Socket, roomId: string, peerId: string): boolean {
+		const ownsPeer = this.leaveRecorderRoom(socket, roomId, peerId);
+		this.deactivateRecorder(socket);
+		return ownsPeer;
+	}
+
+	leaveRecorderRoom(socket: Socket, roomId: string, peerId: string): boolean {
 		this.recorderSockets.get(roomId)?.delete(socket.id);
-		socket.leave(recorderRoom(roomId));
 		const ownsPeer =
 			this.recorderPeerSockets.get(roomId)?.get(peerId) === socket.id;
-		if (ownsPeer) {
-			this.recorderPeerIds.get(roomId)?.delete(peerId);
-			this.recorderPeerSockets.get(roomId)?.delete(peerId);
+		try {
+			socket.leave(recorderRoom(roomId));
+		} finally {
+			if (ownsPeer) {
+				this.recorderPeerIds.get(roomId)?.delete(peerId);
+				this.recorderPeerSockets.get(roomId)?.delete(peerId);
+			}
 		}
-		this.deactivateRecorder(socket);
 		return ownsPeer;
 	}
 
 	isRecorderPeer(roomId: string, peerId: string): boolean {
 		return this.recorderPeerIds.get(roomId)?.has(peerId) ?? false;
+	}
+
+	isJoinedActiveRecorder(socket: Socket, roomId: string): boolean {
+		const recordingId = socket.recordingClaims?.recording_id;
+		const peerId = socket.participantId ?? socket.userId;
+		return Boolean(
+			recordingId &&
+				socket.scope === 'recording' &&
+				socket.roomId === roomId &&
+				this.recorderSockets.get(roomId)?.has(socket.id) &&
+				this.recorderPeerSockets.get(roomId)?.get(peerId) === socket.id &&
+				this.activeRecordings.get(recordingId)?.socket.id === socket.id,
+		);
 	}
 
 	assignSenderId(roomId: string, participantId: string): number {
@@ -294,6 +328,25 @@ export class RoomRegistry {
 		return this.raisedHands[roomId] ?? {};
 	}
 
+	getRecorderStageSnapshot(roomId: string): RecorderStageSnapshot {
+		const state = this.getRecorderProjectionState(roomId);
+		const observedAt = this.observeProjectionAt(state);
+		return {
+			protocol_version: 1,
+			room_id: roomId,
+			cursor: state.cursor,
+			observed_at: observedAt,
+			participants: [...state.participants.values()].map((participant) => ({
+				...participant,
+			})),
+			producers: [...state.producers.values()].map((producer) => ({
+				...producer,
+			})),
+			raised_hands: { ...this.getRaisedHands(roomId) },
+			active_speaker_ids: [...state.activeSpeakerIds],
+		};
+	}
+
 	hasRaisedHand(roomId: string, peerId: string): boolean {
 		return Boolean(this.raisedHands[roomId]?.[peerId]);
 	}
@@ -375,6 +428,7 @@ export class RoomRegistry {
 		this.nextSenderIdByRoom.delete(roomId);
 		this.participantToSender.delete(roomId);
 		this.revokedParticipants.delete(roomId);
+		this.recorderProjection.delete(roomId);
 	}
 
 	emitToScope<Event extends ServerEventName>(
@@ -415,14 +469,57 @@ export class RoomRegistry {
 		event: Event,
 		...args: Parameters<ServerToClientEvents[Event]>
 	): void {
-		const ids = this.io.sockets.adapter.rooms.get(recorderRoom(roomId));
-		if (!ids) return;
-		for (const id of ids) {
+		for (const id of this.recorderSockets.get(roomId) ?? []) {
 			const socket: ServerSocket | undefined = this.io.sockets.sockets.get(id);
-			if (socket) {
+			if (socket && this.isJoinedActiveRecorder(socket, roomId)) {
 				socket.emit(event, ...args);
 			}
 		}
+	}
+
+	private getRecorderProjectionState(roomId: string): RecorderProjectionState {
+		let state = this.recorderProjection.get(roomId);
+		if (!state) {
+			state = {
+				participants: new Map(),
+				producers: new Map(),
+				activeSpeakerIds: [],
+				cursor: 0,
+			};
+			this.recorderProjection.set(roomId, state);
+		}
+		return state;
+	}
+
+	private observeProjectionAt(
+		state: RecorderProjectionState,
+		candidate?: string,
+	): string {
+		const parsed = candidate ? new Date(candidate) : new Date();
+		const observedAt = Number.isNaN(parsed.getTime())
+			? new Date().toISOString()
+			: parsed.toISOString();
+		state.lastObservedAt =
+			state.lastObservedAt && state.lastObservedAt > observedAt
+				? state.lastObservedAt
+				: observedAt;
+		return state.lastObservedAt;
+	}
+
+	private emitProjection(
+		roomId: string,
+		state: RecorderProjectionState,
+		observedAt: string,
+		payload: RecorderStageProjectionPayload,
+	): void {
+		state.cursor += 1;
+		this.emitToRecorders(roomId, 'recording:projection', {
+			protocol_version: 1,
+			room_id: roomId,
+			cursor: state.cursor,
+			observed_at: observedAt,
+			payload,
+		});
 	}
 
 	emitProducerCreated(
@@ -438,6 +535,22 @@ export class RoomRegistry {
 		const payload = { roomId, ...data };
 		this.emitToFullAccessParticipants(roomId, 'producer_created', payload);
 		this.emitToRecorders(roomId, 'producer_created', payload);
+		const state = this.getRecorderProjectionState(roomId);
+		if (!state.participants.has(data.participantId)) return;
+		const observedAt = this.observeProjectionAt(state);
+		const producer: RecorderStageProducer = {
+			producer_id: data.producerId,
+			participant_id: data.participantId,
+			kind: data.kind,
+			paused: data.paused,
+			is_screen: data.isScreen,
+			observed_at: observedAt,
+		};
+		state.producers.set(data.producerId, producer);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'producer_created',
+			producer,
+		});
 	}
 
 	emitProducerClosed(
@@ -461,12 +574,58 @@ export class RoomRegistry {
 			producerId: data.producerId,
 			isScreen: data.isScreen,
 		});
+		const state = this.getRecorderProjectionState(roomId);
+		const retained = state.producers.get(data.producerId);
+		if (
+			!retained ||
+			retained.participant_id !== data.participantId ||
+			retained.is_screen !== data.isScreen
+		)
+			return;
+		const observedAt = this.observeProjectionAt(state);
+		state.producers.delete(data.producerId);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'producer_closed',
+			producer_id: data.producerId,
+			participant_id: data.participantId,
+			is_screen: data.isScreen,
+		});
+	}
+
+	emitProducerPaused(
+		roomId: string,
+		data: { participantId: string; producerId: string; paused: boolean },
+	): void {
+		const state = this.getRecorderProjectionState(roomId);
+		const retained = state.producers.get(data.producerId);
+		if (!retained || retained.participant_id !== data.participantId) return;
+		const observedAt = this.observeProjectionAt(state);
+		state.producers.set(data.producerId, {
+			...retained,
+			paused: data.paused,
+			observed_at: observedAt,
+		});
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'producer_updated',
+			producer_id: data.producerId,
+			paused: data.paused,
+		});
 	}
 
 	emitActiveSpeaker(roomId: string, participantIds: string[]): void {
 		const payload = { participantIds };
 		this.emitToFullAccessParticipants(roomId, 'active_speaker', payload);
 		this.emitToRecorders(roomId, 'active_speaker', payload);
+		const state = this.getRecorderProjectionState(roomId);
+		const observedAt = this.observeProjectionAt(state);
+		const retainedIds = participantIds.filter((id) =>
+			state.participants.has(id),
+		);
+		state.activeSpeakerIds = retainedIds;
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'active_speaker',
+			participant_ids: retainedIds,
+		});
 	}
 
 	emitScreenShare(
@@ -510,11 +669,28 @@ export class RoomRegistry {
 	emitReaction(roomId: string, data: ReactionMessage): void {
 		this.emitToFullAccessParticipants(roomId, 'reaction:message', data);
 		this.emitToRecorders(roomId, 'reaction:message', data);
+		const state = this.getRecorderProjectionState(roomId);
+		const observedAt = this.observeProjectionAt(state, data.timestamp);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'reaction',
+			from_user: data.fromUser,
+			reaction: data.reaction,
+		});
 	}
 
 	emitRaisedHand(roomId: string, data: HandRaisedEvent): void {
 		this.emitToFullAccessParticipants(roomId, 'hand_raised', data);
 		this.emitToRecorders(roomId, 'hand_raised', data);
+		const state = this.getRecorderProjectionState(roomId);
+		if (!state.participants.has(data.participantId)) return;
+		const observedAt = this.observeProjectionAt(state, data.timestamp);
+		if (data.raised) this.setRaisedHand(roomId, data.participantId, observedAt);
+		else this.clearRaisedHand(roomId, data.participantId);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'hand_raised',
+			participant_id: data.participantId,
+			raised: data.raised,
+		});
 	}
 
 	emitPublicChat(roomId: string, data: ChatMessage): void {
@@ -526,6 +702,15 @@ export class RoomRegistry {
 			fromUser: data.fromUser,
 			fromName: data.fromName,
 			timestamp: data.timestamp,
+		});
+		const state = this.getRecorderProjectionState(roomId);
+		const observedAt = this.observeProjectionAt(state, data.timestamp);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'chat_message',
+			message_id: data.messageId,
+			message: data.message,
+			from_user: data.fromUser,
+			from_name: data.fromName,
 		});
 	}
 
@@ -539,6 +724,32 @@ export class RoomRegistry {
 	): void {
 		this.emitToFullAccessParticipants(roomId, 'media_control_update', data);
 		this.emitToRecorders(roomId, 'media_control_update', data);
+		const state = this.getRecorderProjectionState(roomId);
+		if (!state.participants.has(data.participantId)) return;
+		const observedAt = this.observeProjectionAt(state, data.timestamp);
+		const participant = state.participants.get(data.participantId);
+		if (participant) {
+			state.participants.set(data.participantId, {
+				...participant,
+				audio_enabled:
+					data.action === 'mute'
+						? false
+						: data.action === 'unmute'
+							? true
+							: participant.audio_enabled,
+				video_enabled:
+					data.action === 'video_off'
+						? false
+						: data.action === 'video_on'
+							? true
+							: participant.video_enabled,
+			});
+		}
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'media_control',
+			participant_id: data.participantId,
+			action: data.action,
+		});
 	}
 
 	emitParticipantEvent(
@@ -561,18 +772,53 @@ export class RoomRegistry {
 		}
 
 		if (event === 'participant_joined' && userData) {
+			const avatar = userData.avatar || undefined;
 			this.emitToRecorders(roomId, event, {
 				roomId,
 				participantId,
 				userData: {
 					name: userData.name,
-					avatar: userData.avatar,
+					...(avatar ? { avatar } : {}),
 					audio_enabled: userData.audio_enabled,
 					video_enabled: userData.video_enabled,
 				},
 			});
 		} else if (event === 'participant_left') {
 			this.emitToRecorders(roomId, event, { roomId, participantId });
+		}
+
+		const state = this.getRecorderProjectionState(roomId);
+		const observedAt = this.observeProjectionAt(state);
+		if (event === 'participant_joined' && userData) {
+			const participant: RecorderStageParticipant = {
+				participant_id: participantId,
+				name: userData.name,
+				...(userData.avatar ? { avatar: userData.avatar } : {}),
+				audio_enabled: userData.audio_enabled,
+				video_enabled: userData.video_enabled,
+			};
+			state.participants.set(participantId, participant);
+			this.emitProjection(roomId, state, observedAt, {
+				type: 'participant_joined',
+				participant,
+			});
+		} else if (
+			event === 'participant_left' &&
+			state.participants.has(participantId)
+		) {
+			state.participants.delete(participantId);
+			this.clearRaisedHand(roomId, participantId);
+			state.activeSpeakerIds = state.activeSpeakerIds.filter(
+				(id) => id !== participantId,
+			);
+			for (const [producerId, producer] of state.producers) {
+				if (producer.participant_id === participantId)
+					state.producers.delete(producerId);
+			}
+			this.emitProjection(roomId, state, observedAt, {
+				type: 'participant_left',
+				participant_id: participantId,
+			});
 		}
 
 		if (!participantId.startsWith('preview-')) {
@@ -592,5 +838,27 @@ export class RoomRegistry {
 				});
 			}
 		}
+	}
+
+	emitParticipantUpdated(
+		roomId: string,
+		participantId: string,
+		userData: UserData,
+	): void {
+		const state = this.getRecorderProjectionState(roomId);
+		if (!state.participants.has(participantId)) return;
+		const observedAt = this.observeProjectionAt(state);
+		const participant: RecorderStageParticipant = {
+			participant_id: participantId,
+			name: userData.name,
+			...(userData.avatar ? { avatar: userData.avatar } : {}),
+			audio_enabled: userData.audio_enabled,
+			video_enabled: userData.video_enabled,
+		};
+		state.participants.set(participantId, participant);
+		this.emitProjection(roomId, state, observedAt, {
+			type: 'participant_updated',
+			participant,
+		});
 	}
 }

--- a/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RoomRegistry.test.ts
@@ -83,11 +83,21 @@ function addPreviewSocket(
 
 function addRecorderSocket(
 	setup: ReturnType<typeof makeIo>,
+	registry: RoomRegistry,
 	roomId: string,
 	sock: Socket,
 ) {
 	setup.sockets.set(sock.id, sock);
 	setup.joinRoom(sock.id, `${roomId}:recorders`);
+	Object.assign(sock, {
+		scope: 'recording',
+		roomId,
+		userId: `recorder:${sock.id}`,
+		participantId: `recorder:${sock.id}`,
+		recordingClaims: { recording_id: `recording:${sock.id}` },
+	});
+	registry.activateRecorder(sock, `recording:${sock.id}`, `job:${sock.id}`);
+	registry.joinRecorder(sock, roomId, `recorder:${sock.id}`);
 }
 
 describe('RoomRegistry', () => {
@@ -455,7 +465,7 @@ describe('RoomRegistry', () => {
 			const setup = makeIo();
 			const registry = new RoomRegistry(setup.io);
 			const recorder = makeSocket('recorder-1');
-			addRecorderSocket(setup, 'r1', recorder);
+			addRecorderSocket(setup, registry, 'r1', recorder);
 
 			registry.emitToFullAccessParticipants('r1', 'host_control_update', {
 				private: true,
@@ -470,7 +480,14 @@ describe('RoomRegistry', () => {
 			const setup = makeIo();
 			const registry = new RoomRegistry(setup.io);
 			const recorder = makeSocket('recorder-1');
-			addRecorderSocket(setup, 'r1', recorder);
+			addRecorderSocket(setup, registry, 'r1', recorder);
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'p1',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			(recorder as unknown as { _emitCalls: unknown[] })._emitCalls.length = 0;
 
 			registry.emitActiveSpeaker('r1', ['p1']);
 			registry.emitProducerCreated('r1', {
@@ -511,6 +528,7 @@ describe('RoomRegistry', () => {
 			});
 			registry.emitPublicChat('r1', {
 				roomId: 'r1',
+				messageId: 'message-1',
 				message: 'hello',
 				fromUser: 'p1',
 				fromName: 'Alice',
@@ -523,10 +541,11 @@ describe('RoomRegistry', () => {
 				timestamp: 'ts',
 			});
 
+			const eventNames = (
+				recorder as unknown as { _emitCalls: { event: string }[] }
+			)._emitCalls.map((call) => call.event);
 			expect(
-				(
-					recorder as unknown as { _emitCalls: { event: string }[] }
-				)._emitCalls.map((call) => call.event),
+				eventNames.filter((event) => event !== 'recording:projection'),
 			).toEqual([
 				'active_speaker',
 				'producer_created',
@@ -538,6 +557,9 @@ describe('RoomRegistry', () => {
 				'chat:message',
 				'media_control_update',
 			]);
+			expect(
+				eventNames.filter((event) => event === 'recording:projection'),
+			).toHaveLength(7);
 			const calls = (
 				recorder as unknown as {
 					_emitCalls: EmissionFixture[];
@@ -643,13 +665,18 @@ describe('RoomRegistry', () => {
 			const setup = makeIo();
 			const registry = new RoomRegistry(setup.io);
 			const recorder = makeSocket('recorder-1');
-			addRecorderSocket(setup, 'r1', recorder);
+			addRecorderSocket(setup, registry, 'r1', recorder);
 
 			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', userData);
 			registry.emitParticipantEvent('r1', 'participant_left', 'p1');
 
+			const calls = (
+				recorder as unknown as {
+					_emitCalls: { event: string; data: unknown }[];
+				}
+			)._emitCalls;
 			expect(
-				(recorder as unknown as { _emitCalls: unknown[] })._emitCalls,
+				calls.filter((call) => call.event !== 'recording:projection'),
 			).toEqual([
 				{
 					event: 'participant_joined',
@@ -669,6 +696,9 @@ describe('RoomRegistry', () => {
 					data: { roomId: 'r1', participantId: 'p1' },
 				},
 			]);
+			expect(
+				calls.filter((call) => call.event === 'recording:projection'),
+			).toHaveLength(2);
 		});
 
 		it('participant_joined for a preview-* id only emits to full sockets (preview sockets get nothing)', () => {
@@ -756,6 +786,326 @@ describe('RoomRegistry', () => {
 
 			expect(registry.getRaisedHands('r1')).toEqual({});
 			expect(registry.isHostOnlyChat('r1')).toBe(false);
+		});
+	});
+
+	describe('recorder stage projection', () => {
+		it('removes all participant-owned retained state before the leave snapshot', () => {
+			const { io } = makeIo();
+			const registry = new RoomRegistry(io);
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'p1',
+				avatar: '',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			registry.emitProducerCreated('r1', {
+				participantId: 'p1',
+				producerId: 'p1-video',
+				kind: 'video',
+				paused: false,
+				isScreen: false,
+			});
+			registry.emitRaisedHand('r1', {
+				participantId: 'p1',
+				raised: true,
+				timestamp: new Date().toISOString(),
+			});
+			registry.emitActiveSpeaker('r1', ['p1']);
+
+			registry.emitParticipantEvent('r1', 'participant_left', 'p1');
+
+			expect(registry.getRecorderStageSnapshot('r1')).toMatchObject({
+				participants: [],
+				producers: [],
+				raised_hands: {},
+				active_speaker_ids: [],
+			});
+		});
+
+		it('omits empty avatars and projects participant updates without a legacy join', () => {
+			const setup = makeIo();
+			const registry = new RoomRegistry(setup.io);
+			const recorder = makeSocket('recorder-1');
+			addRecorderSocket(setup, registry, 'r1', recorder);
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'p1',
+				avatar: '',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			registry.emitParticipantUpdated('r1', 'p1', {
+				name: 'Alice Updated',
+				userId: 'p1',
+				avatar: '',
+				audio_enabled: false,
+				video_enabled: false,
+			});
+			const calls = (
+				recorder as unknown as {
+					_emitCalls: Array<{
+						event: string;
+						data: { payload: { type: string } };
+					}>;
+				}
+			)._emitCalls;
+			expect(
+				calls.filter((call) => call.event === 'participant_joined'),
+			).toHaveLength(1);
+			expect(
+				calls.filter((call) => call.event === 'recording:projection').at(-1)
+					?.data.payload.type,
+			).toBe('participant_updated');
+			expect(
+				registry.getRecorderStageSnapshot('r1').participants[0],
+			).not.toHaveProperty('avatar');
+		});
+
+		it('does not emit to a stale socket that merely remains in the recorder room', () => {
+			const setup = makeIo();
+			const registry = new RoomRegistry(setup.io);
+			const stale = makeSocket('stale');
+			const active = makeSocket('active');
+			addRecorderSocket(setup, registry, 'r1', stale);
+			addRecorderSocket(setup, registry, 'r1', active);
+			Object.assign(active, {
+				recordingClaims: { recording_id: 'recording:stale' },
+			});
+			registry.activateRecorder(active, 'recording:stale', 'job:stale');
+			(stale as unknown as { _emitCalls: unknown[] })._emitCalls.length = 0;
+			(active as unknown as { _emitCalls: unknown[] })._emitCalls.length = 0;
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'p1',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			expect(
+				(stale as unknown as { _emitCalls: unknown[] })._emitCalls,
+			).toEqual([]);
+			expect(
+				(active as unknown as { _emitCalls: unknown[] })._emitCalls.length,
+			).toBeGreaterThan(0);
+		});
+
+		it('emits safe ordered envelopes and retains only persistent snapshot state', () => {
+			const setup = makeIo();
+			const registry = new RoomRegistry(setup.io);
+			const recorder = makeSocket('recorder-1');
+			addRecorderSocket(setup, registry, 'r1', recorder);
+			const observedAt = new Date().toISOString();
+
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'account-1',
+				avatar: 'alice.png',
+				is_guest: true,
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			registry.emitProducerCreated('r1', {
+				participantId: 'p1',
+				producerId: 'screen-1',
+				kind: 'video',
+				paused: false,
+				isScreen: true,
+			});
+			registry.emitRaisedHand('r1', {
+				participantId: 'p1',
+				raised: true,
+				timestamp: observedAt,
+			});
+			registry.emitActiveSpeaker('r1', ['p1']);
+			registry.emitMediaControlUpdate('r1', {
+				participantId: 'p1',
+				action: 'video_off',
+				timestamp: observedAt,
+			});
+			registry.emitReaction('r1', {
+				roomId: 'r1',
+				fromUser: 'p1',
+				fromName: 'Alice',
+				reaction: 'wave',
+				timestamp: observedAt,
+			});
+			registry.emitPublicChat('r1', {
+				roomId: 'r1',
+				messageId: 'message-1',
+				message: 'hello',
+				fromUser: 'p1',
+				fromName: 'Alice',
+				timestamp: observedAt,
+				clientId: 'private-client-id',
+			});
+
+			const projections = (
+				recorder as unknown as {
+					_emitCalls: Array<{
+						event: string;
+						data: { cursor?: number; observed_at?: string };
+					}>;
+				}
+			)._emitCalls.filter((call) => call.event === 'recording:projection');
+			expect(projections.map((call) => call.data.cursor)).toEqual([
+				1, 2, 3, 4, 5, 6, 7,
+			]);
+			const timestamps = projections.map((call) =>
+				String(call.data.observed_at),
+			);
+			expect(
+				timestamps.every((timestamp) => !Number.isNaN(Date.parse(timestamp))),
+			).toBe(true);
+			expect([...timestamps].sort()).toEqual(timestamps);
+			const projectionJson = JSON.stringify(projections);
+			expect(projectionJson).not.toContain('account-1');
+			expect(projectionJson).not.toContain('is_guest');
+			expect(projectionJson).not.toContain('private-client-id');
+
+			const snapshot = registry.getRecorderStageSnapshot('r1');
+			expect(snapshot).toMatchObject({
+				protocol_version: 1,
+				room_id: 'r1',
+				cursor: 7,
+				participants: [
+					{
+						participant_id: 'p1',
+						name: 'Alice',
+						avatar: 'alice.png',
+						audio_enabled: true,
+						video_enabled: false,
+					},
+				],
+				producers: [
+					{
+						producer_id: 'screen-1',
+						participant_id: 'p1',
+						kind: 'video',
+						paused: false,
+						is_screen: true,
+					},
+				],
+				raised_hands: { p1: expect.any(String) },
+				active_speaker_ids: ['p1'],
+			});
+			expect(snapshot).not.toHaveProperty('reactions');
+			expect(snapshot).not.toHaveProperty('chat_messages');
+			expect(Date.parse(snapshot.observed_at)).not.toBeNaN();
+		});
+
+		it('does not project separate screen-share events', () => {
+			const setup = makeIo();
+			const registry = new RoomRegistry(setup.io);
+			const recorder = makeSocket('recorder-1');
+			addRecorderSocket(setup, registry, 'r1', recorder);
+
+			registry.emitScreenShare('r1', 'screen_share_started', {
+				participantId: 'p1',
+				shareData: { producerId: 'screen-1' },
+				timestamp: new Date().toISOString(),
+			});
+
+			expect(
+				(
+					recorder as unknown as { _emitCalls: Array<{ event: string }> }
+				)._emitCalls.filter((call) => call.event === 'recording:projection'),
+			).toEqual([]);
+			expect(registry.getRecorderStageSnapshot('r1').cursor).toBe(0);
+		});
+
+		it('retains and projects producer pause changes', () => {
+			const setup = makeIo();
+			const registry = new RoomRegistry(setup.io);
+			const recorder = makeSocket('recorder-1');
+			addRecorderSocket(setup, registry, 'r1', recorder);
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'p1',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+			registry.emitProducerCreated('r1', {
+				participantId: 'p1',
+				producerId: 'producer-1',
+				kind: 'video',
+				paused: false,
+				isScreen: false,
+			});
+
+			registry.emitProducerPaused('r1', {
+				participantId: 'p1',
+				producerId: 'producer-1',
+				paused: true,
+			});
+
+			expect(registry.getRecorderStageSnapshot('r1').producers[0]?.paused).toBe(
+				true,
+			);
+			const projections = (
+				recorder as unknown as {
+					_emitCalls: Array<{
+						event: string;
+						data: { payload: unknown };
+					}>;
+				}
+			)._emitCalls.filter((call) => call.event === 'recording:projection');
+			expect(projections.at(-1)?.data.payload).toEqual({
+				type: 'producer_updated',
+				producer_id: 'producer-1',
+				paused: true,
+			});
+
+			registry.emitProducerPaused('r1', {
+				participantId: 'p1',
+				producerId: 'producer-1',
+				paused: false,
+			});
+			expect(registry.getRecorderStageSnapshot('r1').producers[0]?.paused).toBe(
+				false,
+			);
+		});
+
+		it('cleans retained projection state', () => {
+			const { io } = makeIo();
+			const registry = new RoomRegistry(io);
+			registry.emitParticipantEvent('r1', 'participant_joined', 'p1', {
+				name: 'Alice',
+				userId: 'account-1',
+				audio_enabled: true,
+				video_enabled: true,
+			});
+
+			registry.cleanupMediaRoom('r1');
+
+			expect(registry.getRecorderStageSnapshot('r1')).toMatchObject({
+				cursor: 0,
+				participants: [],
+				producers: [],
+				raised_hands: {},
+				active_speaker_ids: [],
+			});
+		});
+
+		it('recognizes only the joined active recorder owner', () => {
+			const { io } = makeIo();
+			const registry = new RoomRegistry(io);
+			const recorder = makeSocket('recorder-1');
+			Object.assign(recorder, {
+				scope: 'recording',
+				roomId: 'r1',
+				userId: 'recorder:recording-1',
+				participantId: 'recorder:recording-1',
+				recordingClaims: {
+					recording_id: 'recording-1',
+					recorder_job_id: 'job-1',
+				},
+			});
+
+			registry.activateRecorder(recorder, 'recording-1', 'job-1');
+			expect(registry.isJoinedActiveRecorder(recorder, 'r1')).toBe(false);
+			registry.joinRecorder(recorder, 'r1', 'recorder:recording-1');
+			expect(registry.isJoinedActiveRecorder(recorder, 'r1')).toBe(true);
 		});
 	});
 });

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -343,6 +343,67 @@ describe('SocketHandlerManager characterization', () => {
 		});
 	});
 
+	it('recording:join rolls back recorder and media membership when peer creation fails', async () => {
+		const harness = createManager();
+		const recorder = connectFullSocket(harness, {
+			id: 'recorder-rollback',
+			scope: 'recording',
+			recordingProofComplete: true,
+			userId: 'recorder:rollback',
+			recordingClaims: {
+				recording_id: 'recording-rollback',
+				recorder_job_id: 'job-rollback',
+			} as never,
+		});
+		const registry = (
+			harness.manager as unknown as {
+				registry: {
+					activateRecorder(
+						socket: MockSocket,
+						recordingId: string,
+						jobId: string,
+					): void;
+					getRecorderSockets(roomId: string): MockSocket[];
+					isRecorderPeer(roomId: string, peerId: string): boolean;
+					isJoinedActiveRecorder(socket: MockSocket, roomId: string): boolean;
+				};
+			}
+		).registry;
+		registry.activateRecorder(recorder, 'recording-rollback', 'job-rollback');
+		vi.mocked(harness.mediasoup.addPeer).mockRejectedValueOnce(
+			new Error('injected peer fault'),
+		);
+		const callback = vi.fn();
+
+		recorder.fire('recording:join', { roomId: 'room-1' }, callback);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'injected peer fault',
+		});
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
+			'room-1',
+			'recorder:rollback',
+		);
+		expect(recorder.roomId).toBeUndefined();
+		expect(recorder.participantId).toBeUndefined();
+		expect(harness.io.socketsAdapterRooms.get('room-1')).not.toContain(
+			recorder.id,
+		);
+		expect(
+			harness.io.socketsAdapterRooms.get('room-1:recorders'),
+		).not.toContain(recorder.id);
+		expect(registry.getRecorderSockets('room-1')).toEqual([]);
+		expect(registry.isRecorderPeer('room-1', 'recorder:rollback')).toBe(false);
+
+		const retryCallback = vi.fn();
+		recorder.fire('recording:join', { roomId: 'room-1' }, retryCallback);
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(retryCallback).toHaveBeenCalledWith({ success: true });
+		expect(registry.isJoinedActiveRecorder(recorder, 'room-1')).toBe(true);
+	});
+
 	it('disconnects an unproved recorder after ten seconds and clears the timer on proof', async () => {
 		vi.useFakeTimers();
 		const grantManager = {
@@ -1035,7 +1096,17 @@ describe('SocketHandlerManager characterization', () => {
 			userId: 'user-1',
 		});
 		const callback = vi.fn();
-		emitJoin(reconnected, { connectionId: 'stable-device' }, callback);
+		emitJoin(
+			reconnected,
+			{
+				connectionId: 'stable-device',
+				name: 'Alice Updated',
+				avatar: 'updated.png',
+				audioEnabled: false,
+				videoEnabled: false,
+			},
+			callback,
+		);
 		await new Promise((r) => setImmediate(r));
 
 		expect(callback).toHaveBeenCalledWith({
@@ -1053,6 +1124,22 @@ describe('SocketHandlerManager characterization', () => {
 		expect(
 			reconnected.emitCalls.some((call) => call.event === 'participant_joined'),
 		).toBe(false);
+		const registry = (
+			harness.manager as unknown as {
+				registry: {
+					getRecorderStageSnapshot(roomId: string): { participants: unknown[] };
+				};
+			}
+		).registry;
+		expect(registry.getRecorderStageSnapshot('room-1').participants).toEqual([
+			{
+				participant_id: 'user-1',
+				name: 'Alice Updated',
+				avatar: 'updated.png',
+				audio_enabled: false,
+				video_enabled: false,
+			},
+		]);
 	});
 
 	it('keeps previews connected while grace cleanup evicts recorders and closes media', async () => {
@@ -1563,6 +1650,68 @@ describe('SocketHandlerManager characterization', () => {
 			event: 'producer_created',
 			data: expect.objectContaining({ producerId: 'producer-1' }),
 		});
+	});
+
+	it('closes a producer created after its participant connection loses ownership', async () => {
+		const harness = createManager();
+		const publisher = connectFullSocket(harness, {
+			id: 'publisher-old',
+			userId: 'publisher-race',
+		});
+		emitJoin(publisher, {
+			userId: 'publisher-race',
+			connectionId: 'publisher-device',
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		let resolveProducer!: (producer: {
+			id: string;
+			kind: 'video';
+			appData: { type: 'camera' };
+		}) => void;
+		vi.mocked(harness.mediasoup.createProducer).mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveProducer = resolve;
+			}) as never,
+		);
+		const callback = vi.fn();
+		publisher.fire(
+			'create_producer',
+			{
+				transportId: 'send-1',
+				rtpParameters: {},
+				kind: 'video',
+				appData: { type: 'camera' },
+			},
+			callback,
+		);
+
+		const replacement = connectFullSocket(harness, {
+			id: 'publisher-new',
+			userId: 'publisher-race',
+		});
+		emitJoin(replacement, {
+			userId: 'publisher-race',
+			connectionId: 'publisher-device',
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		resolveProducer({
+			id: 'producer-race',
+			kind: 'video',
+			appData: { type: 'camera' },
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.closeProducer).toHaveBeenCalledWith(
+			'producer-race',
+			{ reason: 'cleanup' },
+		);
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Participant connection is no longer active',
+		});
+		expect(
+			replacement.emitCalls.some((call) => call.event === 'producer_created'),
+		).toBe(false);
 	});
 
 	it('reports a consumer creation fault and allows the same request to retry', async () => {
@@ -2110,6 +2259,52 @@ describe('SocketHandlerManager characterization', () => {
 		expect(host.emitCalls.some((c) => c.event === 'chat:pin_updated')).toBe(
 			false,
 		);
+	});
+
+	it('rejects chat restriction and pin mutations from a replaced host connection', async () => {
+		const harness = createManager();
+		const staleHost = connectFullSocket(harness, {
+			id: 'stale-chat-host',
+			userId: 'chat-host',
+			userName: 'Chat Host',
+			isHost: true,
+		});
+		emitJoin(staleHost, {
+			userId: 'chat-host',
+			connectionId: 'chat-device',
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		const sendCallback = vi.fn();
+		staleHost.fire('chat:send', { message: 'owned message' }, sendCallback);
+		const messageId = sendCallback.mock.calls[0]?.[0].messageId as string;
+
+		const currentHost = connectFullSocket(harness, {
+			id: 'current-chat-host',
+			userId: 'chat-host',
+			userName: 'Chat Host',
+			isHost: true,
+		});
+		emitJoin(currentHost, {
+			userId: 'chat-host',
+			connectionId: 'chat-device',
+		});
+		await new Promise((resolve) => setImmediate(resolve));
+		currentHost.emitCalls.length = 0;
+
+		staleHost.fire('chat:toggle_restriction', { enabled: true });
+		const pinCallback = vi.fn();
+		staleHost.fire('chat:pin', { messageId, action: 'pin' }, pinCallback);
+
+		expect(currentHost.emitCalls).not.toContainEqual(
+			expect.objectContaining({ event: 'chat:restriction_updated' }),
+		);
+		expect(currentHost.emitCalls).not.toContainEqual(
+			expect.objectContaining({ event: 'chat:pin_updated' }),
+		);
+		expect(pinCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Participant connection is no longer active',
+		});
 	});
 
 	it('late joiners receive existing_pinned_message for a currently pinned chat message', async () => {

--- a/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ChatHandlers.ts
@@ -3,6 +3,7 @@ import type { Socket } from 'socket.io';
 import type { ChatMessage, PinnedChatMessage } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+import { ensureParticipantOwner } from './utils';
 
 function toPinnedChatMessage(
 	message: ChatMessage,
@@ -22,9 +23,9 @@ export function registerChatHandlers(deps: HandlerDeps) {
 		socket.on('chat:toggle_restriction', (data) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const roomId = socket.roomId;
+				const { roomId } = ensureParticipantOwner(socket, deps.registry);
 
-				if (!roomId || (!socket.isHost && !socket.isCohost)) return;
+				if (!socket.isHost && !socket.isCohost) return;
 				const isRestricted = Boolean(data.enabled);
 				deps.registry.setHostOnlyChat(roomId, isRestricted);
 
@@ -41,17 +42,15 @@ export function registerChatHandlers(deps: HandlerDeps) {
 		socket.on('chat:send', (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const roomId = socket.roomId;
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const text = (
 					typeof data.message === 'string' ? data.message : ''
 				).slice(0, 2000);
 
-				if (
-					!roomId ||
-					!text.trim() ||
-					!socket.participantId ||
-					!socket.userName
-				) {
+				if (!text.trim() || !socket.userName) {
 					callback?.({ success: false, error: 'Invalid chat message' });
 					return;
 				}
@@ -77,7 +76,7 @@ export function registerChatHandlers(deps: HandlerDeps) {
 					roomId,
 					messageId: randomUUID(),
 					message: text,
-					fromUser: socket.participantId,
+					fromUser: participantId,
 					fromName: socket.userName,
 					timestamp: new Date().toISOString(),
 				};
@@ -105,9 +104,9 @@ export function registerChatHandlers(deps: HandlerDeps) {
 		socket.on('chat:pin', (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const roomId = socket.roomId;
+				const { roomId } = ensureParticipantOwner(socket, deps.registry);
 
-				if (!roomId || (!socket.isHost && !socket.isCohost)) {
+				if (!socket.isHost && !socket.isCohost) {
 					callback?.({
 						success: false,
 						error: 'Only hosts and co-hosts can pin messages',

--- a/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/HostControlHandlers.ts
@@ -1,7 +1,7 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { findSocketsByParticipantId } from './utils';
+import { ensureParticipantOwner, findSocketsByParticipantId } from './utils';
 
 export function registerHostControlHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -18,13 +18,11 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const { action, targetParticipantId } = data;
-				const roomId = socket.roomId;
-
-				if (!roomId || !socket.participantId) {
-					fail('Not in a room');
-					return;
-				}
 
 				if (!socket.isHost && !socket.isCohost) {
 					fail('Only host or co-host can control participants');
@@ -83,13 +81,13 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 							targetSocket.emit('host_control_update', {
 								action,
 								targetParticipantId,
-								hostId: socket.participantId,
+								hostId: participantId,
 								timestamp: new Date().toISOString(),
 							});
 						}
 						loggers.socketHandler.info(
 							'Host %s sent mute command to participant %s in room %s',
-							socket.participantId,
+							participantId,
 							targetParticipantId,
 							roomId,
 						);
@@ -128,14 +126,14 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 							targetSocket.emit('host_control_update', {
 								action,
 								targetParticipantId,
-								hostId: socket.participantId,
+								hostId: participantId,
 								timestamp: new Date().toISOString(),
 							});
 						}
 
 						loggers.socketHandler.info(
 							'Host %s removed participant %s (senderIds=%s) from room %s',
-							socket.participantId,
+							participantId,
 							targetParticipantId,
 							targetSenderIds.join(','),
 							roomId,
@@ -176,14 +174,14 @@ export function registerHostControlHandlers(deps: HandlerDeps) {
 							return;
 						}
 						deps.registry.clearRaisedHand(roomId, targetParticipantId);
-						deps.registry.emitToFullAccessParticipants(roomId, 'hand_raised', {
+						deps.registry.emitRaisedHand(roomId, {
 							participantId: targetParticipantId,
 							raised: false,
 							timestamp: new Date().toISOString(),
 						});
 						loggers.socketHandler.info(
 							'Host %s lowered hand of participant %s',
-							socket.participantId,
+							participantId,
 							targetParticipantId,
 						);
 						break;

--- a/suite/meet/sfu-server/src/server/handlers/MediaControlHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/MediaControlHandlers.ts
@@ -1,23 +1,21 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+import { ensureParticipantOwner } from './utils';
 
 export function registerMediaControlHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
 		socket.on('media_control', async (data) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const { action } = data;
-				const roomId = socket.roomId;
-
-				if (!roomId || !socket.participantId) return;
 
 				try {
-					deps.mediasoup.applyMediaControl(
-						roomId,
-						socket.participantId,
-						action,
-					);
+					deps.mediasoup.applyMediaControl(roomId, participantId, action);
 				} catch (e) {
 					loggers.socketHandler.warn(
 						'Failed to apply media control on server: %s',
@@ -27,18 +25,18 @@ export function registerMediaControlHandlers(deps: HandlerDeps) {
 
 				if (
 					action === 'unmute' &&
-					deps.registry.hasRaisedHand(roomId, socket.participantId)
+					deps.registry.hasRaisedHand(roomId, participantId)
 				) {
-					deps.registry.clearRaisedHand(roomId, socket.participantId);
+					deps.registry.clearRaisedHand(roomId, participantId);
 					deps.registry.emitRaisedHand(roomId, {
-						participantId: socket.participantId,
+						participantId,
 						raised: false,
 						timestamp: new Date().toISOString(),
 					});
 				}
 
 				deps.registry.emitMediaControlUpdate(roomId, {
-					participantId: socket.participantId,
+					participantId,
 					action,
 					timestamp: new Date().toISOString(),
 				});

--- a/suite/meet/sfu-server/src/server/handlers/MediaControlHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/MediaControlHandlers.ts
@@ -1,7 +1,26 @@
 import type { Socket } from 'socket.io';
+import type { MediaControlAction } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
 import { ensureParticipantOwner } from './utils';
+
+function normalizeMediaControlAction(value: unknown): MediaControlAction {
+	if (
+		value === 'mute' ||
+		value === 'unmute' ||
+		value === 'video_off' ||
+		value === 'video_on'
+	)
+		return value;
+	if (value && typeof value === 'object' && !Array.isArray(value)) {
+		const { type, enabled } = value as { type?: unknown; enabled?: unknown };
+		if (typeof enabled === 'boolean') {
+			if (type === 'audio') return enabled ? 'unmute' : 'mute';
+			if (type === 'video') return enabled ? 'video_on' : 'video_off';
+		}
+	}
+	throw new Error('invalid media control action');
+}
 
 export function registerMediaControlHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -12,7 +31,7 @@ export function registerMediaControlHandlers(deps: HandlerDeps) {
 					socket,
 					deps.registry,
 				);
-				const { action } = data;
+				const action = normalizeMediaControlAction(data.action);
 
 				try {
 					deps.mediasoup.applyMediaControl(roomId, participantId, action);

--- a/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ProducerHandlers.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { getPeerId, getRoomId } from './utils';
+import { ensureParticipantOwner, getPeerId } from './utils';
 
 export function registerProducerHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -21,10 +21,13 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 			let outcome: 'success' | 'failure' = 'failure';
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				enforceE2EEMediaPolicy(socket);
 				const { transportId, rtpParameters, kind } = data;
 				const startPaused = appData.e2eeStartPaused === true;
-				const roomId = getRoomId(socket);
 				const producer = await deps.mediasoup.createProducer(
 					transportId,
 					roomId,
@@ -35,6 +38,20 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 					socket.senderId ?? 0,
 					startPaused,
 				);
+				try {
+					ensureParticipantOwner(socket, deps.registry);
+				} catch (error) {
+					try {
+						deps.mediasoup.closeProducer(producer.id, { reason: 'cleanup' });
+					} catch (cleanupError) {
+						loggers.socketHandler.warn(
+							'Producer rollback failed for %s: %s',
+							producer.id,
+							(cleanupError as Error).message,
+						);
+					}
+					throw error;
+				}
 
 				const isScreen =
 					(producer.appData && producer.appData.type === 'screen') ||
@@ -44,7 +61,7 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 				outcome = 'success';
 
 				deps.registry.emitProducerCreated(roomId, {
-					participantId: socket.userId,
+					participantId,
 					producerId: producer.id,
 					kind: producer.kind,
 					paused: startPaused,
@@ -73,13 +90,14 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 		socket.on('close_producer', async (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId } = ensureParticipantOwner(socket, deps.registry);
 				const { producerId } = data;
 				const reason = producerCloseReason(data.reason);
 				const source = data.source === 'screen-share' ? data.source : undefined;
 				const details = sanitizeProducerCloseDetails(data.details);
 				deps.mediasoup.assertProducerAccess(
 					producerId,
-					getRoomId(socket),
+					roomId,
 					getPeerId(socket),
 				);
 				const result = deps.mediasoup.closeProducer(producerId, {
@@ -111,13 +129,25 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 		socket.on('pause_producer', async (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const { producerId } = data;
 				deps.mediasoup.assertProducerAccess(
 					producerId,
-					getRoomId(socket),
+					roomId,
 					getPeerId(socket),
 				);
 				const paused = await deps.mediasoup.pauseProducer(producerId);
+				ensureParticipantOwner(socket, deps.registry);
+				if (paused) {
+					deps.registry.emitProducerPaused(roomId, {
+						participantId,
+						producerId,
+						paused: true,
+					});
+				}
 
 				callback({ success: true, paused });
 			} catch (error) {
@@ -132,13 +162,25 @@ export function registerProducerHandlers(deps: HandlerDeps) {
 		socket.on('resume_producer', async (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const { producerId } = data;
 				deps.mediasoup.assertProducerAccess(
 					producerId,
-					getRoomId(socket),
+					roomId,
 					getPeerId(socket),
 				);
 				const resumed = await deps.mediasoup.resumeProducer(producerId);
+				ensureParticipantOwner(socket, deps.registry);
+				if (resumed) {
+					deps.registry.emitProducerPaused(roomId, {
+						participantId,
+						producerId,
+						paused: false,
+					});
+				}
 
 				callback({ success: true, resumed });
 			} catch (error) {

--- a/suite/meet/sfu-server/src/server/handlers/RaiseHandHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RaiseHandHandlers.ts
@@ -1,32 +1,21 @@
 import type { Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+import { ensureParticipantOwner } from './utils';
 
 export function registerRaiseHandHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
 		socket.on('raise_hand', (data, callback) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const roomId = socket.roomId;
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const raised = typeof data?.raised === 'boolean' ? data.raised : false;
 
-				if (!roomId || !socket.participantId) {
-					callback({ success: false, error: 'Invalid room or participant' });
-					return;
-				}
-
-				if (raised) {
-					deps.registry.setRaisedHand(
-						roomId,
-						socket.participantId,
-						new Date().toISOString(),
-					);
-				} else {
-					deps.registry.clearRaisedHand(roomId, socket.participantId);
-				}
-
 				deps.registry.emitRaisedHand(roomId, {
-					participantId: socket.participantId,
+					participantId,
 					raised,
 					timestamp: new Date().toISOString(),
 				});

--- a/suite/meet/sfu-server/src/server/handlers/ReactionHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ReactionHandlers.ts
@@ -2,24 +2,28 @@ import type { Socket } from 'socket.io';
 import type { ReactionMessage } from '../../types';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
+import { ensureParticipantOwner } from './utils';
 
 export function registerReactionHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
 		socket.on('reaction:send', (data = {}) => {
 			try {
 				deps.authManager.ensureFullAccess(socket);
-				const roomId = socket.roomId;
+				const { roomId, participantId } = ensureParticipantOwner(
+					socket,
+					deps.registry,
+				);
 				const reaction =
 					typeof data.reaction === 'string' ? data.reaction : null;
 
-				if (!roomId || !reaction || !socket.participantId) {
+				if (!reaction) {
 					return;
 				}
 
 				const payload: ReactionMessage = {
 					roomId,
 					reaction,
-					fromUser: socket.participantId,
+					fromUser: participantId,
 					fromName: socket.userName,
 					timestamp: new Date().toISOString(),
 				};

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -22,6 +22,7 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 		const scope = socket.scope ?? 'unknown';
 		let participantClaimed = false;
 		let firstConnection = false;
+		let participantReconnected = false;
 		if (socket.scope === 'full' && !socket.peerId) socket.peerId = socket.id;
 		const peerId = socket.peerId ?? participantId;
 		const rejoin = Boolean(
@@ -57,6 +58,9 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 				}
 				participantClaimed = true;
 				firstConnection = acquisition.status === 'acquired';
+				participantReconnected =
+					acquisition.status === 'reconnect' ||
+					acquisition.status === 'takeover';
 				if (acquisition.replacedSocket) {
 					acquisition.replacedSocket.emit('participant_connection_replaced', {
 						reason: acquisition.status,
@@ -120,6 +124,15 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 					deps.registry.emitParticipantEvent(
 						scopedRoomId,
 						'participant_joined',
+						participantId,
+						userData,
+					);
+				} else if (
+					participantReconnected &&
+					isRealParticipant(userData.userId)
+				) {
+					deps.registry.emitParticipantUpdated(
+						scopedRoomId,
 						participantId,
 						userData,
 					);
@@ -239,23 +252,33 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 
 	return (socket: Socket) => {
 		socket.on('recording:join', async (data, callback) => {
+			let roomJoinAttempted = false;
+			let fieldsAssigned = false;
+			let recorderJoinAttempted = false;
+			let peerCreationAttempted = false;
+			let roomId: string | undefined;
+			let peerId: string | undefined;
 			try {
 				deps.authManager.ensureRecorderAccess(socket);
 				if (data?.roomId !== socket.meetingId)
 					throw new Error('Room ID mismatch');
-				const roomId = getRoomId(socket);
-				const peerId = socket.userId;
+				roomId = getRoomId(socket);
+				peerId = socket.userId;
 				await deps.mediasoup.createRoom(roomId, (roomIdInner, peerIds) => {
 					deps.registry.emitActiveSpeaker(
 						roomIdInner,
 						participantIdsForPeers(deps, roomIdInner, peerIds),
 					);
 				});
-				socket.join(roomId);
+				roomJoinAttempted = true;
+				await socket.join(roomId);
 				socket.roomId = roomId;
 				socket.participantId = peerId;
+				fieldsAssigned = true;
+				recorderJoinAttempted = true;
 				deps.registry.joinRecorder(socket, roomId, peerId);
-				deps.mediasoup.addPeer(roomId, peerId, {
+				peerCreationAttempted = true;
+				await deps.mediasoup.addPeer(roomId, peerId, {
 					name: 'Recorder',
 					userId: peerId,
 					audio_enabled: false,
@@ -267,6 +290,45 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 				});
 				callback({ success: true });
 			} catch (error) {
+				if (roomId && peerId) {
+					if (peerCreationAttempted) {
+						try {
+							await deps.mediasoup.removePeer(roomId, peerId);
+						} catch (cleanupError) {
+							loggers.socketHandler.warn(
+								'Recorder peer rollback failed for %s: %s',
+								peerId,
+								(cleanupError as Error).message,
+							);
+						}
+					}
+					if (recorderJoinAttempted) {
+						try {
+							deps.registry.leaveRecorderRoom(socket, roomId, peerId);
+						} catch (cleanupError) {
+							loggers.socketHandler.warn(
+								'Recorder registry rollback failed for %s: %s',
+								peerId,
+								(cleanupError as Error).message,
+							);
+						}
+					}
+					if (roomJoinAttempted) {
+						try {
+							socket.leave(roomId);
+						} catch (cleanupError) {
+							loggers.socketHandler.warn(
+								'Recorder room rollback failed for %s: %s',
+								peerId,
+								(cleanupError as Error).message,
+							);
+						}
+					}
+				}
+				if (fieldsAssigned) {
+					socket.roomId = undefined;
+					socket.participantId = undefined;
+				}
 				callback({ success: false, error: (error as Error).message });
 			}
 		});

--- a/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomQueryHandlers.ts
@@ -6,6 +6,22 @@ import { checkSocketRateLimits, getRoomId } from './utils';
 
 export function registerRoomQueryHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
+		socket.on('recording:get_projection_snapshot', (_data, callback) => {
+			try {
+				deps.authManager.ensureRecorderAccess(socket);
+				const roomId = getRoomId(socket);
+				if (!deps.registry.isJoinedActiveRecorder(socket, roomId))
+					throw new Error('Recorder must join the room first');
+
+				callback({
+					success: true,
+					snapshot: deps.registry.getRecorderStageSnapshot(roomId),
+				});
+			} catch (error) {
+				callback({ success: false, error: (error as Error).message });
+			}
+		});
+
 		socket.on('get_router_rtp_capabilities', async (_data, callback) => {
 			try {
 				deps.authManager.ensureMediaConsumerAccess(socket);

--- a/suite/meet/sfu-server/src/server/handlers/__tests__/ProjectionParticipantHandlers.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/__tests__/ProjectionParticipantHandlers.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerChatHandlers } from '../ChatHandlers';
+import { registerHostControlHandlers } from '../HostControlHandlers';
+import { registerMediaControlHandlers } from '../MediaControlHandlers';
+import { registerProducerHandlers } from '../ProducerHandlers';
+import { registerRaiseHandHandlers } from '../RaiseHandHandlers';
+import { registerReactionHandlers } from '../ReactionHandlers';
+
+type Handler = (data: never, callback?: (response: unknown) => void) => unknown;
+
+function setup(isOwner: boolean) {
+	const handlers = new Map<string, Handler>();
+	const socket = {
+		id: 'socket-1',
+		roomId: 'room-1',
+		participantId: 'participant-1',
+		peerId: 'peer-1',
+		userId: 'participant-1',
+		userName: 'Alice',
+		isHost: true,
+		isCohost: false,
+		on: vi.fn((event: string, handler: Handler) =>
+			handlers.set(event, handler),
+		),
+		emit: vi.fn(),
+	};
+	const registry = {
+		isParticipantOwner: vi.fn(() => isOwner),
+		emitProducerCreated: vi.fn(),
+		emitProducerPaused: vi.fn(),
+		emitMediaControlUpdate: vi.fn(),
+		emitRaisedHand: vi.fn(),
+		emitReaction: vi.fn(),
+		emitPublicChat: vi.fn(),
+		emitParticipantEvent: vi.fn(),
+		recordChatMessage: vi.fn(),
+		setRaisedHand: vi.fn(),
+		clearRaisedHand: vi.fn(),
+		hasRaisedHand: vi.fn(() => false),
+		isHostOnlyChat: vi.fn(() => false),
+		releaseParticipant: vi.fn(() => false),
+	};
+	const mediasoup = {
+		createProducer: vi.fn(async () => ({
+			id: 'producer-1',
+			kind: 'video',
+			appData: {},
+		})),
+		assertProducerAccess: vi.fn(),
+		closeProducer: vi.fn(),
+		pauseProducer: vi.fn(async () => true),
+		resumeProducer: vi.fn(async () => true),
+		applyMediaControl: vi.fn(),
+		participantExistsInRoom: vi.fn(() => true),
+	};
+	const deps = {
+		registry,
+		mediasoup,
+		authManager: { ensureFullAccess: vi.fn() },
+		telemetry: { recordMediaOperation: vi.fn() },
+		io: { sockets: { adapter: { rooms: new Map() }, sockets: new Map() } },
+		roomLifecycle: { scheduleCleanupIfHumanEmpty: vi.fn() },
+		e2eeEpochRelay: {
+			getCurrentEpochNumber: vi.fn(() => 0),
+			requestCommitForRemoval: vi.fn(),
+		},
+	};
+	registerProducerHandlers(deps as never)(socket as never);
+	registerMediaControlHandlers(deps as never)(socket as never);
+	registerRaiseHandHandlers(deps as never)(socket as never);
+	registerReactionHandlers(deps as never)(socket as never);
+	registerChatHandlers(deps as never)(socket as never);
+	registerHostControlHandlers(deps as never)(socket as never);
+	return { handlers, mediasoup, registry };
+}
+
+describe('projection-producing participant handlers', () => {
+	it('rejects every event from a participant whose ownership was released before disconnect', async () => {
+		const { handlers, mediasoup, registry } = setup(false);
+		const callback = vi.fn();
+
+		await handlers.get('create_producer')?.(
+			{
+				kind: 'video',
+				appData: {},
+				rtpParameters: {},
+				transportId: 'tx',
+			} as never,
+			callback,
+		);
+		await handlers.get('close_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			callback,
+		);
+		await handlers.get('pause_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			callback,
+		);
+		await handlers.get('resume_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			callback,
+		);
+		await handlers.get('media_control')?.({ action: 'mute' } as never);
+		handlers.get('raise_hand')?.({ raised: true } as never, callback);
+		handlers.get('reaction:send')?.({ reaction: 'wave' } as never);
+		handlers.get('chat:send')?.({ message: 'hello' } as never, callback);
+		await handlers.get('host_control')?.(
+			{ action: 'lower_hand', targetParticipantId: 'participant-2' } as never,
+			callback,
+		);
+
+		expect(mediasoup.createProducer).not.toHaveBeenCalled();
+		expect(mediasoup.closeProducer).not.toHaveBeenCalled();
+		expect(mediasoup.pauseProducer).not.toHaveBeenCalled();
+		expect(mediasoup.resumeProducer).not.toHaveBeenCalled();
+		expect(mediasoup.applyMediaControl).not.toHaveBeenCalled();
+		expect(registry.recordChatMessage).not.toHaveBeenCalled();
+		expect(registry.setRaisedHand).not.toHaveBeenCalled();
+		expect(registry.emitProducerCreated).not.toHaveBeenCalled();
+		expect(registry.emitProducerPaused).not.toHaveBeenCalled();
+		expect(registry.emitMediaControlUpdate).not.toHaveBeenCalled();
+		expect(registry.emitRaisedHand).not.toHaveBeenCalled();
+		expect(registry.emitReaction).not.toHaveBeenCalled();
+		expect(registry.emitPublicChat).not.toHaveBeenCalled();
+		expect(registry.emitParticipantEvent).not.toHaveBeenCalled();
+	});
+
+	it('projects successful pause and resume changes for the current owner', async () => {
+		const { handlers, registry } = setup(true);
+
+		await handlers.get('pause_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			vi.fn(),
+		);
+		await handlers.get('resume_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			vi.fn(),
+		);
+
+		expect(registry.emitProducerPaused.mock.calls).toEqual([
+			[
+				'room-1',
+				{
+					participantId: 'participant-1',
+					producerId: 'producer-1',
+					paused: true,
+				},
+			],
+			[
+				'room-1',
+				{
+					participantId: 'participant-1',
+					producerId: 'producer-1',
+					paused: false,
+				},
+			],
+		]);
+	});
+
+	it('rechecks ownership after an awaited producer mutation', async () => {
+		const { handlers, registry } = setup(true);
+		registry.isParticipantOwner
+			.mockReturnValueOnce(true)
+			.mockReturnValueOnce(false);
+
+		await handlers.get('pause_producer')?.(
+			{ producerId: 'producer-1' } as never,
+			vi.fn(),
+		);
+
+		expect(registry.emitProducerPaused).not.toHaveBeenCalled();
+	});
+});

--- a/suite/meet/sfu-server/src/server/handlers/__tests__/ProjectionParticipantHandlers.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/__tests__/ProjectionParticipantHandlers.test.ts
@@ -170,4 +170,27 @@ describe('projection-producing participant handlers', () => {
 
 		expect(registry.emitProducerPaused).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		['audio', false, 'mute'],
+		['audio', true, 'unmute'],
+		['video', false, 'video_off'],
+		['video', true, 'video_on'],
+	] as const)('normalizes legacy %s media state before projection', async (type, enabled, action) => {
+		const { handlers, mediasoup, registry } = setup(true);
+
+		await handlers.get('media_control')?.({
+			action: { type, enabled },
+		} as never);
+
+		expect(mediasoup.applyMediaControl).toHaveBeenCalledWith(
+			'room-1',
+			'participant-1',
+			action,
+		);
+		expect(registry.emitMediaControlUpdate).toHaveBeenCalledWith(
+			'room-1',
+			expect.objectContaining({ action }),
+		);
+	});
 });

--- a/suite/meet/sfu-server/src/server/handlers/__tests__/RoomQueryHandlers.test.ts
+++ b/suite/meet/sfu-server/src/server/handlers/__tests__/RoomQueryHandlers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createManager } from '../../__tests__/test-helpers';
+import type { RoomRegistry } from '../../RoomRegistry';
+
+function getRegistry(harness: ReturnType<typeof createManager>): RoomRegistry {
+	return (
+		harness.manager as unknown as {
+			registry: RoomRegistry;
+		}
+	).registry;
+}
+
+describe('RoomQueryHandlers recorder projection snapshot', () => {
+	it('rejects a recorder before it joins the room', () => {
+		const harness = createManager();
+		const socket = harness.createSocket({
+			id: 'recorder-socket',
+			scope: 'recording',
+			userId: 'recorder:recording-1',
+			recordingProofComplete: true,
+			recordingClaims: {
+				recording_id: 'recording-1',
+				recorder_job_id: 'job-1',
+			} as never,
+		});
+		harness.connect(socket);
+		getRegistry(harness).activateRecorder(socket, 'recording-1', 'job-1');
+		const callback = vi.fn();
+
+		socket.fire('recording:get_projection_snapshot', {}, callback);
+
+		expect(harness.authManager.ensureRecorderAccess).toHaveBeenCalledWith(
+			socket,
+		);
+		expect(callback).toHaveBeenCalledWith({
+			success: false,
+			error: 'Recorder must join the room first',
+		});
+	});
+
+	it('returns one retained projection cut to the joined active recorder', async () => {
+		const harness = createManager();
+		const socket = harness.createSocket({
+			id: 'recorder-socket',
+			scope: 'recording',
+			userId: 'recorder:recording-1',
+			recordingProofComplete: true,
+			recordingClaims: {
+				recording_id: 'recording-1',
+				recorder_job_id: 'job-1',
+			} as never,
+		});
+		harness.connect(socket);
+		const registry = getRegistry(harness);
+		registry.activateRecorder(socket, 'recording-1', 'job-1');
+		socket.fire('recording:join', { roomId: 'room-1' }, vi.fn());
+		await new Promise((resolve) => setImmediate(resolve));
+		registry.emitParticipantEvent('room-1', 'participant_joined', 'p1', {
+			name: 'Alice',
+			userId: 'account-1',
+			audio_enabled: true,
+			video_enabled: false,
+		});
+		const callback = vi.fn();
+
+		socket.fire('recording:get_projection_snapshot', {}, callback);
+
+		expect(callback).toHaveBeenCalledWith({
+			success: true,
+			snapshot: expect.objectContaining({
+				protocol_version: 1,
+				room_id: 'room-1',
+				cursor: 1,
+				participants: [
+					{
+						participant_id: 'p1',
+						name: 'Alice',
+						audio_enabled: true,
+						video_enabled: false,
+					},
+				],
+			}),
+		});
+	});
+});

--- a/suite/meet/sfu-server/src/server/handlers/utils.ts
+++ b/suite/meet/sfu-server/src/server/handlers/utils.ts
@@ -1,6 +1,7 @@
 import type { Server, Socket } from 'socket.io';
 import { loggers } from '../../utils/logger';
 import type { RateLimiter } from '../../utils/rateLimiter';
+import type { RoomRegistry } from '../RoomRegistry';
 import type { TypedSocket } from './Handler';
 
 export function isRealParticipant(participantId: string): boolean {
@@ -18,6 +19,22 @@ export function getRoomId(socket: Socket): string {
 
 export function getPeerId(socket: Socket): string {
 	return socket.peerId ?? socket.userId;
+}
+
+export function ensureParticipantOwner(
+	socket: Socket,
+	registry: RoomRegistry,
+): { roomId: string; participantId: string } {
+	const roomId = socket.roomId;
+	const participantId = socket.participantId;
+	if (
+		!roomId ||
+		!participantId ||
+		!registry.isParticipantOwner(socket, roomId, participantId)
+	) {
+		throw new Error('Participant connection is no longer active');
+	}
+	return { roomId, participantId };
 }
 
 export function checkSocketRateLimits(

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -49,7 +49,13 @@ import type {
 	RaiseHandRequest,
 	ReactionMessage,
 	ReactionSendRequest,
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionEvent,
+	RecorderStageProjectionPayload,
+	RecorderStageSnapshot,
 	RecordingJoinRequest,
+	RecordingProjectionSnapshotResponse,
 	RecordingProofChallenge,
 	RecordingProofRequest,
 	RecordingProofResponse,
@@ -103,7 +109,13 @@ export type {
 	RaiseHandRequest,
 	ReactionMessage,
 	ReactionSendRequest,
+	RecorderStageParticipant,
+	RecorderStageProducer,
+	RecorderStageProjectionEvent,
+	RecorderStageProjectionPayload,
+	RecorderStageSnapshot,
 	RecordingJoinRequest,
+	RecordingProjectionSnapshotResponse,
 	RecordingProofChallenge,
 	RecordingProofRequest,
 	RecordingProofResponse,
@@ -128,6 +140,7 @@ export type {
 // Socket.IO types
 export interface ServerToClientEvents {
 	'recording:challenge': (data: RecordingProofChallenge) => void;
+	'recording:projection': (data: RecorderStageProjectionEvent) => void;
 	participant_joined: (data: ParticipantJoinedEvent) => void;
 	participant_left: (data: ParticipantLeftEvent) => void;
 	participant_connection_replaced: (data: {
@@ -165,6 +178,10 @@ export interface ClientToServerEvents {
 	'recording:join': (
 		data: RecordingJoinRequest,
 		callback: (response: SFUResponse) => void,
+	) => void;
+	'recording:get_projection_snapshot': (
+		data: Record<string, never>,
+		callback: (response: RecordingProjectionSnapshotResponse) => void,
 	) => void;
 	client_telemetry: (data: ClientTelemetryEvent) => void;
 	'auth:update_token': (

--- a/suite/meet/types/index.ts
+++ b/suite/meet/types/index.ts
@@ -18,6 +18,74 @@ export interface RecordingProofRequest {
 	signature: string;
 }
 
+export interface RecorderStageParticipant {
+	participant_id: string;
+	name: string;
+	avatar?: string;
+	audio_enabled: boolean;
+	video_enabled: boolean;
+}
+
+export interface RecorderStageProducer {
+	producer_id: string;
+	participant_id: string;
+	kind: 'audio' | 'video';
+	paused: boolean;
+	is_screen: boolean;
+	observed_at: string;
+}
+
+export interface RecorderStageSnapshot {
+	protocol_version: 1;
+	room_id: string;
+	cursor: number;
+	observed_at: string;
+	participants: RecorderStageParticipant[];
+	producers: RecorderStageProducer[];
+	raised_hands: Record<string, string>;
+	active_speaker_ids: string[];
+}
+
+export type RecorderStageProjectionPayload =
+	| { type: 'participant_joined'; participant: RecorderStageParticipant }
+	| { type: 'participant_updated'; participant: RecorderStageParticipant }
+	| { type: 'participant_left'; participant_id: string }
+	| { type: 'producer_created'; producer: RecorderStageProducer }
+	| { type: 'producer_updated'; producer_id: string; paused: boolean }
+	| {
+			type: 'producer_closed';
+			producer_id: string;
+			participant_id: string;
+			is_screen: boolean;
+	  }
+	| {
+			type: 'media_control';
+			participant_id: string;
+			action: MediaControlAction;
+	  }
+	| { type: 'active_speaker'; participant_ids: string[] }
+	| { type: 'hand_raised'; participant_id: string; raised: boolean }
+	| { type: 'reaction'; from_user: string; reaction: string }
+	| {
+			type: 'chat_message';
+			message_id: string;
+			message: string;
+			from_user: string;
+			from_name: string;
+	  };
+
+export interface RecorderStageProjectionEvent {
+	protocol_version: 1;
+	room_id: string;
+	cursor: number;
+	observed_at: string;
+	payload: RecorderStageProjectionPayload;
+}
+
+export type RecordingProjectionSnapshotResponse =
+	| { success: true; snapshot: RecorderStageSnapshot }
+	| { success: false; error: string };
+
 export type RecordingProofResponse =
 	| { protocol_version: 1; success: true }
 	| {


### PR DESCRIPTION
## Summary

- project an ordered, recorder-safe Shared Stage from the SFU into the standard Meet stores and `MeetingLayout`
- gate each FFmpeg capture epoch on snapshot reconciliation, media attachment, transient reset, and a committed frame
- make capture timestamps durable before browser release and preserve startup/recovery ordering across crashes
- fail closed on invalid projection data and cover the complete SFU-to-browser-to-artifact media path

## Follow-up fixes

- recover usable media from the FFmpeg launch-to-manifest crash window
- normalize legacy media-control fallbacks before recorder projection

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.4% (no change) · Frontend 34.9% (+0.3%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.4%** (21,072 / 37,353) (no change) | Unavailable |
| Frontend | **34.9%** (14,149 / 40,495) (+0.3%) | **29.5%** (9,142 / 30,992) (+0.4%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33484418471) for commit `a440887`.</sub>

</details>
<!-- suite-coverage:end -->