### PR TITLE
fix(ci): show zero coverage deltas

### DIFF
--- a/.github/scripts/coverage_report.py
+++ b/.github/scripts/coverage_report.py
@@ -58,7 +58,7 @@ def delta(current: float | None, baseline: float | None) -> str:
         return ""
     change = current - baseline
     if abs(change) < 0.05:
-        return " (no change)"
+        return " (+0%)"
     return f" ({change:+.1f}%)"
 
 

--- a/.github/scripts/test_coverage_reporting.py
+++ b/.github/scripts/test_coverage_reporting.py
@@ -55,6 +55,9 @@ class CoverageReportTest(unittest.TestCase):
         self.assertIn("Backend 85.0% (+5.0%)", markdown)
         self.assertIn("**70.0%** (70 / 100) (-2.0%)", markdown)
 
+    def test_renders_rounded_zero_delta_as_percentage(self):
+        self.assertEqual(coverage_report.delta(34.6, 34.6), " (+0%)")
+
 
 class UpdatePrCoverageTest(unittest.TestCase):
     def test_appends_and_replaces_one_block(self):

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -162,6 +162,7 @@ jobs:
         working-directory: /home/runner/frappe-bench
         run: |
           mkdir -p "$GITHUB_WORKSPACE/test-results/backend"
+          printf '[run]\nbranch = true\n' > "$RUNNER_TEMP/suite-coveragerc"
           bench --site test_site set-config allow_tests true
           status=0
           bench --site test_site run-tests --app suite --coverage --junit-xml-output "$GITHUB_WORKSPACE/test-results/backend/junit-fragments.xml" || status=$?
@@ -171,6 +172,7 @@ jobs:
           rm "$GITHUB_WORKSPACE/test-results/backend/junit-fragments.xml"
           exit "$status"
         env:
+          COVERAGE_RCFILE: ${{ runner.temp }}/suite-coveragerc
           TYPE: server
 
       - name: Check Background Worker


### PR DESCRIPTION
## Summary

- display rounded zero coverage changes as `+0%` instead of prose
- collect backend branch coverage through Suite CI’s coverage configuration
- keep positive, negative, and unavailable delta behavior unchanged

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.4% (no change) · Frontend 34.9% (no change)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.4%** (21,072 / 37,353) (no change) | **29.3%** (2,828 / 9,654) |
| Frontend | **34.9%** (14,149 / 40,495) (no change) | **29.5%** (9,142 / 30,992) (no change) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33487180513) for commit `fc1a06a`.</sub>

</details>
<!-- suite-coverage:end -->
