### PR TITLE
feat(calendar): delete and a legible title in the event modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
     "feather-icons": "^4.29.2",
     "file-saver": "^2.0.5",
     "firebase": "^12.2.1",
-    "frappe-ui": "frappe/frappe-ui#a89a95fa902e18f71d01c369ad92e5cb9d3ec954",
+    "frappe-ui": "frappe/frappe-ui#965df418bb244454ea5266b57fb2d8c3a7f8a199",
     "fuzzysort": "^3.1.0",
     "gemoji": "^8.1.0",
     "hast-util-to-html": "^9.0.5",

--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -12,7 +12,6 @@ import {
 	Repeat,
 	SquarePen,
 	Text,
-	Trash2,
 	Users,
 	X,
 } from 'lucide-vue-next'
@@ -26,6 +25,7 @@ import { fromEventZone, inUserTimeZone } from '@/apps/calendar/utils/datetime'
 import { eventLastDay, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
+import { useEventDelete } from '@/apps/calendar/composables/useEventDelete'
 import EventParticipantList from '@/apps/calendar/components/EventParticipantList.vue'
 import LinkifiedText from '@/components/LinkifiedText.vue'
 
@@ -277,134 +277,19 @@ const hasDetails = computed(
 
 // --- Actions dropdown (delete) ---
 
-const dropdownOptions = computed(() => {
-	const editOption = { label: __('Edit'), icon: SquarePen, onClick: () => emit('edit') }
-
-	if (calendarEvent.recurrence_id)
-		return [
-			editOption,
-			{
-				label: __('Delete'),
-				icon: Trash2,
-				submenu: [
-					{ label: __('This instance'), onClick: () => handleDeleteEventInstance() },
-					{
-						label: __('This and following instances'),
-						onClick: () => handleDeleteFollowingEventInstances(),
-					},
-					{ label: __('Entire series'), onClick: () => handleDeleteEvent() },
-				],
-			},
-		]
-	return [
-		editOption,
-		{ label: __('Delete'), icon: Trash2, onClick: () => handleDeleteEvent() },
-	]
-})
-
-// --- Server calls ---
-
-const editEvent = createResource({
-	url: 'suite.calendar.api.edit_calendar_event',
-	makeParams: ({ patch }) => ({
-		account: store.accountId,
-		// master_id is only set on recurring events; fall back to the event's own id
-		id: calendarEvent.master_id || calendarEvent.id,
-		...patch,
-		send_scheduling_messages: true,
-	}),
-	onSuccess: () => emit('reloadEvents'),
-})
-
-// When the organizer deletes an event with other participants, offer to email a cancellation
-// (mirrors the "Notify Participants" prompt shown when creating/editing an event).
-const isOrganizer = computed(
-	() =>
-		participantIdentities.data?.some(
-			(id) => id.email === (calendarEvent.organizer || '').replace('mailto:', ''),
-		) ?? false,
-)
-const hasParticipantsOtherThanUser = computed(
-	() =>
-		calendarEvent.participants?.some((p) => participantIdentities.data?.every((i) => i.email !== p.email)) ??
-		false,
-)
-
-const showNotifyModal = ref(false)
-const pendingDelete = ref<((sendEmail: boolean) => void) | null>(null)
-
-const confirmDelete = (submit: (sendEmail: boolean) => Promise<any>, recurring: boolean) => {
-	const run = (sendEmail: boolean) => {
-		showNotifyModal.value = false
-		toast.promise(submit(sendEmail), {
-			loading: recurring ? __('Deleting events...') : __('Deleting event...'),
-			success: recurring ? __('Events deleted.') : __('Event deleted.'),
-			error: __('Action failed. Please try again in some time.'),
-		})
-	}
-
-	// A draft never sent its invitations, so there is no one to tell it is gone.
-	if (isOrganizer.value && hasParticipantsOtherThanUser.value && !calendarEvent.isDraft) {
-		pendingDelete.value = run
-		showNotifyModal.value = true
-	} else {
-		run(false)
-	}
-}
-
-const handleDeleteEventInstance = () =>
-	confirmDelete((sendEmail) => deleteEventInstance.submit({ sendEmail }), false)
-
-const handleDeleteFollowingEventInstances = () => {
-	const recurrenceRule = { ...calendarEvent.recurrence_rule }
-	recurrenceRule.until = `${calendarEvent.date}T00:00:00Z`
-	const patch = { recurrence_rule: JSON.stringify(recurrenceRule) }
-
-	toast.promise(
-		editEvent.submit({ patch }).then(() => emit('close')),
-		{
-			loading: __('Deleting events...'),
-			success: __('Events deleted.'),
-			error: __('Action failed. Please try again in some time.'),
+const { deleteOption, isDeleting, showNotifyModal, pendingDelete, NOTIFY_DELETE_OPTIONS } =
+	useEventDelete(
+		() => calendarEvent,
+		() => {
+			emit('reloadEvents')
+			emit('close')
 		},
 	)
-}
 
-const handleDeleteEvent = () =>
-	confirmDelete((sendEmail) => deleteEvent.submit({ sendEmail }), !!calendarEvent.recurrence_id)
-
-const deleteEventInstance = createResource({
-	url: 'suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_event_instance',
-	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
-		account: store.accountId,
-		master_id: calendarEvent.master_id,
-		recurrence_id: calendarEvent.recurrence_id,
-		send_scheduling_messages: sendEmail,
-	}),
-	onSuccess: () => {
-		emit('reloadEvents')
-		emit('close')
-	},
-})
-
-const deleteEvent = createResource({
-	url: 'suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_events',
-	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
-		account: store.accountId,
-		ids: [calendarEvent.master_id || calendarEvent.id],
-		send_scheduling_messages: sendEmail,
-	}),
-	onSuccess: () => {
-		emit('reloadEvents')
-		emit('close')
-	},
-})
-
-const NOTIFY_DELETE_OPTIONS = {
-	title: __('Notify Participants'),
-	icon: { name: 'lucide-bell' },
-	message: __('Send a cancellation email to let attendees know this event was deleted?'),
-}
+const dropdownOptions = computed(() => [
+	{ label: __('Edit'), icon: SquarePen, onClick: () => emit('edit') },
+	deleteOption.value,
+])
 
 const openUrl = (location: string) => {
 	if (isUrl(location)) window.open(location, '_blank')
@@ -433,7 +318,7 @@ const openUrl = (location: string) => {
 				<Dropdown :options="dropdownOptions">
 					<Button
 						variant="ghost"
-						:disabled="deleteEventInstance.loading || deleteEvent.loading"
+						:disabled="isDeleting"
 					>
 						<MoreHorizontal class="icon text-ink-gray-7" />
 					</Button>

--- a/frontend/src/apps/calendar/components/EventParticipantList.vue
+++ b/frontend/src/apps/calendar/components/EventParticipantList.vue
@@ -59,7 +59,10 @@ const getParticipantStatusValues = (status: string) => {
 							/>
 						</div>
 					</div>
-					<span class="text-ink-gray-5 text-sm">{{ p.email }}</span>
+					<!-- The paragraph variant, not `text-sm`: at 13px its 1.15 leading gives a
+					     line box shorter than the glyphs themselves, so the descender of a g or a
+					     y hung below it and the participants list clipped it at its scroll edge. -->
+					<span class="text-ink-gray-5 text-p-sm">{{ p.email }}</span>
 				</div>
 			</div>
 

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -1,6 +1,18 @@
 <script setup lang="ts">
 import { computed, inject, nextTick, reactive, ref, watch } from 'vue'
-import { AlignLeft, Bell, Briefcase, ChevronDown, Clock, Copy, MapPin, Users, X } from 'lucide-vue-next'
+import {
+	AlignLeft,
+	Bell,
+	Briefcase,
+	ChevronDown,
+	Clock,
+	Copy,
+	MapPin,
+	MoreHorizontal,
+	Pencil,
+	Users,
+	X,
+} from 'lucide-vue-next'
 import { Button, Dialog, Dropdown, FormControl, Switch, createResource, toast } from 'frappe-ui'
 
 import meetLogo from '@/assets/app-logos/meet.png'
@@ -8,6 +20,7 @@ import { getMeetUrl, getReorderedParticipants } from '@/apps/calendar/utils'
 import { fromEventZone, fromWallClock, inUserTimeZone } from '@/apps/calendar/utils/datetime'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
+import { useEventDelete } from '@/apps/calendar/composables/useEventDelete'
 import EventAlertList from '@/apps/calendar/components/EventAlertList.vue'
 import ParticipantSelector from '@/apps/calendar/components/ParticipantSelector.vue'
 import EventRepeatSettingsModal from '@/apps/calendar/components/Modals/EventRepeatSettingsModal.vue'
@@ -28,6 +41,17 @@ const isNew = computed(() => !selectedEvent?.calendarEvent)
 const isDraft = computed(() => !!selectedEvent?.calendarEvent?.isDraft)
 // Set for the length of one save: the resources read it into `draft`.
 const savingDraft = ref(false)
+
+// The lead title reads as plain bold text until you click it, so a pencil sits beside
+// it as the affordance; clicking it puts the caret in the field. Once the field has the
+// caret the hint has done its job and would only sit there restating it, so it goes.
+// Hovering the row dotted-underlines the title instead of tinting the pencil: the cue
+// belongs on the thing you are about to edit, and it stays out of the way while typing.
+// The underline colour goes through the raw token var — ink-gray-* are frappe-ui CSS
+// classes, not Tailwind palette colours, so `decoration-ink-gray-4` generates nothing
+// and the rule would silently fall back to the title's own near-black.
+const titleInput = ref<HTMLInputElement | null>(null)
+const isTitleFocused = ref(false)
 
 // --- Event initialization ---
 
@@ -634,6 +658,28 @@ const setAllDay = (isAllDay: boolean) => {
 	if (untouched) event.alerts = [defaultAlert(isAllDay, event.startDate)]
 }
 
+// --- Delete ---
+//
+// Only a saved event has something to delete; a new one is thrown away by
+// Cancel. Deleting leaves straight away — there is nothing left to keep, so
+// the unsaved-changes question would be noise.
+
+const {
+	deleteOption,
+	isDeleting,
+	showNotifyModal: showNotifyDeleteModal,
+	pendingDelete,
+	NOTIFY_DELETE_OPTIONS,
+} = useEventDelete(
+	() => selectedEvent?.calendarEvent,
+	() => {
+		show.value = false
+		emit('reloadEvents')
+	},
+)
+
+const eventOptions = computed(() => [deleteOption.value])
+
 // --- Dialog options ---
 
 const isSaving = computed(
@@ -650,18 +696,13 @@ const disableSave = computed(() => {
 	return false
 })
 
-// The primary says what it does: "Send" while there are invitations to send —
-// a new event or a draft with participants — and "Save" otherwise.
-// The primary says what it does: "Send" while there are invitations to send
-// (a new event or a draft with participants), "Save" otherwise. A new event
-// or a draft can also be kept as a draft — the split beside the primary, as
-// mail's compose has it; a published event cannot go back to being one, so
-// it gets a plain button.
-const primaryLabel = computed(() =>
-	(isNew.value || isDraft.value) && hasParticipantsOtherThanUser(event.participants)
-		? __('Send')
-		: __('Save'),
-)
+// The primary always reads "Save": whether anything is sent is the next
+// question, asked by the Notify Participants prompt behind it, and a button
+// that already said "Send" made that prompt look like a second one.
+//
+// A new event or a draft can also be kept as a draft — the split beside the
+// primary, as mail's compose has it; a published event cannot go back to
+// being one, so it gets a plain button.
 const canSaveDraft = computed(() => isNew.value || isDraft.value)
 const draftOptions = computed(() => [
 	{ label: __('Save as draft'), icon: 'lucide-file-pen-line', onClick: saveDraftAndLeave },
@@ -717,21 +758,66 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 				<!-- header -->
 				<div class="flex items-center border-b px-6 py-4">
 					<span class="text-md font-semibold">{{ dialogTitle }}</span>
-					<Button variant="ghost" class="ml-auto" @click="leave">
-						<template #icon><X :size="18" class="icon text-ink-gray-5" /></template>
-					</Button>
+					<div class="ml-auto flex items-center gap-1">
+						<Dropdown v-if="!isNew" :options="eventOptions">
+							<Button variant="ghost" :disabled="isDeleting" :aria-label="__('Event options')">
+								<template #icon>
+									<MoreHorizontal :size="18" class="icon text-ink-gray-5" />
+								</template>
+							</Button>
+						</Dropdown>
+						<Button variant="ghost" @click="leave">
+							<template #icon><X :size="18" class="icon text-ink-gray-5" /></template>
+						</Button>
+					</div>
 				</div>
 
 				<div class="flex min-h-0 flex-1">
 					<!-- left: event details -->
 					<div class="min-w-0 flex-1 overflow-y-auto px-6 py-5">
-						<!-- lead title -->
-						<input
-							v-model="event.title"
-							:autofocus="isNew"
-							:placeholder="__('Add title')"
-							class="w-full border-none bg-transparent p-0 pb-4 text-xl font-semibold tracking-tight text-ink-gray-8 outline-none placeholder:text-ink-gray-4 focus:ring-0"
-						/>
+						<!-- lead title. The field sizes to its own text — a mirror span shares
+						     the grid cell and sets the width — so the pencil sits against the
+						     title instead of adrift at the column's edge. The mirror falls back
+						     to the placeholder so an empty title still leaves something to click,
+						     and max-w-full keeps a long one inside the column, where the input
+						     scrolls internally as it did at full width. w-fit ends the hover
+						     group at the pencil, so the underline answers the title and the
+						     pencil only — not the empty column beside them, and the pb sits on
+						     a wrapper so the band below the title is outside it too. The click
+						     is on the row rather than its two children, which is what makes the
+						     gap between title and pencil live rather than dead space. -->
+						<div class="pb-4">
+							<div
+								class="group flex w-fit max-w-full items-center gap-2"
+								:class="{ 'cursor-pointer': !isTitleFocused }"
+								@click="titleInput?.focus()"
+							>
+								<div class="grid min-w-0 max-w-full">
+									<span
+										aria-hidden="true"
+										class="invisible col-start-1 row-start-1 whitespace-pre text-xl font-semibold tracking-tight"
+									>{{ event.title || __('Add title') }}</span>
+									<input
+										ref="titleInput"
+										v-model="event.title"
+										size="1"
+										:autofocus="isNew"
+										:placeholder="__('Add title')"
+										class="col-start-1 row-start-1 w-full border-none bg-transparent p-0 text-xl font-semibold tracking-tight text-ink-gray-8 decoration-[--ink-gray-4] decoration-dotted underline-offset-4 outline-none placeholder:text-ink-gray-4 focus:ring-0"
+										:class="{ 'cursor-pointer group-hover:underline': !isTitleFocused }"
+										@focus="isTitleFocused = true"
+										@blur="isTitleFocused = false"
+									/>
+								</div>
+								<button
+									v-if="event.title && !isTitleFocused"
+									class="shrink-0 cursor-pointer text-ink-gray-4"
+									:title="__('Edit title')"
+								>
+									<Pencil class="icon size-4" />
+								</button>
+							</div>
+						</div>
 
 						<!-- date & time — one grouped card -->
 						<div class="rounded-7 border border-outline-gray-2">
@@ -930,7 +1016,7 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 					     footer background as the divider. -->
 					<div class="flex items-center gap-px">
 						<Button
-							:label="primaryLabel"
+							:label="__('Save')"
 							variant="solid"
 							:disabled="disableSave"
 							class="min-w-16"
@@ -971,6 +1057,18 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 		<template #actions>
 			<div class="flex justify-end space-x-2">
 				<Button @click="handleSaveRecurringEvent(false)">{{ __('Entire Series') }}</Button>
+			</div>
+		</template>
+	</Dialog>
+	<Dialog v-model:open="showNotifyDeleteModal" v-bind="NOTIFY_DELETE_OPTIONS">
+		<template #actions>
+			<div class="flex justify-end space-x-2">
+				<Button variant="outline" @click="pendingDelete?.(false)">
+					{{ __('Skip') }}
+				</Button>
+				<Button variant="solid" @click="pendingDelete?.(true)">
+					{{ __('Send Email') }}
+				</Button>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/calendar/composables/useEventDelete.ts
+++ b/frontend/src/apps/calendar/composables/useEventDelete.ts
@@ -1,0 +1,144 @@
+import { computed, ref } from 'vue'
+import { Trash2 } from 'lucide-vue-next'
+import { createResource, toast } from 'frappe-ui'
+
+import { userStore } from '@/apps/calendar/stores/user'
+
+// Deleting an event is the same act wherever it is offered — the detail
+// sidebar's ⋯ menu and the edit modal's — so both read it from here: the same
+// choices for a recurring event, the same cancellation email, the same toasts.
+//
+// `getEvent` is a getter so the caller can hand over a prop it destructured;
+// `onDeleted` is what the host does afterwards (reload the calendar, close).
+export function useEventDelete(getEvent: () => any, onDeleted: () => void) {
+	const store = userStore()
+	const { participantIdentities } = store
+
+	const calendarEvent = computed(() => getEvent() ?? {})
+	const eventId = computed(() => calendarEvent.value.master_id || calendarEvent.value.id)
+
+	const deleteEventInstance = createResource({
+		url: 'suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_event_instance',
+		makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
+			account: store.accountId,
+			master_id: calendarEvent.value.master_id,
+			recurrence_id: calendarEvent.value.recurrence_id,
+			send_scheduling_messages: sendEmail,
+		}),
+		onSuccess: onDeleted,
+	})
+
+	const deleteEvent = createResource({
+		url: 'suite.calendar.doctype.calendar_event.calendar_event.delete_calendar_events',
+		makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
+			account: store.accountId,
+			ids: [eventId.value],
+			send_scheduling_messages: sendEmail,
+		}),
+		onSuccess: onDeleted,
+	})
+
+	// "This and following" is an edit, not a delete: the series stops the day before.
+	const editEvent = createResource({
+		url: 'suite.calendar.api.edit_calendar_event',
+		makeParams: ({ patch }: { patch: object }) => ({
+			account: store.accountId,
+			id: eventId.value,
+			...patch,
+			send_scheduling_messages: true,
+		}),
+		onSuccess: onDeleted,
+	})
+
+	const isDeleting = computed(
+		() => deleteEventInstance.loading || deleteEvent.loading || editEvent.loading,
+	)
+
+	// When the organizer deletes an event with other participants, offer to email a
+	// cancellation (mirrors the "Notify Participants" prompt shown when creating/editing).
+	const isOrganizer = computed(
+		() =>
+			participantIdentities.data?.some(
+				(id: any) => id.email === (calendarEvent.value.organizer || '').replace('mailto:', ''),
+			) ?? false,
+	)
+	const hasParticipantsOtherThanUser = computed(
+		() =>
+			calendarEvent.value.participants?.some((p: any) =>
+				participantIdentities.data?.every((i: any) => i.email !== p.email),
+			) ?? false,
+	)
+
+	const showNotifyModal = ref(false)
+	const pendingDelete = ref<((sendEmail: boolean) => void) | null>(null)
+
+	const confirmDelete = (submit: (sendEmail: boolean) => Promise<any>, recurring: boolean) => {
+		const run = (sendEmail: boolean) => {
+			showNotifyModal.value = false
+			toast.promise(submit(sendEmail), {
+				loading: recurring ? __('Deleting events...') : __('Deleting event...'),
+				success: recurring ? __('Events deleted.') : __('Event deleted.'),
+				error: __('Action failed. Please try again in some time.'),
+			})
+		}
+
+		// A draft never sent its invitations, so there is no one to tell it is gone.
+		if (isOrganizer.value && hasParticipantsOtherThanUser.value && !calendarEvent.value.isDraft) {
+			pendingDelete.value = run
+			showNotifyModal.value = true
+		} else {
+			run(false)
+		}
+	}
+
+	const handleDeleteEventInstance = () =>
+		confirmDelete((sendEmail) => deleteEventInstance.submit({ sendEmail }), false)
+
+	const handleDeleteEvent = () =>
+		confirmDelete(
+			(sendEmail) => deleteEvent.submit({ sendEmail }),
+			!!calendarEvent.value.recurrence_id,
+		)
+
+	const handleDeleteFollowingEventInstances = () => {
+		const recurrenceRule = { ...calendarEvent.value.recurrence_rule }
+		recurrenceRule.until = `${calendarEvent.value.date}T00:00:00Z`
+		const patch = { recurrence_rule: JSON.stringify(recurrenceRule) }
+
+		toast.promise(editEvent.submit({ patch }), {
+			loading: __('Deleting events...'),
+			success: __('Events deleted.'),
+			error: __('Action failed. Please try again in some time.'),
+		})
+	}
+
+	// The one entry a host drops into its own dropdown: a plain item, or the
+	// three choices a recurring event has.
+	const deleteOption = computed(() =>
+		calendarEvent.value.recurrence_id
+			? {
+					label: __('Delete'),
+					icon: Trash2,
+					submenu: [
+						{ label: __('This instance'), onClick: handleDeleteEventInstance },
+						{ label: __('This and following instances'), onClick: handleDeleteFollowingEventInstances },
+						{ label: __('Entire series'), onClick: handleDeleteEvent },
+					],
+				}
+			: { label: __('Delete'), icon: Trash2, onClick: handleDeleteEvent },
+	)
+
+	const NOTIFY_DELETE_OPTIONS = {
+		title: __('Notify Participants'),
+		icon: { name: 'lucide-bell' },
+		message: __('Send a cancellation email to let attendees know this event was deleted?'),
+	}
+
+	return {
+		deleteOption,
+		isDeleting,
+		showNotifyModal,
+		pendingDelete,
+		NOTIFY_DELETE_OPTIONS,
+	}
+}

--- a/frontend/src/apps/calendar/composables/useEventDelete.ts
+++ b/frontend/src/apps/calendar/composables/useEventDelete.ts
@@ -3,18 +3,47 @@ import { Trash2 } from 'lucide-vue-next'
 import { createResource, toast } from 'frappe-ui'
 
 import { userStore } from '@/apps/calendar/stores/user'
+import type { ParticipantIdentity } from '@/apps/calendar/types/doctypes'
 
-// Deleting an event is the same act wherever it is offered — the detail
-// sidebar's ⋯ menu and the edit modal's — so both read it from here: the same
-// choices for a recurring event, the same cancellation email, the same toasts.
-//
-// `getEvent` is a getter so the caller can hand over a prop it destructured;
-// `onDeleted` is what the host does afterwards (reload the calendar, close).
-export function useEventDelete(getEvent: () => any, onDeleted: () => void) {
+/** The part of a calendar event that deleting one reads. */
+export interface DeletableEvent {
+	/** The event's own id. A recurring instance carries the series id in `master_id`. */
+	id?: string
+	master_id?: string
+	/** Set on an instance of a recurring series; absent on a one-off. */
+	recurrence_id?: string
+	recurrence_rule?: Record<string, unknown>
+	/** The instance's own day — where "this and following" ends the series. */
+	date?: string
+	organizer?: string
+	participants?: { email: string }[]
+	/** A draft sent no invitations, so it never asks about a cancellation email. */
+	isDraft?: boolean
+}
+
+/**
+ * Deleting an event is the same act wherever it is offered — the detail
+ * sidebar's ⋯ menu and the edit modal's — so both read it from here: the same
+ * choices for a recurring event, the same cancellation email, the same toasts.
+ *
+ * @param getEvent - The event to delete. A getter, so the caller can hand over
+ *   a prop it destructured, and so the menu follows the selection as it moves;
+ *   it may return nothing while none is selected.
+ * @param onDeleted - What the host does once the server confirms: reload the
+ *   calendar, close itself.
+ * @returns `deleteOption` for the host's own dropdown, `isDeleting` for the
+ *   trigger's disabled state, and the three pieces of the cancellation-email
+ *   prompt the host renders: `showNotifyModal`, `pendingDelete` and
+ *   `NOTIFY_DELETE_OPTIONS`.
+ */
+export function useEventDelete(
+	getEvent: () => DeletableEvent | undefined,
+	onDeleted: () => void,
+) {
 	const store = userStore()
 	const { participantIdentities } = store
 
-	const calendarEvent = computed(() => getEvent() ?? {})
+	const calendarEvent = computed<DeletableEvent>(() => getEvent() ?? {})
 	const eventId = computed(() => calendarEvent.value.master_id || calendarEvent.value.id)
 
 	const deleteEventInstance = createResource({
@@ -59,20 +88,21 @@ export function useEventDelete(getEvent: () => any, onDeleted: () => void) {
 	const isOrganizer = computed(
 		() =>
 			participantIdentities.data?.some(
-				(id: any) => id.email === (calendarEvent.value.organizer || '').replace('mailto:', ''),
+				(id: ParticipantIdentity) =>
+					id.email === (calendarEvent.value.organizer || '').replace('mailto:', ''),
 			) ?? false,
 	)
 	const hasParticipantsOtherThanUser = computed(
 		() =>
-			calendarEvent.value.participants?.some((p: any) =>
-				participantIdentities.data?.every((i: any) => i.email !== p.email),
+			calendarEvent.value.participants?.some((p) =>
+				participantIdentities.data?.every((i: ParticipantIdentity) => i.email !== p.email),
 			) ?? false,
 	)
 
 	const showNotifyModal = ref(false)
 	const pendingDelete = ref<((sendEmail: boolean) => void) | null>(null)
 
-	const confirmDelete = (submit: (sendEmail: boolean) => Promise<any>, recurring: boolean) => {
+	const confirmDelete = (submit: (sendEmail: boolean) => Promise<unknown>, recurring: boolean) => {
 		const run = (sendEmail: boolean) => {
 			showNotifyModal.value = false
 			toast.promise(submit(sendEmail), {

--- a/frontend/src/composables/useTheme.ts
+++ b/frontend/src/composables/useTheme.ts
@@ -8,7 +8,7 @@ export const useTheme = () => {
 	const cycleTheme = () => {
 		const next = nextTheme(themeMode.value)
 		switchTheme(next)
-		toast.success(__('Appearance updated to {0}.', [__(next === 'automatic' ? 'Automatic' : next)]))
+		toast.success(__('Appearance updated to {0}.', [__(next)]))
 	}
 
 	return { dataTheme: resolvedTheme, themeMode, switchTheme, cycleTheme }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4653,9 +4653,9 @@ fraction.js@^5.3.4:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-5.3.4.tgz#8c0fcc6a9908262df4ed197427bdeef563e0699a"
   integrity sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==
 
-frappe-ui@frappe/frappe-ui#a89a95fa902e18f71d01c369ad92e5cb9d3ec954:
-  version "1.0.0-beta.55"
-  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/a89a95fa902e18f71d01c369ad92e5cb9d3ec954"
+frappe-ui@frappe/frappe-ui#965df418bb244454ea5266b57fb2d8c3a7f8a199:
+  version "1.0.0-beta.56"
+  resolved "https://codeload.github.com/frappe/frappe-ui/tar.gz/965df418bb244454ea5266b57fb2d8c3a7f8a199"
   dependencies:
     "@codemirror/lang-css" "^6.3.0"
     "@codemirror/lang-html" "^6.4.9"


### PR DESCRIPTION
### Delete, from the edit modal

The modal grew a ⋯ menu with Delete, so an event can go without first opening the detail sidebar. The delete moves to a `useEventDelete` composable that both surfaces read — same choices for a recurring event, same cancellation email, same toasts. The sidebar loses 139 lines of its own copy.

### A title that looks like a field

The lead title read as plain bold text with nothing to say it could be edited. It now carries a pencil beside it and dotted-underlines on hover; the field sizes to its own text so the pencil sits against the title rather than adrift at the column's edge.

### Save, not Send

The primary said "Send" whenever there were invitations to go out. The Notify Participants prompt asks exactly that a moment later, so the button was answering the question ahead of the dialog that asks it. It always reads "Save" now.

### The clipped descender

A participant's email is set in `text-p-sm` rather than `text-sm`. At 13px, `text-sm`'s 1.15 leading gives a **14.94px** line box for a **16px** glyph box, and the participants list (`max-h-[32rem] … overflow-y-auto`) clipped the overhang — the descender of a `g` or a `y` was cut off. The paragraph variant's 1.5 leading contains it with 2.5px to spare.

### frappe-ui → 965df418b

Carries frappe/frappe-ui#1114. A click on any event pill left a keydown listener on the document that cancelled Backspace and Delete for the whole page, so the title in this very modal could be typed into but never corrected. Two faults: `Popover` announced an `open` it never performed when a controlled parent declined the request, so the listener armed and never disarmed; and the shortcut cancelled those keys without checking whether a text field was being typed in.

Also in the bump: 26 upstream commits this pin was behind.

### Not in here

The acting-participant-identity seeding is left out — #792 covers that ground.

---

The appearance toast hands the mode to the translator as it stands instead of spelling 'automatic' out separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ccpiU4qNKjTTzFwqNKhxR