### PR TITLE
fix(mail): a mail to yourself reads once in its thread

### DIFF
--- a/frontend/src/apps/mail/components/MailActions.vue
+++ b/frontend/src/apps/mail/components/MailActions.vue
@@ -59,6 +59,7 @@ import {
 	raiseToast,
 } from '@/apps/mail/utils'
 import { useFilterBySender, useScreenSize, useUndo } from '@/apps/mail/utils/composables'
+import { mailCopyIds } from '@/apps/mail/utils/mailCopies'
 import { injectAccountScope } from '@/apps/mail/utils/accountScope'
 
 import type { ComposeMailData, Identity, Mail, ScreenedAddress } from '@/apps/mail/types'
@@ -113,13 +114,13 @@ const isSenderBlocked = (email: string) =>
 const primaryActions = (mail: Mail): MailAction[] => [
 	{
 		label: __('Unstar'),
-		onClick: () => emit('setFlagged', mail.id, false),
+		onClick: () => emit('setFlagged', mailCopyIds(mail), false),
 		icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
 		condition: !!mail.flagged && mailbox !== mailboxIds.value.trash && !isMobile.value,
 	},
 	{
 		label: __('Star'),
-		onClick: () => emit('setFlagged', mail.id, true),
+		onClick: () => emit('setFlagged', mailCopyIds(mail), true),
 		icon: Star,
 		condition: !mail.flagged && !mail.draft && mailbox !== mailboxIds.value.trash && !isMobile.value,
 	},
@@ -179,13 +180,13 @@ const moreActions = (mail: Mail): GroupedAction[] => [
 		options: [
 			{
 				label: __('Unstar'),
-				onClick: () => emit('setFlagged', mail.id, false),
+				onClick: () => emit('setFlagged', mailCopyIds(mail), false),
 				icon: () => h(Star, { style: FLAGGED_STAR_STYLE }),
 				condition: () => !!mail.flagged && mailbox !== mailboxIds.value.trash,
 			},
 			{
 				label: __('Star'),
-				onClick: () => emit('setFlagged', mail.id, true),
+				onClick: () => emit('setFlagged', mailCopyIds(mail), true),
 				icon: Star,
 				condition: () => !mail.flagged && !mail.draft && mailbox !== mailboxIds.value.trash,
 			},
@@ -327,7 +328,7 @@ const handleMarkUnreadFromHere = () => {
 	const ids = thread
 		.slice(idx)
 		.filter((m: Mail) => !m.draft)
-		.map((m: Mail) => m.id)
+		.flatMap(mailCopyIds)
 	if (ids.length) setMailsSeen.submit({ ids })
 }
 

--- a/frontend/src/apps/mail/components/MailThread.vue
+++ b/frontend/src/apps/mail/components/MailThread.vue
@@ -153,8 +153,8 @@
 										:reload-mails="handleReload"
 										:thread="thread"
 										@set-flagged="
-											(id: string, flagged: boolean) =>
-												emit('setFlagged', [id], flagged)
+											(ids: string[], flagged: boolean) =>
+												emit('setFlagged', ids, flagged)
 										"
 										@sync-unseen="handleSyncUnseen"
 										@move-mail="(m: Mail, target: string) => emit('moveMail', m, target)"
@@ -323,8 +323,8 @@
 												:reload-mails="handleReload"
 												:thread="thread"
 												@set-flagged="
-													(id: string, flagged: boolean) =>
-														emit('setFlagged', [id], flagged)
+													(ids: string[], flagged: boolean) =>
+														emit('setFlagged', ids, flagged)
 												"
 												@sync-unseen="handleSyncUnseen"
 												@move-mail="(m: Mail, target: string) => emit('moveMail', m, target)"
@@ -584,6 +584,7 @@ import {
 } from '@/apps/mail/utils'
 import { containEmailHtml } from '@/apps/mail/utils/containEmailHtml'
 import { getSenderInitial } from '@/apps/mail/utils/participants'
+import { mailCopyIds } from '@/apps/mail/utils/mailCopies'
 import { useFilterBySender, useScreenSize, useSettings, useTheme } from '@/apps/mail/utils/composables'
 import { provideAccountScope } from '@/apps/mail/utils/accountScope'
 import { userStore } from '@/apps/mail/stores/user'
@@ -898,7 +899,7 @@ const loadThread = () => {
 // all). Persisted via the parent (list + server) WITHOUT mutating the displayed messages, so the
 // "unread from here" marker survives reopening. Works for list and get_thread-fallback threads alike.
 const setThreadSeen = (seen: boolean) => {
-	const ids = (sourceMessages() ?? thread.value).map((mail) => mail.id)
+	const ids = (sourceMessages() ?? thread.value).flatMap(mailCopyIds)
 	emit('setSeen', seen, ids)
 }
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -189,6 +189,7 @@ import {
 } from '@/apps/mail/utils/listNavigation'
 import { useStoredFilter } from '@/apps/mail/utils/listFilter'
 import { useAccountScope } from '@/apps/mail/utils/accountScope'
+import { mailCopyIds, rowMailIds } from '@/apps/mail/utils/mailCopies'
 import { useListReload, useUndo, useScreenSize, useSwipeNav } from '@/apps/mail/utils/composables'
 import { closeComposeWindowFor } from '@/apps/mail/composables/useComposeWindow'
 import { useListRows } from '@/apps/mail/composables/useListRows'
@@ -618,7 +619,7 @@ const paneCall = (method: string, params: Record<string, unknown>, account?: str
 	return call(`suite.mail.api.mail.${method}`, { account: acting, ...params })
 }
 
-const messageIdsOf = (thread: Thread) => thread.messages?.map((m) => m.id) ?? [thread.id]
+const messageIdsOf = (thread: Thread) => thread.messages?.flatMap(mailCopyIds) ?? [thread.id]
 
 // Marked unread from a message downwards: MailThread reports the ids, we mirror it in the list.
 const handleSyncUnseen = (ids: string[]) => {
@@ -834,7 +835,7 @@ const handleSetSeen = (thread: Thread, seen: boolean, silent = false) => {
 // message, so BOTH have to be told: the pane's star stayed hollow when starring from the list, and
 // the list's star stayed hollow when starring from the pane. Only the ids actually sent to the
 // server are flipped locally, or a refetch would contradict whatever we lit up.
-const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = [thread.id]) => {
+const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = rowMailIds(thread)) => {
 	// The row stands for its representative mail (see serialize_thread), so it takes the star only
 	// when that mail is one of the ones being starred.
 	const rowChanged = ids.includes(thread.id)

--- a/frontend/src/apps/mail/types/index.ts
+++ b/frontend/src/apps/mail/types/index.ts
@@ -140,9 +140,34 @@ export interface Mail {
 	attachments: Attachment[]
 	// Blob id of a bounce message's message/delivery-status part (see DeliveryStatusBanner).
 	dsn_blob_id?: string | null
+	// The other copies of this same message the account holds — see MailCopy.
+	duplicates?: MailCopy[]
 	user_image?: string
 	collapsed?: boolean
 }
+
+/**
+ * One of the copies a message left in the account, stripped to what acting on it takes.
+ *
+ * Mail you send to yourself lands twice: the copy saved in Sent and the one delivery filed. The
+ * thread shows a single message for the pair (the server picks it — see collapse_duplicate_copies)
+ * and hangs the copies it stands in for off it, so an action can still reach them. A body is never
+ * copied here; it is the same message.
+ */
+export type MailCopy = Pick<
+	Mail,
+	| 'name'
+	| 'id'
+	| 'thread_id'
+	| 'from_name'
+	| 'from_email'
+	| 'received_at'
+	| 'mailboxes'
+	| 'seen'
+	| 'junk'
+	| 'flagged'
+	| 'draft'
+>
 
 export interface DraftRecipient {
 	email: string

--- a/frontend/src/apps/mail/utils/mailCopies.test.ts
+++ b/frontend/src/apps/mail/utils/mailCopies.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { mailCopies, mailCopyIds, mailCopyNames, rowMailIds } from './mailCopies'
+
+import type { Mail, MailCopy, Thread } from '@/apps/mail/types'
+
+const mail = (overrides: Partial<Mail> = {}): Mail =>
+	({ name: 'message-d1', id: 'd1', ...overrides }) as Mail
+
+// What the server hangs off a self-addressed message: the copy sitting in Sent, which the thread
+// doesn't show but every action still has to reach.
+const sentCopy = { name: 'message-s1', id: 's1' } as MailCopy
+
+describe('mailCopies', () => {
+	it('is the message itself when the account holds only one of it', () => {
+		const only = mail()
+		expect(mailCopies(only)).toEqual([only])
+	})
+
+	it('leads with the message the thread shows, then the copies it stands in for', () => {
+		const shown = mail({ duplicates: [sentCopy] })
+		expect(mailCopies(shown)).toEqual([shown, sentCopy])
+	})
+
+	it('gives an action every id, so no copy is left behind in Sent', () => {
+		expect(mailCopyIds(mail({ duplicates: [sentCopy] }))).toEqual(['d1', 's1'])
+	})
+
+	it('gives a delete every document name', () => {
+		expect(mailCopyNames(mail({ duplicates: [sentCopy] }))).toEqual(['message-d1', 'message-s1'])
+	})
+})
+
+// The row names one message of its thread — in Sent, for a mail to yourself, the copy the pane does
+// not render.
+const row = (id: string, messages: Mail[]): Thread => ({ id, messages }) as Thread
+
+describe('rowMailIds', () => {
+	it('reaches the copy the pane shows when the row stands for the other one', () => {
+		const shown = mail({ duplicates: [sentCopy] })
+		expect(rowMailIds(row('s1', [shown]))).toEqual(['d1', 's1'])
+	})
+
+	it('is the row\'s own mail when it has no twin', () => {
+		expect(rowMailIds(row('d1', [mail()]))).toEqual(['d1'])
+	})
+
+	it('falls back to the row itself when its conversation is not loaded', () => {
+		expect(rowMailIds({ id: 'x1' } as Thread)).toEqual(['x1'])
+	})
+})

--- a/frontend/src/apps/mail/utils/mailCopies.ts
+++ b/frontend/src/apps/mail/utils/mailCopies.ts
@@ -1,0 +1,38 @@
+import type { Mail, MailCopy, Thread } from '@/apps/mail/types'
+
+/**
+ * A message together with the other copies of it the account holds.
+ *
+ * Mail you send to yourself — directly, by copying yourself, or through a list you are on — leaves
+ * two of the same message behind: the copy saved in Sent, and the copy delivery filed. The server
+ * hands the thread one of them (see `collapse_duplicate_copies`) with the rest hanging off it as
+ * `duplicates`, so the conversation reads once and the row counts once.
+ *
+ * Which is exactly the split to keep in mind here: **render the message, act on its copies**. An
+ * action that reaches only the copy on screen leaves the invisible one behind, and the invisible one
+ * still counts — a trashed mail keeps a twin in Sent, an unstarred thread stays starred (JMAP asks
+ * whether *any* message in the thread carries the keyword), and a conversation marked read stays
+ * unread. Undo has the same appetite: each copy must go back to the mailboxes it came from, which is
+ * why a copy carries its own membership rather than the survivor's.
+ *
+ * Every message but a self-addressed handful has no twin, so these are lists of one.
+ */
+export const mailCopies = (mail: Mail): MailCopy[] => [mail, ...(mail.duplicates ?? [])]
+
+/** The mail ids an action on `mail` should carry: its own, and those of the copies it stands for. */
+export const mailCopyIds = (mail: Mail): string[] => mailCopies(mail).map((copy) => copy.id)
+
+/** The same, as Mail Message document names — what deletes are addressed by. */
+export const mailCopyNames = (mail: Mail): string[] => mailCopies(mail).map((copy) => copy.name)
+
+/**
+ * The mail ids a list row's star, or any action naming no message of its own, should carry.
+ *
+ * A row stands for one representative message (see serialize_thread) — and in Sent, for a mail you
+ * sent yourself, that is the copy the pane does *not* render. Acting on it alone leaves the row and
+ * the open thread disagreeing about the same message: starred in the list, hollow in the pane.
+ */
+export const rowMailIds = (thread: Thread): string[] => {
+	const shown = (thread.messages ?? []).find((mail) => mailCopyIds(mail).includes(thread.id))
+	return shown ? mailCopyIds(shown) : [thread.id]
+}

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -5,11 +5,12 @@ import { createResource } from 'frappe-ui'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, raiseOptimisticToast, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
 import { useBlockSender, useUndo } from '@/apps/mail/utils/composables'
+import { mailCopies, mailCopyIds, mailCopyNames, rowMailIds } from '@/apps/mail/utils/mailCopies'
 import { closeComposeWindowFor } from '@/apps/mail/composables/useComposeWindow'
 import { useMailRemoval } from '@/apps/mail/composables/useMailRemoval'
 import { userStore } from '@/apps/mail/stores/user'
 
-import type { Mail, Mailbox, Thread } from '@/apps/mail/types'
+import type { Mail, MailCopy, Mailbox, Thread } from '@/apps/mail/types'
 
 export type SetSeenParams = {
 	0?: string[]
@@ -71,16 +72,19 @@ export function useThreadActions(deps: {
 	const { setUndoAction, undo } = useUndo()
 	const { promptBlockSenders, willJunkSenders } = useBlockSender()
 
-	const threadMails = (threadIds: string[]): Mail[] => {
+	// Every mail the given threads hold — the copies included. A thread's messages are what the pane
+	// *shows*, and a message the account holds twice (mail to yourself) shows once; an action has to
+	// reach both copies all the same, and undo has to put each back where it was. See mailCopies.
+	const threadMails = (threadIds: string[]): MailCopy[] => {
 		const items = (threadsResource.value.data ?? []).filter((t: Thread) =>
 			threadIds.includes(t.thread_id),
 		)
 		// In search, each result is itself a mail with no nested conversation.
-		if (mailbox.value === 'search') return items as unknown as Mail[]
-		return items.flatMap((t: Thread) => t.messages ?? [])
+		if (mailbox.value === 'search') return items as unknown as MailCopy[]
+		return items.flatMap((t: Thread) => (t.messages ?? []).flatMap(mailCopies))
 	}
 
-	const isSentMail = (m: Mail) => m.mailboxes.some((mb) => mb.mailbox_id === mailboxIds.sent)
+	const isSentMail = (m: MailCopy) => m.mailboxes.some((mb) => mb.mailbox_id === mailboxIds.sent)
 
 	const allMailIds = (threadIds: string[]): string[] => threadMails(threadIds).map((m) => m.id)
 
@@ -90,7 +94,7 @@ export function useThreadActions(deps: {
 
 	// Mails of the threads that live in the current view's mailbox(es) — mirrors the old
 	// get_filtered_message_ids (starred → all non-trash, search → all).
-	const currentMailboxMails = (threadIds: string[]): Mail[] => {
+	const currentMailboxMails = (threadIds: string[]): MailCopy[] => {
 		const mails = threadMails(threadIds)
 		if (mailbox.value === 'search') return mails
 		const ids =
@@ -370,7 +374,7 @@ export function useThreadActions(deps: {
 		isUndo = false,
 	) => {
 		// Only remove mails that are in this mailbox AND at least one other — never orphan a mail.
-		const isRemovable = (m: Mail) =>
+		const isRemovable = (m: MailCopy) =>
 			m.mailboxes.length > 1 && m.mailboxes.some((mb) => mb.mailbox_id === mailboxId)
 
 		const threadIdsToBeUpdated = threadIds.filter((threadId) =>
@@ -600,7 +604,7 @@ export function useThreadActions(deps: {
 		setUndoAction(undefined)
 		const ids = threadsResource.value.data
 			.filter((t: Thread) => threadIDs.includes(t.thread_id))
-			.map((t: Thread) => t.id)
+			.flatMap(rowMailIds)
 		setFlagged.submit({ ids, flagged })
 	}
 
@@ -957,18 +961,28 @@ export function useThreadActions(deps: {
 		afterForward: refillIfEmpty,
 	})
 
-	const mailSnapshot = (mail: Mail) => [
-		{ id: mail.id, mailbox_ids: mail.mailboxes.map((mb) => mb.mailbox_id), junk: mail.junk },
-	]
+	// Each copy snapshotted with its OWN mailboxes, so undo puts the sent copy back in Sent rather
+	// than wherever the copy on screen came from.
+	const mailSnapshot = (mail: Mail) =>
+		mailCopies(mail).map((copy) => ({
+			id: copy.id,
+			mailbox_ids: copy.mailboxes.map((mb) => mb.mailbox_id),
+			junk: copy.junk,
+		}))
 
 	const handleMailMove = (mail: Mail, target: string) => {
 		const snapshot = mailSnapshot(mail)
 		const mailboxName = mailboxes.data?.find((m) => m.id === target)?._name
+		// Trash and Junk take the message away entirely, so they take every copy of it — leave the
+		// twin of a self-addressed mail behind and it sits in Sent, keeping the thread alive there.
+		// Any other move moves the copy at hand and lets the sent one keep Sent, which is what a
+		// thread-level move does with sent mails too (see handleMoveThreads).
+		const ids = [mailboxIds.junk, mailboxIds.trash].includes(target) ? mailCopyIds(mail) : [mail.id]
 		runMailRemoval(
 			mail,
 			() =>
 				moveMails.submit({
-					ids: [mail.id],
+					ids,
 					mailbox: target,
 					clear_junk: mail.junk === 1 && target !== mailboxIds.junk,
 				}),
@@ -991,7 +1005,7 @@ export function useThreadActions(deps: {
 					: __('Mail marked as Not Junk.')
 		runMailRemoval(
 			mail,
-			() => setMailsSpam.submit({ ids: [mail.id], spam, screen_action: screenForward }),
+			() => setMailsSpam.submit({ ids: mailCopyIds(mail), spam, screen_action: screenForward }),
 			success,
 			{
 				undoReq: () =>
@@ -1007,7 +1021,7 @@ export function useThreadActions(deps: {
 	}
 
 	const handleMailDelete = (mail: Mail) =>
-		runMailRemoval(mail, () => bulkDelete.submit({ names: [mail.name] }), __('Mail deleted.'))
+		runMailRemoval(mail, () => bulkDelete.submit({ names: mailCopyNames(mail) }), __('Mail deleted.'))
 
 	const getOriginalState = (
 		selectedThreads: string[],

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -281,7 +281,11 @@ def get_threads(account: str, mailbox: str, limit: int, start: int = 0, filter_b
         # draft reply must keep its own recipients and its "Draft" badge when the thread it answers
         # receives a newer mail.
         latest = in_mailbox[-1] if mailbox in outgoing_mailboxes else visible[-1]
-        threads.append(serialize_thread(in_mailbox, visible, latest, first=conversation[0]))
+        threads.append(
+            serialize_thread(
+                in_mailbox, visible, latest, first=conversation[0], sent_mailbox=ids_by_role.get("sent")
+            )
+        )
 
     # Avatars for the list-view summary rows, and for each message in the nested threads.
     add_user_images_to_emails(account, threads, is_thread=False)
@@ -312,6 +316,75 @@ def visible_in_mailbox(messages: list[dict], mailbox: str, trash: str | None, ju
         return [m for m in messages if m.get("junk")] or messages
 
     return [m for m in messages if not is_trashed(m) and not m.get("junk")] or messages
+
+
+# Of a message's copies, the one kept carries these fields of the ones it stands in for — what an
+# action needs to reach them, and what an undo needs to put them back exactly as they were. Never a
+# body: the copies are the same message, and a second copy of it is only weight on the wire.
+DUPLICATE_COPY_FIELDS = (
+    "name",
+    "id",
+    "thread_id",
+    "from_name",
+    "from_email",
+    "received_at",
+    "mailboxes",
+    "seen",
+    "junk",
+    "flagged",
+    "draft",
+)
+
+
+def collapse_duplicate_copies(mails: list[dict], sent_mailbox: str | None) -> list[dict]:
+    """Collapse the copies one message left in the account back into the single message they are.
+
+    Mail you send to yourself — directly, by copying yourself, or through a list you are on — leaves
+    the account holding two JMAP Emails: the copy saved in Sent, and the copy the delivery filed.
+    They share a Message-ID because they are one message, and the thread was showing both, as was
+    the list row's message count, which is read off this same list.
+
+    The delivered copy is the one kept, in every view: it is the message as it actually arrived,
+    headers and unread state and all, and choosing it by what the message *is* rather than by which
+    mailbox is being looked at means the same copy survives in Sent as in Inbox — nothing swaps under
+    the reader when they change view, and nothing swaps between one request and the next. Where that
+    doesn't decide it (no copy in Sent, or both there), received time and then id settle it.
+
+    What is collapsed away is not dropped. Those are real messages on the server, and an action on
+    the survivor has to reach them, or trashing a mail to yourself would leave its twin sitting in
+    Sent and unstarring it would leave the thread starred. They ride along under `duplicates`, which
+    is what the client fans its actions out over (see utils/mailCopies); only the display reads the
+    collapsed list.
+
+    Drafts and mail with no Message-ID are left alone: a draft has no delivered twin, and an absent
+    header is not an identity.
+    """
+
+    groups: dict[str, list[dict]] = {}
+    for mail in mails:
+        if mail.get("draft") or not mail.get("message_id"):
+            continue
+        groups.setdefault(mail["message_id"], []).append(mail)
+
+    duplicated = [group for group in groups.values() if len(group) > 1]
+    if not duplicated:
+        return mails
+
+    def in_sent(mail: dict) -> bool:
+        return any(mb["mailbox_id"] == sent_mailbox for mb in mail["mailboxes"])
+
+    merged: dict[str, dict] = {}
+    absorbed: set[str] = set()
+    for group in duplicated:
+        survivor = min(group, key=lambda mail: (in_sent(mail), str(mail["received_at"] or ""), mail["id"]))
+        copies = [mail for mail in group if mail["id"] != survivor["id"]]
+        merged[survivor["id"]] = {
+            **survivor,
+            "duplicates": [{field: mail[field] for field in DUPLICATE_COPY_FIELDS} for mail in copies],
+        }
+        absorbed.update(mail["id"] for mail in copies)
+
+    return [merged.get(mail["id"], mail) for mail in mails if mail["id"] not in absorbed]
 
 
 def get_user_jmap_accounts() -> list[dict]:
@@ -407,7 +480,10 @@ def get_thread(account: str, thread_id: str) -> list[dict]:
     """Returns the full list of messages in a thread, for threads not present in the mailbox list
     (e.g. search results or a thread on another page)."""
 
-    mails = [serialize_mail(m) for m in fetch_thread(account, thread_id)]
+    mails = collapse_duplicate_copies(
+        [serialize_mail(m) for m in fetch_thread(account, thread_id)],
+        get_mailbox_id_by_role(account, "sent"),
+    )
     return add_user_images_to_emails(account, mails, is_thread=True)
 
 
@@ -430,6 +506,7 @@ def serialize_thread(
     thread_messages: list[dict],
     latest: dict | None = None,
     first: dict | None = None,
+    sent_mailbox: str | None = None,
 ) -> dict:
     """Serializes a thread for response.
 
@@ -470,7 +547,9 @@ def serialize_thread(
         **{field: latest[field] for field in activity_fields},
         "subject": first["subject"],
         "attachments": serialize_attachments(latest.get("attachments", [])),
-        "messages": [serialize_mail(message) for message in thread_messages],
+        "messages": collapse_duplicate_copies(
+            [serialize_mail(message) for message in thread_messages], sent_mailbox
+        ),
     }
 
 

--- a/suite/mail/tests/test_thread_duplicate_copies.py
+++ b/suite/mail/tests/test_thread_duplicate_copies.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+"""What a thread does with the two copies one message can leave in an account.
+
+Mail to yourself is delivered as well as saved: the account ends up holding the copy in Sent and the
+copy delivery filed, one Message-ID between them. The conversation shows it once — and shows the
+*same* one of the two wherever it is opened from — while keeping the copy it stands in for within
+reach, because an action on the message has to land on both."""
+
+import unittest
+
+from suite.mail.api.mail import collapse_duplicate_copies
+
+SENT = "mailbox-sent"
+INBOX = "mailbox-inbox"
+
+
+def mail(id: str, message_id: str, mailboxes: list[str], **overrides) -> dict:
+    return {
+        "name": f"message-{id}",
+        "id": id,
+        "message_id": message_id,
+        "thread_id": "thread-1",
+        "from_name": "Vibhav",
+        "from_email": "vibhav@example.com",
+        "subject": "Note to self",
+        "html_body": "<p>Note to self</p>",
+        "received_at": "2026-09-01 12:00:00",
+        "mailboxes": [{"mailbox_id": mailbox} for mailbox in mailboxes],
+        "seen": 0,
+        "junk": 0,
+        "flagged": 0,
+        "draft": 0,
+    } | overrides
+
+
+class MailToYourself(unittest.TestCase):
+    """The pair reads as one message, and the one it reads as does not move."""
+
+    def setUp(self):
+        self.sent = mail("s1", "<1@example.com>", [SENT], received_at="2026-09-01 11:59:59")
+        self.delivered = mail("d1", "<1@example.com>", [INBOX])
+        self.conversation = [self.sent, self.delivered]
+
+    def test_shows_once(self):
+        collapsed = collapse_duplicate_copies(self.conversation, SENT)
+        self.assertEqual([m["id"] for m in collapsed], ["d1"])
+
+    def test_keeps_the_delivered_copy(self):
+        """The message as it arrived — its headers, its unread state — is the one kept."""
+
+        collapsed = collapse_duplicate_copies(self.conversation, SENT)
+        self.assertEqual(collapsed[0]["mailboxes"], [{"mailbox_id": INBOX}])
+
+    def test_same_copy_survives_whatever_order_it_arrives_in(self):
+        forwards = collapse_duplicate_copies(self.conversation, SENT)
+        backwards = collapse_duplicate_copies(list(reversed(self.conversation)), SENT)
+        self.assertEqual([m["id"] for m in forwards], [m["id"] for m in backwards])
+
+    def test_the_sent_copy_rides_along(self):
+        """Collapsed away, not dropped: trashing the message has to reach it in Sent."""
+
+        [collapsed] = collapse_duplicate_copies(self.conversation, SENT)
+        self.assertEqual([copy["id"] for copy in collapsed["duplicates"]], ["s1"])
+
+    def test_a_copy_carries_its_own_mailboxes(self):
+        """Undo restores each copy to where it was, so Sent stays Sent."""
+
+        [collapsed] = collapse_duplicate_copies(self.conversation, SENT)
+        self.assertEqual(collapsed["duplicates"][0]["mailboxes"], [{"mailbox_id": SENT}])
+
+    def test_a_copy_carries_no_body(self):
+        """The same message twice on the wire is only weight."""
+
+        [collapsed] = collapse_duplicate_copies(self.conversation, SENT)
+        self.assertNotIn("html_body", collapsed["duplicates"][0])
+
+    def test_more_than_two_copies_still_leave_one(self):
+        archived = mail("a1", "<1@example.com>", ["mailbox-archive"])
+        collapsed = collapse_duplicate_copies([*self.conversation, archived], SENT)
+        self.assertEqual(len(collapsed), 1)
+        self.assertEqual(len(collapsed[0]["duplicates"]), 2)
+
+
+class EverythingElse(unittest.TestCase):
+    """Mail with one copy is left exactly as it was."""
+
+    def test_ordinary_conversation_is_untouched(self):
+        conversation = [
+            mail("m1", "<1@example.com>", [INBOX]),
+            mail("m2", "<2@example.com>", [SENT]),
+        ]
+        self.assertIs(collapse_duplicate_copies(conversation, SENT), conversation)
+
+    def test_drafts_are_not_copies(self):
+        """A draft has no delivered twin, whatever Message-ID it is carrying."""
+
+        draft = mail("draft-1", "<1@example.com>", ["mailbox-drafts"], draft=1)
+        collapsed = collapse_duplicate_copies([mail("d1", "<1@example.com>", [INBOX]), draft], SENT)
+        self.assertEqual([m["id"] for m in collapsed], ["d1", "draft-1"])
+
+    def test_a_missing_message_id_is_not_an_identity(self):
+        conversation = [mail("m1", "", [INBOX]), mail("m2", "", [INBOX])]
+        self.assertEqual([m["id"] for m in collapse_duplicate_copies(conversation, SENT)], ["m1", "m2"])
+
+    def test_copies_are_still_collapsed_without_a_sent_mailbox(self):
+        """Nothing about the account should decide whether a duplicate is shown twice."""
+
+        conversation = [
+            mail("s1", "<1@example.com>", [SENT], received_at="2026-09-01 11:59:59"),
+            mail("d1", "<1@example.com>", [INBOX]),
+        ]
+        self.assertEqual(len(collapse_duplicate_copies(conversation, None)), 1)


### PR DESCRIPTION
Mailing yourself leaves the account with two JMAP Emails for one message — the copy saved in Sent and the copy delivery filed. Same Message-ID, because they are the same message. The thread showed both, and the list row's count (read off that same list) said 2.

The conversation now collapses the pair. The delivered copy is the one kept, in every view: it's the message as it actually arrived, and picking it by what the message *is* rather than by which mailbox is open means the same copy survives in Sent as in Inbox, on this request and the next.

The copy that's collapsed away is still a real message on the server, so it rides along under `duplicates` and actions fan out over it (`utils/mailCopies`):

- trashing or junking the mail takes the twin out of Sent
- unstarring clears both — JMAP asks whether *any* message in a thread carries the keyword, so a star left behind kept the thread starred
- marking read/unread reaches the whole conversation
- undo restores each copy to its own mailboxes, so the sent one goes back to Sent
- a move anywhere other than Trash/Junk still moves only the copy at hand, the way a thread-level move already leaves a sent mail in Sent

A list row stands for one representative message, which in Sent is the copy the pane doesn't render — `rowMailIds` carries the row's star to both, so the row and the open thread no longer disagree about it.

Search is untouched: results there are messages rather than threads, and collapsing within a page would short the page and misreport the total.

Tests: `suite/mail/tests/test_thread_duplicate_copies.py` (the collapse rule and its stability) and `utils/mailCopies.test.ts`.
