### PR TITLE
fix(mail): a scroll never pages the thread

### DIFF
--- a/frontend/src/apps/mail/components/EmailContent.vue
+++ b/frontend/src/apps/mail/components/EmailContent.vue
@@ -485,17 +485,34 @@ const srcdoc = computed(() => {
 					}
 					return false;
 				};
+				// Same rule as useSwipeNav in the parent, and for the same reason: a gesture
+				// that has scrolled 24px vertically is a scroll and stays one, however it
+				// ends. Reading a message is mostly scrolling, so endpoint-only judgement
+				// paged the thread out from under the reader.
 				let swipeOrigin = null;
+				let swipeScrolling = false;
 				document.addEventListener('touchstart', (e) => {
+					swipeScrolling = false;
 					swipeOrigin = e.touches.length === 1 && !inHorizontalScroller(e.target)
 						? { x: e.touches[0].clientX, y: e.touches[0].clientY }
 						: null;
+				}, { passive: true });
+				document.addEventListener('touchmove', (e) => {
+					if (!swipeOrigin || swipeScrolling) return;
+					const touch = e.touches[0];
+					if (!touch) return;
+					const dy = touch.clientY - swipeOrigin.y;
+					if (Math.abs(dy) > 24 && Math.abs(dy) > Math.abs(touch.clientX - swipeOrigin.x))
+						swipeScrolling = true;
 				}, { passive: true });
 				document.addEventListener('touchend', (e) => {
 					if (!swipeOrigin) return;
 					const dx = e.changedTouches[0].clientX - swipeOrigin.x;
 					const dy = e.changedTouches[0].clientY - swipeOrigin.y;
+					const wasScrolling = swipeScrolling;
 					swipeOrigin = null;
+					swipeScrolling = false;
+					if (wasScrolling) return;
 					if (Math.abs(dx) < 64 || Math.abs(dx) < Math.abs(dy) * 2) return;
 					window.parent.postMessage({ type: 'swipe', direction: dx < 0 ? 'left' : 'right' }, '*');
 				}, { passive: true });

--- a/frontend/src/apps/mail/components/ThreadPane.vue
+++ b/frontend/src/apps/mail/components/ThreadPane.vue
@@ -33,6 +33,7 @@
 				hidden: !isMobile && !showReadingPane && !threadOpen,
 			}"
 			@touchstart.passive="emit('touchStart', $event)"
+			@touchmove.passive="emit('touchMove', $event)"
 			@touchend.passive="emit('touchEnd', $event)"
 		>
 			<!-- The swipe slide lives inside MailThread (its toolbar must not move), armed via
@@ -71,6 +72,7 @@ const { threadOpen } = defineProps<{
 // forwards the touches. `.passive` stays on the listener here, where the native event is bound.
 const emit = defineEmits<{
 	touchStart: [TouchEvent]
+	touchMove: [TouchEvent]
 	touchEnd: [TouchEvent]
 }>()
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -31,6 +31,7 @@
 			<ThreadPane
 				:thread-open="!!threadID"
 				@touch-start="onThreadTouchStart"
+				@touch-move="onThreadTouchMove"
 				@touch-end="onThreadTouchEnd"
 			>
 				<template #list>
@@ -397,7 +398,11 @@ const threadSlide = ref('')
 let pendingThreadSlide = ''
 
 // Swipe on the open thread (mobile): left → next thread, right → previous.
-const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSwipeNav(
+const {
+	onTouchStart: onThreadTouchStart,
+	onTouchMove: onThreadTouchMove,
+	onTouchEnd: onThreadTouchEnd,
+} = useSwipeNav(
 	() => isMobile.value && !!threadID,
 	(offset) => {
 		// Arms the paging animation for this navigation only — openThread consumes it.

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -66,6 +66,7 @@
 			<ThreadPane
 				:thread-open="!!threadID"
 				@touch-start="onThreadTouchStart"
+				@touch-move="onThreadTouchMove"
 				@touch-end="onThreadTouchEnd"
 			>
 				<template #list>
@@ -1370,7 +1371,11 @@ const goToThreadByOffset = (offset: number) => {
 }
 
 // Swipe on the open thread (mobile): left → next thread, right → previous.
-const { onTouchStart: onThreadTouchStart, onTouchEnd: onThreadTouchEnd } = useSwipeNav(
+const {
+	onTouchStart: onThreadTouchStart,
+	onTouchMove: onThreadTouchMove,
+	onTouchEnd: onThreadTouchEnd,
+} = useSwipeNav(
 	() => isMobile.value && !!threadID,
 	(offset) => {
 		// Arms the paging animation for this navigation only — goToThread consumes it, so

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -271,6 +271,7 @@
 						hidden: !isMobile && !showReadingPane && !openSender,
 					}"
 					@touchstart.passive="onPreviewTouchStart"
+					@touchmove.passive="onPreviewTouchMove"
 					@touchend.passive="onPreviewTouchEnd"
 				>
 					<template v-if="openSender">
@@ -638,7 +639,11 @@ watch(
 
 // Swipe on the open preview (mobile): left → next sender, right → previous — the
 // screener counterpart of the mailbox thread swipe.
-const { onTouchStart: onPreviewTouchStart, onTouchEnd: onPreviewTouchEnd } = useSwipeNav(
+const {
+	onTouchStart: onPreviewTouchStart,
+	onTouchMove: onPreviewTouchMove,
+	onTouchEnd: onPreviewTouchEnd,
+} = useSwipeNav(
 	() => isMobile.value && !!openSender.value,
 	(offset) => {
 		const list = senders.data ?? []

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -7,6 +7,7 @@ import { useTheme as useSuiteTheme } from '@/composables/useTheme'
 import { matchesScreenedValue, raiseOptimisticToast, raiseToast } from '@/apps/mail/utils'
 import router from '@/apps/mail/router'
 import { userStore } from '@/apps/mail/stores/user'
+import { createSwipeGesture } from '@/apps/mail/utils/swipeGesture'
 
 import type { ComposeMailData, Identity, ScreenedAddress } from '@/apps/mail/types'
 
@@ -100,16 +101,15 @@ export const useSidebar = () => {
 }
 
 // Horizontal swipe-to-page detection, shared by the mailbox thread pane and the screener
-// preview: left → onSwipe(1) (next), right → onSwipe(-1). Judged on touchend (passive) so
-// vertical scrolling is never delayed; a swipe must be decisively horizontal — at least
-// 64px long and twice its vertical drift. Swipes over an email body never reach the pane:
-// EmailContent detects them inside its iframe and re-broadcasts them as `email-swipe`
-// window events, which this subscribes to as well. The time guard dedupes those (every
-// mounted EmailContent re-dispatches the same message) and paces direct swipes alike.
-const SWIPE_MIN_X = 64
-
+// preview: left → onSwipe(1) (next), right → onSwipe(-1). The rule itself lives in
+// createSwipeGesture; this binds it to the touch events and to the view. Judged on
+// touchend (passive) so vertical scrolling is never delayed. Swipes over an email body
+// never reach the pane: EmailContent detects them inside its iframe and re-broadcasts
+// them as `email-swipe` window events, which this subscribes to as well. The time guard
+// dedupes those (every mounted EmailContent re-dispatches the same message) and paces
+// direct swipes alike.
 export const useSwipeNav = (enabled: () => boolean, onSwipe: (offset: 1 | -1) => void) => {
-	let origin: { x: number; y: number } | null = null
+	const gesture = createSwipeGesture()
 	let lastSwipeAt = 0
 
 	const swipe = (offset: 1 | -1) => {
@@ -121,19 +121,18 @@ export const useSwipeNav = (enabled: () => boolean, onSwipe: (offset: 1 | -1) =>
 	}
 
 	const onTouchStart = (e: TouchEvent) => {
-		origin =
-			enabled() && e.touches.length === 1
-				? { x: e.touches[0].clientX, y: e.touches[0].clientY }
-				: null
+		if (!enabled()) return gesture.cancel()
+		gesture.start(e.touches[0].clientX, e.touches[0].clientY, e.touches.length)
+	}
+
+	const onTouchMove = (e: TouchEvent) => {
+		const touch = e.touches[0]
+		if (touch) gesture.move(touch.clientX, touch.clientY)
 	}
 
 	const onTouchEnd = (e: TouchEvent) => {
-		if (!origin) return
-		const dx = e.changedTouches[0].clientX - origin.x
-		const dy = e.changedTouches[0].clientY - origin.y
-		origin = null
-		if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return
-		swipe(dx < 0 ? 1 : -1)
+		const offset = gesture.end(e.changedTouches[0].clientX, e.changedTouches[0].clientY)
+		if (offset) swipe(offset)
 	}
 
 	const onEmailSwipe = (e: Event) => swipe((e as CustomEvent).detail === 'left' ? 1 : -1)
@@ -141,7 +140,7 @@ export const useSwipeNav = (enabled: () => boolean, onSwipe: (offset: 1 | -1) =>
 	onMounted(() => window.addEventListener('email-swipe', onEmailSwipe))
 	onUnmounted(() => window.removeEventListener('email-swipe', onEmailSwipe))
 
-	return { onTouchStart, onTouchEnd }
+	return { onTouchStart, onTouchMove, onTouchEnd }
 }
 
 // Mobile folder bottom sheet — shared so both the header title (mailbox views)

--- a/frontend/src/apps/mail/utils/swipeGesture.test.ts
+++ b/frontend/src/apps/mail/utils/swipeGesture.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSwipeGesture } from './swipeGesture'
+
+describe('createSwipeGesture', () => {
+	it('pages on a decisively horizontal swipe', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(280, 400)
+		gesture.move(220, 404)
+		gesture.move(160, 408)
+
+		expect(gesture.end(150, 410)).toBe(1)
+	})
+
+	it('pages the other way on a swipe to the right', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(100, 400)
+		gesture.move(180, 402)
+
+		expect(gesture.end(200, 404)).toBe(-1)
+	})
+
+	// The reported bug: scrolling a message paged to the next thread. A scroll wanders
+	// back towards the height it began at, so the two endpoints alone say "100px
+	// sideways, no vertical drift" — a swipe, by the old rule.
+	it('ignores a scroll that ends back at the height it began', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(200, 400)
+		gesture.move(210, 250)
+		gesture.move(240, 330)
+		gesture.move(262, 396)
+
+		expect(gesture.end(300, 400)).toBeNull()
+	})
+
+	it('holds the scroll verdict even when the finger then travels sideways', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(300, 400)
+		gesture.move(300, 300)
+		gesture.move(120, 300)
+
+		expect(gesture.end(100, 300)).toBeNull()
+	})
+
+	it('lets a swipe through a drift smaller than the scroll lock', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(300, 400)
+		gesture.move(240, 420)
+		gesture.move(180, 418)
+
+		expect(gesture.end(170, 416)).toBe(1)
+	})
+
+	it('refuses a sideways drag that is too short', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(200, 400)
+		gesture.move(170, 402)
+
+		expect(gesture.end(160, 402)).toBeNull()
+	})
+
+	it('refuses a diagonal that never dominates its own vertical travel', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(300, 400)
+
+		expect(gesture.end(200, 340)).toBeNull()
+	})
+
+	it('ignores a two-finger gesture', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(200, 400, 2)
+
+		expect(gesture.end(100, 400)).toBeNull()
+	})
+
+	it('forgets a cancelled gesture', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(280, 400)
+		gesture.cancel()
+
+		expect(gesture.end(150, 400)).toBeNull()
+	})
+
+	it('starts each gesture clean after a scroll', () => {
+		const gesture = createSwipeGesture()
+
+		gesture.start(200, 400)
+		gesture.move(210, 250)
+		expect(gesture.end(264, 400)).toBeNull()
+
+		gesture.start(280, 400)
+		gesture.move(160, 404)
+		expect(gesture.end(150, 406)).toBe(1)
+	})
+})

--- a/frontend/src/apps/mail/utils/swipeGesture.ts
+++ b/frontend/src/apps/mail/utils/swipeGesture.ts
@@ -1,0 +1,58 @@
+// The geometry behind swipe-to-page, kept apart from its Vue wiring: `useSwipeNav`
+// is bound to a router, a store and a theme, and the rule itself is worth being able
+// to state — and test — without any of them. The message iframe carries a copy of
+// this rule rather than an import (EmailContent builds its script as a string, into
+// a sandboxed document); keep the two in step.
+
+/** A swipe must travel at least this far sideways. */
+export const SWIPE_MIN_X = 64
+
+// Vertical travel that settles a gesture as a scroll, for good. The path decides that,
+// not the two endpoints: a scroll that wanders back towards the height it began at nets
+// almost no dy, and a thumb travelling that far arcs well past SWIPE_MIN_X sideways —
+// which is how reading a message used to page to the next one. Once a gesture has
+// scrolled it can never become a swipe, however it ends.
+export const SCROLL_LOCK_Y = 24
+
+/** Left → 1 (next), right → -1 (previous). */
+export type SwipeOffset = 1 | -1
+
+export const createSwipeGesture = () => {
+	let origin: { x: number; y: number } | null = null
+	let scrolling = false
+
+	return {
+		/** `touchCount` over one hand back the gesture: a pinch or a two-finger scroll. */
+		start(x: number, y: number, touchCount = 1) {
+			scrolling = false
+			origin = touchCount === 1 ? { x, y } : null
+		},
+
+		move(x: number, y: number) {
+			if (!origin || scrolling) return
+			const dy = y - origin.y
+			if (Math.abs(dy) > SCROLL_LOCK_Y && Math.abs(dy) > Math.abs(x - origin.x))
+				scrolling = true
+		},
+
+		/** The direction to page, or null when the gesture was not a swipe. */
+		end(x: number, y: number): SwipeOffset | null {
+			if (!origin) return null
+			const dx = x - origin.x
+			const dy = y - origin.y
+			const wasScrolling = scrolling
+			origin = null
+			scrolling = false
+
+			if (wasScrolling) return null
+			if (Math.abs(dx) < SWIPE_MIN_X || Math.abs(dx) < Math.abs(dy) * 2) return null
+			return dx < 0 ? 1 : -1
+		},
+
+		/** Drops the gesture — nothing it does afterwards can page the thread. */
+		cancel() {
+			origin = null
+			scrolling = false
+		},
+	}
+}


### PR DESCRIPTION
Swipe-to-page was judged on the two endpoints of a touch, and reading a message is mostly scrolling: a thumb that travels far enough vertically arcs well past the 64px sideways threshold on the way, and a scroll that wanders back towards the height it began at nets almost no vertical delta to weigh that against. The thread paged out from under the reader.

The gesture is now watched along its path — the views pass `touchmove` through to the pane alongside `touchstart`/`touchend`. Once a gesture has scrolled 24px vertically it stays a scroll, whatever its endpoints say.

The rule moves to `utils/swipeGesture`, apart from its Vue wiring: `useSwipeNav` is bound to a router, a store and a theme, and the geometry is worth stating and testing without any of them. The message iframe keeps its own copy rather than an import (EmailContent builds that script as a string, into a sandboxed document) and now carries the same scroll lock, so a swipe over a message body is judged exactly as one over the pane.

Tests: `utils/swipeGesture.test.ts`.
