### PR TITLE
feat(meet): separate recorder health and admission

### DIFF
--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -502,6 +502,7 @@ def start(meeting_id: str, request_id: str) -> dict:
             recording=recording.name,
             job=recording.recorder_job_id,
             limits=_limits(recording),
+            recording_allowed=bool(preflight["eligible"]),
         )
     )
     return _finish_start(room, recording, outcome, client)

--- a/suite/meet/docs/adr/0012-separate-recorder-health-and-admission.md
+++ b/suite/meet/docs/adr/0012-separate-recorder-health-and-admission.md
@@ -1,0 +1,12 @@
+# Separate recorder health from Recording Startup admission
+
+Frappe treats Meet Media Deployment configuration, cached Recorder Readiness, advisory Recording Capacity, and authoritative Recording Startup admission as distinct facts. Periodic authenticated probes update a short-lived health record for preflight and operations, while only the recorder's reservation response decides admission; synchronous participant-request health calls and queued recording requests were rejected because they add latency without removing races.
+
+## Consequences
+
+- The recorder exposes an authenticated deployment-health response with observation time, readiness, typed readiness reason, configured capacity, active count, and advisory available count.
+- Frappe records health with a bounded freshness period. Missing configuration is a hard preflight failure; stale, unready, or zero-capacity observations are advisory and do not disable an authorized reservation attempt.
+- Preflight reports policy eligibility separately from deployment health. It does not present cached capacity as a reservation guarantee.
+- Reservation remains immediate and unqueued. Capacity, recorder storage, readiness, recovery state, policy, and invalid-request rejections use distinct typed reason codes from ADR-0009.
+- The Frappe recorder Adapter preserves typed outcomes. Participant presentation maps safe reason codes to specific messages while retaining generic treatment for invalid or security-sensitive requests.
+- Tests cover stale probes, configured-but-unready deployment, capacity races in both directions, disk admission, recovery-required state, typed presentation, and the invariant that no result queues a Recording Startup.

--- a/suite/meet/recorder-server/README.md
+++ b/suite/meet/recorder-server/README.md
@@ -39,7 +39,9 @@ finalization output; `/ready` fails when free space falls below the floor.
 
 The recorder API remains bound to host loopback on port 3010. Caddy exposes
 the control and status routes plus bearer-protected `/recorder/metrics` over
-HTTPS. Configure the Frappe site with the same secret:
+HTTPS. Frappe probes `/v1/deployment-health` with a short-lived deployment-health
+JWT; the response is advisory, while `POST /v1/recordings` remains the only
+authoritative admission decision. Configure the Frappe site with the same secret:
 
 ```json
 {

--- a/suite/meet/recorder-server/deploy/Caddyfile
+++ b/suite/meet/recorder-server/deploy/Caddyfile
@@ -10,7 +10,7 @@
 			reverse_proxy 127.0.0.1:3010
 		}
 
-		@control path /v1/recordings /v1/recordings/*
+		@control path /v1/deployment-health /v1/recordings /v1/recordings/*
 		handle @control {
 			request_body {
 				max_size 16KB

--- a/suite/meet/recorder-server/src/AuthManager.ts
+++ b/suite/meet/recorder-server/src/AuthManager.ts
@@ -5,8 +5,12 @@ import {
 	COMMAND_AUDIENCE,
 	COMMAND_TYPE,
 	type CommandClaims,
+	HEALTH_AUDIENCE,
+	HEALTH_TYPE,
+	type HealthClaims,
 	PROTOCOL_VERSION,
 	type RecordingLimits,
+	type RecordingPolicy,
 } from './types.js';
 
 const CLAIM_KEYS = [
@@ -19,13 +23,26 @@ const CLAIM_KEYS = [
 	'limits',
 	'operation',
 	'origin',
+	'policy',
 	'protocol_version',
 	'recording',
 	'room',
 	'site',
 ];
+const HEALTH_CLAIM_KEYS = [
+	'aud',
+	'exp',
+	'iat',
+	'iss',
+	'jti',
+	'operation',
+	'origin',
+	'protocol_version',
+	'site',
+];
 const LIMIT_KEYS = ['budget_bytes', 'max_ends_at', 'output'];
 const OUTPUT_KEYS = ['audio', 'fps', 'height', 'video', 'width'];
+const POLICY_KEYS = ['recording_allowed'];
 
 export class AuthError extends Error {}
 
@@ -98,6 +115,19 @@ function parseLimits(value: unknown): RecordingLimits | null {
 	};
 }
 
+function parsePolicy(value: unknown): RecordingPolicy | null {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!exactKeys(value, POLICY_KEYS) ||
+		!('recording_allowed' in value) ||
+		typeof value.recording_allowed !== 'boolean'
+	)
+		return null;
+	return { recording_allowed: value.recording_allowed };
+}
+
 export class AuthManager {
 	constructor(
 		private readonly secret: string,
@@ -106,7 +136,7 @@ export class AuthManager {
 		private readonly store: JobStore,
 	) {}
 
-	async consume(claims: CommandClaims): Promise<void> {
+	async consume(claims: { jti: string; exp: number }): Promise<void> {
 		if (!(await this.store.consumeJti(claims.jti, claims.exp)))
 			throw new AuthError('replayed command');
 	}
@@ -175,6 +205,55 @@ export class AuthManager {
 		return claims;
 	}
 
+	authenticateHealth(
+		authorization: string | undefined,
+		now = Math.floor(Date.now() / 1000),
+	): HealthClaims {
+		if (!authorization?.startsWith('Bearer ') || authorization.length === 7)
+			throw new AuthError('missing bearer token');
+		const token = authorization.slice(7);
+		let header: JwtHeader | undefined;
+		try {
+			header = jwt.decode(token, { complete: true })?.header;
+		} catch {
+			throw new AuthError('invalid token');
+		}
+		if (
+			!header ||
+			!exactKeys(header, ['alg', 'typ']) ||
+			header.alg !== 'HS256' ||
+			header.typ !== HEALTH_TYPE
+		)
+			throw new AuthError('invalid header');
+		let decoded: unknown;
+		try {
+			decoded = jwt.verify(token, this.secret, {
+				algorithms: ['HS256'],
+				audience: HEALTH_AUDIENCE,
+				issuer: `frappe-site:${this.site}`,
+				clockTimestamp: now,
+			});
+		} catch {
+			throw new AuthError('invalid signature or registered claims');
+		}
+		const claims = parseHealthClaims(decoded);
+		if (
+			claims.site !== this.site ||
+			claims.origin !== this.origin ||
+			claims.iss !== `frappe-site:${claims.site}`
+		)
+			throw new AuthError('wrong health scope');
+		if (![claims.site, claims.origin, claims.jti].every(nonempty))
+			throw new AuthError('invalid binding');
+		if (
+			claims.exp - claims.iat !== 30 ||
+			claims.iat > now + 5 ||
+			claims.iat < now - 35
+		)
+			throw new AuthError('invalid health lifetime');
+		return claims;
+	}
+
 	authenticateMetrics(
 		authorization: string | undefined,
 		token: string,
@@ -219,6 +298,9 @@ export function parseCommandClaims(value: unknown): CommandClaims {
 	}
 	const limits = parseLimits(value.limits);
 	if (!limits) throw new AuthError('invalid limits');
+	if (!('policy' in value)) throw new AuthError('invalid policy');
+	const policy = parsePolicy(value.policy);
+	if (!policy) throw new AuthError('invalid policy');
 	return {
 		protocol_version: PROTOCOL_VERSION,
 		iss: claimString(value, 'iss'),
@@ -230,6 +312,41 @@ export function parseCommandClaims(value: unknown): CommandClaims {
 		job: claimString(value, 'job'),
 		operation: value.operation,
 		limits,
+		policy,
+		jti: claimString(value, 'jti'),
+		iat: value.iat,
+		exp: value.exp,
+	};
+}
+
+export function parseHealthClaims(value: unknown): HealthClaims {
+	if (
+		!value ||
+		typeof value !== 'object' ||
+		Array.isArray(value) ||
+		!exactKeys(value, HEALTH_CLAIM_KEYS) ||
+		!('protocol_version' in value) ||
+		value.protocol_version !== PROTOCOL_VERSION ||
+		!('aud' in value) ||
+		value.aud !== HEALTH_AUDIENCE ||
+		!('operation' in value) ||
+		value.operation !== 'deployment_health' ||
+		!('iat' in value) ||
+		typeof value.iat !== 'number' ||
+		!Number.isSafeInteger(value.iat) ||
+		!('exp' in value) ||
+		typeof value.exp !== 'number' ||
+		!Number.isSafeInteger(value.exp)
+	) {
+		throw new AuthError('invalid health claims');
+	}
+	return {
+		protocol_version: PROTOCOL_VERSION,
+		iss: claimString(value, 'iss'),
+		aud: HEALTH_AUDIENCE,
+		site: claimString(value, 'site'),
+		origin: claimString(value, 'origin'),
+		operation: 'deployment_health',
 		jti: claimString(value, 'jti'),
 		iat: value.iat,
 		exp: value.exp,

--- a/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
+++ b/suite/meet/recorder-server/src/CaptureLifecycle.test.ts
@@ -29,6 +29,7 @@ const command = (job: string): CommandClaims => ({
 	recording: 'recording',
 	job,
 	operation: 'reserve',
+	policy: { recording_allowed: true },
 	limits: {
 		budget_bytes: 100_000_000,
 		max_ends_at: '2030-01-01T00:00:00Z',

--- a/suite/meet/recorder-server/src/JobManager.ts
+++ b/suite/meet/recorder-server/src/JobManager.ts
@@ -1,7 +1,13 @@
 import type { StorageGuard } from './DiskGuard.js';
 import type { JobStore } from './JobStore.js';
 import type { RendererBridge } from './RendererBridge.js';
-import type { CommandClaims, JobRecord } from './types.js';
+import {
+	type CommandClaims,
+	type CommandRejectionReason,
+	type DeploymentHealthResponse,
+	type JobRecord,
+	PROTOCOL_VERSION,
+} from './types.js';
 
 const TERMINAL_STATES = ['complete', 'partial', 'failed'] as const;
 const MAX_ACKNOWLEDGED_TERMINAL_JOBS = 1_000;
@@ -30,7 +36,7 @@ export type ReserveResult =
 	| { status: 'accepted'; job: JobRecord }
 	| {
 			status: 'rejected';
-			reason: 'capacity' | 'storage' | 'policy' | 'invalid_job';
+			reason: CommandRejectionReason;
 	  };
 
 const unrestrictedStorage: StorageGuard = {
@@ -45,6 +51,7 @@ function sameCommand(job: JobRecord, command: CommandClaims): boolean {
 		job.origin === command.origin &&
 		job.room === command.room &&
 		job.recording === command.recording &&
+		command.policy.recording_allowed &&
 		job.limits.max_ends_at === command.limits.max_ends_at &&
 		JSON.stringify(job.limits.output) ===
 			JSON.stringify(command.limits.output) &&
@@ -55,6 +62,7 @@ function sameCommand(job: JobRecord, command: CommandClaims): boolean {
 export class JobManager {
 	private operations: Promise<void> = Promise.resolve();
 	private recoveryRequired = false;
+	private readonly pendingReservations = new Map<string, CommandClaims>();
 	private readonly terminalDeliveries = new Map<string, Promise<void>>();
 	private readonly healthDeliveries = new Map<string, Promise<unknown>>();
 
@@ -161,20 +169,56 @@ export class JobManager {
 	}
 
 	get ready(): boolean {
-		return (
-			this.store.ready &&
-			this.bridge.productionReady &&
-			!this.recoveryRequired &&
-			this.storage.ready()
-		);
+		return this.deploymentHealth().ready;
+	}
+	get ledgerReady(): boolean {
+		return this.store.ready;
 	}
 	get activeCount(): number {
-		return this.store.all().filter((job) => !terminal(job)).length;
+		return (
+			(this.store.ready
+				? this.store.all().filter((job) => !terminal(job)).length
+				: 0) + this.pendingReservations.size
+		);
+	}
+
+	deploymentHealth(): DeploymentHealthResponse {
+		const reason = !this.store.ready
+			? 'ledger_unavailable'
+			: !this.bridge.productionReady
+				? 'renderer_unavailable'
+				: this.recoveryRequired
+					? 'recovery_required'
+					: !this.storage.ready()
+						? 'storage_unavailable'
+						: 'ready';
+		const activeCount = this.store.ready ? this.activeCount : this.capacity;
+		return {
+			protocol_version: PROTOCOL_VERSION,
+			observed_at: new Date().toISOString(),
+			ready: reason === 'ready',
+			reason_code: reason,
+			configured_capacity: this.capacity,
+			active_count: activeCount,
+			available_count: Math.max(0, this.capacity - activeCount),
+		};
 	}
 
 	async reserve(command: CommandClaims): Promise<ReserveResult> {
 		let result: ReserveResult | undefined;
 		await this.serial(async () => {
+			if (!command.policy.recording_allowed) {
+				result = { status: 'rejected', reason: 'policy' };
+				return;
+			}
+			if (this.recoveryRequired) {
+				result = { status: 'rejected', reason: 'recovery_required' };
+				return;
+			}
+			if (!this.store.ready) {
+				result = { status: 'rejected', reason: 'readiness' };
+				return;
+			}
 			const existing = this.store.get(command.job);
 			if (existing) {
 				result =
@@ -183,6 +227,14 @@ export class JobManager {
 					(terminal(existing) || this.bridge.hasWorker(existing.job))
 						? { status: 'accepted', job: existing }
 						: { status: 'rejected', reason: 'invalid_job' };
+				return;
+			}
+			if (this.pendingReservations.has(command.job)) {
+				result = { status: 'rejected', reason: 'invalid_job' };
+				return;
+			}
+			if (!this.bridge.productionReady) {
+				result = { status: 'rejected', reason: 'readiness' };
 				return;
 			}
 			if (this.activeCount >= this.capacity) {
@@ -199,13 +251,21 @@ export class JobManager {
 				}
 				requiredBytes += remaining;
 			}
+			for (const pending of this.pendingReservations.values())
+				requiredBytes += pending.limits.budget_bytes * 2;
 			if (
 				!Number.isSafeInteger(requiredBytes) ||
+				!this.storage.ready() ||
 				!this.storage.canReserve(requiredBytes)
 			) {
 				result = { status: 'rejected', reason: 'storage' };
 				return;
 			}
+			this.pendingReservations.set(command.job, structuredClone(command));
+		});
+		if (result) return result;
+
+		try {
 			const publicJwk = await this.bridge.reserve(command, 0);
 			const job: JobRecord = {
 				job: command.job,
@@ -222,18 +282,22 @@ export class JobManager {
 				stop_operation_ids: [],
 				captured_bytes: 0,
 			};
-			try {
+			await this.serial(async () => {
 				await this.store.update((jobs) => {
 					jobs[job.job] = job;
 				});
-			} catch (error) {
-				await this.bridge.stop(job.job);
-				throw error;
-			}
-			result = { status: 'accepted', job };
-		});
-		if (!result) throw new Error('reservation did not complete');
-		return result;
+				this.pendingReservations.delete(command.job);
+			});
+			return { status: 'accepted', job };
+		} catch (error) {
+			await this.bridge.stop(command.job).catch(() => undefined);
+			throw error;
+		} finally {
+			if (this.pendingReservations.has(command.job))
+				await this.serial(async () => {
+					this.pendingReservations.delete(command.job);
+				});
+		}
 	}
 
 	query(command: CommandClaims): JobRecord | undefined {

--- a/suite/meet/recorder-server/src/ProtocolContract.test.ts
+++ b/suite/meet/recorder-server/src/ProtocolContract.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { parseCommandClaims, validUtcTimestamp } from './AuthManager.js';
+import {
+	parseCommandClaims,
+	parseHealthClaims,
+	validUtcTimestamp,
+} from './AuthManager.js';
 import { grantBody, reserveBody, stopBody } from './app.js';
 import {
 	parseFinalizationResponse,
@@ -53,9 +57,14 @@ const contract = JSON.parse(
 			rejected: JsonObject[];
 		};
 		command_claims: { accepted: JsonObject[]; rejected: JsonObject[] };
+		health_claims: { accepted: JsonObject[]; rejected: JsonObject[] };
 		command_requests: {
 			accepted: { operation: string; body: JsonObject }[];
 			rejected: { operation: string; body: JsonObject }[];
+		};
+		command_rejected_responses: {
+			accepted: { http_status: number; body: JsonObject }[];
+			rejected: { http_status: number; body: JsonObject }[];
 		};
 		finite_values: { [key: string]: string[] };
 	};
@@ -154,6 +163,23 @@ describe('recording protocol contract v1', () => {
 			expect(parseCommandClaims({ ...base, operation }).operation).toBe(
 				operation,
 			);
+	});
+
+	it('runs shared deployment-health claims through the production parser', () => {
+		for (const value of contract.vectors.health_claims.accepted)
+			expect(parseHealthClaims(value)).toBeDefined();
+		for (const value of contract.vectors.health_claims.rejected)
+			expect(() => parseHealthClaims(value)).toThrow();
+	});
+
+	it('covers every finite command rejection reason', () => {
+		expect(
+			new Set(
+				contract.vectors.command_rejected_responses.accepted.map(
+					(value) => value.body.reason_code,
+				),
+			),
+		).toEqual(new Set(contract.vocabularies.command_rejection_reason_codes));
 	});
 
 	it('enumerates every finite vocabulary in executable vectors', () => {

--- a/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
+++ b/suite/meet/recorder-server/src/RecorderVerticalChain.test.ts
@@ -49,6 +49,7 @@ const command: CommandClaims = {
 	recording: 'recording-vertical',
 	job: 'job-vertical',
 	operation: 'reserve',
+	policy: { recording_allowed: true },
 	limits: {
 		budget_bytes: 1_000_000,
 		max_ends_at: '2026-07-31T12:00:00Z',

--- a/suite/meet/recorder-server/src/RendererBridge.test.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.test.ts
@@ -21,6 +21,7 @@ const command: CommandClaims = {
 	recording: 'recording-1',
 	job: 'job-1',
 	operation: 'reserve',
+	policy: { recording_allowed: true },
 	limits: {
 		budget_bytes: 1_000_000,
 		max_ends_at: '2026-07-31T12:00:00Z',

--- a/suite/meet/recorder-server/src/RendererBridge.ts
+++ b/suite/meet/recorder-server/src/RendererBridge.ts
@@ -989,7 +989,7 @@ export const TEST_PUBLIC_JWK: PublicJwk = {
 };
 
 export class FakeRendererBridge implements RendererBridge {
-	readonly productionReady = false;
+	readonly productionReady = true;
 	readonly grants: Array<{
 		job: string;
 		grant: string;

--- a/suite/meet/recorder-server/src/app.ts
+++ b/suite/meet/recorder-server/src/app.ts
@@ -209,6 +209,20 @@ export function createApp(
 			return res.status(401).json({ status: 'unauthorized' });
 		res.type(registry.contentType).send(await registry.metrics());
 	});
+	app.get('/v1/deployment-health', (req, res) => {
+		try {
+			auth.authenticateHealth(req.header('authorization'));
+			return res.json(jobs.deploymentHealth());
+		} catch (error) {
+			log.info({
+				event: 'authorization_rejected',
+				reason: error instanceof AuthError ? error.message : 'invalid',
+			});
+			return res
+				.status(401)
+				.json({ protocol_version: PROTOCOL_VERSION, status: 'unauthorized' });
+		}
+	});
 
 	function command(operation: CommandClaims['operation']) {
 		return (req: Request, res: Response, next: NextFunction): void => {
@@ -246,8 +260,17 @@ export function createApp(
 						protocol_version: PROTOCOL_VERSION,
 						status: 'rejected',
 						job: claims.job,
-						reason_code: 'invalid_job',
+						reason_code: 'invalid_request',
 					});
+				if (!jobs.ledgerReady) {
+					starts.inc({ outcome: 'rejected', reason: 'readiness' });
+					return res.status(503).json({
+						protocol_version: PROTOCOL_VERSION,
+						status: 'rejected',
+						job: claims.job,
+						reason_code: 'readiness',
+					});
+				}
 				await auth.consume(claims);
 				const result = await jobs.reserve(claims);
 				if (result.status === 'accepted') {
@@ -262,7 +285,10 @@ export function createApp(
 							? 429
 							: result.reason === 'storage'
 								? 507
-								: 422,
+								: result.reason === 'readiness' ||
+										result.reason === 'recovery_required'
+									? 503
+									: 422,
 					)
 					.json({
 						protocol_version: PROTOCOL_VERSION,

--- a/suite/meet/recorder-server/src/core.test.ts
+++ b/suite/meet/recorder-server/src/core.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import type { Express } from 'express';
 import jwt from 'jsonwebtoken';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { AuthError, AuthManager } from './AuthManager.js';
+import { AuthError, AuthManager, validUtcTimestamp } from './AuthManager.js';
 import { createApp } from './app.js';
 import type { Config } from './config.js';
 import { loadConfig } from './config.js';
@@ -17,6 +17,9 @@ import {
 	COMMAND_AUDIENCE,
 	COMMAND_TYPE,
 	type CommandClaims,
+	HEALTH_AUDIENCE,
+	HEALTH_TYPE,
+	type HealthClaims,
 	PROTOCOL_VERSION,
 } from './types.js';
 
@@ -32,6 +35,7 @@ const baseClaims = {
 	recording: 'recording',
 	job: 'job',
 	operation: 'reserve',
+	policy: { recording_allowed: true },
 	jti: 'nonce',
 	iat: now,
 	exp: now + 30,
@@ -41,6 +45,18 @@ const baseClaims = {
 		output: { width: 1920, height: 1080, fps: 30, video: 'h264', audio: 'aac' },
 	},
 } satisfies CommandClaims;
+
+const baseHealthClaims = {
+	protocol_version: PROTOCOL_VERSION,
+	iss: 'frappe-site:site.test',
+	aud: HEALTH_AUDIENCE,
+	site: 'site.test',
+	origin: 'https://site.test',
+	operation: 'deployment_health',
+	jti: 'health-nonce',
+	iat: now,
+	exp: now + 30,
+} satisfies HealthClaims;
 
 function token(
 	overrides: Partial<Omit<CommandClaims, 'aud' | 'limits'>> & {
@@ -56,6 +72,17 @@ function token(
 		{
 			algorithm: 'HS256',
 			header: { alg: 'HS256', typ: COMMAND_TYPE, ...header },
+		},
+	);
+}
+
+function healthToken(overrides: Partial<HealthClaims> = {}): string {
+	return jwt.sign(
+		{ ...baseHealthClaims, jti: crypto.randomUUID(), ...overrides },
+		secret,
+		{
+			algorithm: 'HS256',
+			header: { alg: 'HS256', typ: HEALTH_TYPE },
 		},
 	);
 }
@@ -338,6 +365,123 @@ describe('JobStore and JobManager', () => {
 		]);
 		const again = await manager.reserve(baseClaims);
 		expect(again.status).toBe('accepted');
+	});
+
+	it('claims capacity before renderer startup without queueing another reservation', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const reserve = vi.fn(async () => {
+			await blocked;
+			return TEST_PUBLIC_JWK;
+		});
+		const bridge = Object.assign(new FakeRendererBridge(), {
+			productionReady: true,
+			reserve,
+		});
+		const manager = new JobManager(store, bridge, 1);
+
+		expect(manager.deploymentHealth().available_count).toBe(1);
+		const first = manager.reserve(baseClaims);
+		await vi.waitFor(() => expect(reserve).toHaveBeenCalledOnce());
+		expect(manager.deploymentHealth().available_count).toBe(0);
+		const second = manager.reserve({ ...baseClaims, job: 'job-2' });
+		await expect(second).resolves.toEqual({
+			status: 'rejected',
+			reason: 'capacity',
+		});
+		expect(reserve).toHaveBeenCalledOnce();
+
+		release();
+		await expect(first).resolves.toMatchObject({ status: 'accepted' });
+		expect(bridge.hasWorker('job-2')).toBe(false);
+	});
+
+	it('reports every deployment readiness reason with deterministic precedence', async () => {
+		const unavailableStore = new JobStore(path);
+		const unavailable = new JobManager(
+			unavailableStore,
+			new FakeRendererBridge(),
+			1,
+		);
+		expect(unavailable.deploymentHealth()).toMatchObject({
+			ready: false,
+			reason_code: 'ledger_unavailable',
+			active_count: 1,
+			available_count: 0,
+		});
+
+		const store = new JobStore(path);
+		await store.initialize();
+		const rendererUnavailable = new FakeRendererBridge();
+		Object.defineProperty(rendererUnavailable, 'productionReady', {
+			value: false,
+		});
+		expect(
+			new JobManager(store, rendererUnavailable, 1).deploymentHealth(),
+		).toMatchObject({ ready: false, reason_code: 'renderer_unavailable' });
+
+		const storageUnavailable = new JobManager(
+			store,
+			new FakeRendererBridge(),
+			1,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			{ ready: () => false, canReserve: () => false },
+		);
+		expect(storageUnavailable.deploymentHealth()).toMatchObject({
+			ready: false,
+			reason_code: 'storage_unavailable',
+		});
+	});
+
+	it('separates deployment readiness and advisory capacity', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		const bridge = Object.assign(new FakeRendererBridge(), {
+			productionReady: true,
+		});
+		const manager = new JobManager(store, bridge, 1);
+
+		expect(manager.deploymentHealth()).toMatchObject({
+			protocol_version: 1,
+			ready: true,
+			reason_code: 'ready',
+			configured_capacity: 1,
+			active_count: 0,
+			available_count: 1,
+		});
+		await manager.reserve(baseClaims);
+		expect(manager.deploymentHealth()).toMatchObject({
+			ready: true,
+			reason_code: 'ready',
+			active_count: 1,
+			available_count: 0,
+		});
+	});
+
+	it('rejects policy and recorder readiness with distinct outcomes', async () => {
+		const store = new JobStore(path);
+		await store.initialize();
+		const bridge = new FakeRendererBridge();
+		Object.defineProperty(bridge, 'productionReady', { value: false });
+		const manager = new JobManager(store, bridge, 1);
+
+		await expect(
+			manager.reserve({
+				...baseClaims,
+				policy: { recording_allowed: false },
+			}),
+		).resolves.toEqual({ status: 'rejected', reason: 'policy' });
+		await expect(manager.reserve(baseClaims)).resolves.toEqual({
+			status: 'rejected',
+			reason: 'readiness',
+		});
 	});
 
 	it('persists monotonic progress and returns exact retries without another callback', async () => {
@@ -1010,8 +1154,13 @@ describe('JobStore and JobManager', () => {
 		const restarted = new JobManager(reloaded, restartedBridge, 1);
 		await restarted.initialize();
 		expect(restarted.ready).toBe(false);
+		expect(restarted.deploymentHealth().reason_code).toBe('recovery_required');
 		expect(reloaded.get('job')?.state).toBe('recovery_required');
 		expect(restarted.query(baseClaims)).toBeUndefined();
+		expect(await restarted.reserve({ ...baseClaims, job: 'job-2' })).toEqual({
+			status: 'rejected',
+			reason: 'recovery_required',
+		});
 	});
 
 	it('durably tracks capture readiness and interruption', async () => {
@@ -1452,7 +1601,9 @@ describe('JobStore and JobManager', () => {
 		const bridge = new FakeRendererBridge();
 		const manager = new JobManager(store, bridge, 1);
 		await manager.reserve(baseClaims);
+		expect(manager.deploymentHealth().available_count).toBe(0);
 		await bridge.emit({ job: 'job', type: 'failed' });
+		expect(manager.deploymentHealth().available_count).toBe(1);
 
 		const next = await manager.reserve({ ...baseClaims, job: 'job-2' });
 
@@ -1490,14 +1641,32 @@ describe('JobStore and JobManager', () => {
 		).toBe('accepted');
 	});
 
-	it('stops a reserved browser when the durable store update fails', async () => {
+	it('holds capacity until renderer cleanup after durable persistence fails', async () => {
 		const store = new JobStore(path);
 		await store.initialize();
 		const bridge = new FakeRendererBridge();
 		const manager = new JobManager(store, bridge, 1);
 		vi.spyOn(store, 'update').mockRejectedValueOnce(new Error('disk failed'));
-		await expect(manager.reserve(baseClaims)).rejects.toThrow('disk failed');
+		let cleanupStarted!: () => void;
+		const started = new Promise<void>((resolve) => {
+			cleanupStarted = resolve;
+		});
+		let finishCleanup!: () => void;
+		const cleanup = new Promise<void>((resolve) => {
+			finishCleanup = resolve;
+		});
+		vi.spyOn(bridge, 'stop').mockImplementation(async (job) => {
+			cleanupStarted();
+			await cleanup;
+			bridge.stopped.add(job);
+		});
+		const reservation = manager.reserve(baseClaims);
+		await started;
+		expect(manager.deploymentHealth().available_count).toBe(0);
+		finishCleanup();
+		await expect(reservation).rejects.toThrow('disk failed');
 		expect(bridge.stopped.has('job')).toBe(true);
+		expect(manager.deploymentHealth().available_count).toBe(1);
 	});
 
 	it('persists stop operation IDs before invoking the bridge and never persists grants', async () => {
@@ -1519,13 +1688,14 @@ describe('JobStore and JobManager', () => {
 describe('HTTP contract', () => {
 	let app: ReturnType<typeof createApp>;
 	let bridge: FakeRendererBridge;
+	let store: JobStore;
 	let logs: LogEntry[];
 	let config: Config;
 	let storageAllowed: boolean;
 
 	beforeEach(async () => {
 		const directory = await mkdtemp(join(tmpdir(), 'recorder-http-'));
-		const store = new JobStore(join(directory, 'ledger.json'));
+		store = new JobStore(join(directory, 'ledger.json'));
 		await store.initialize();
 		bridge = new FakeRendererBridge();
 		storageAllowed = true;
@@ -1586,6 +1756,7 @@ describe('HTTP contract', () => {
 	afterEach(() => vi.restoreAllMocks());
 
 	it('serves liveness but remains unready without a production bridge', async () => {
+		Object.defineProperty(bridge, 'productionReady', { value: false });
 		const health = await call(app, '/health');
 		expect([health.status, await health.json()]).toEqual([
 			200,
@@ -1596,6 +1767,59 @@ describe('HTTP contract', () => {
 			503,
 			{ status: 'not_ready' },
 		]);
+	});
+
+	it('serves exact authenticated deployment health separately from liveness', async () => {
+		Object.defineProperty(bridge, 'productionReady', { value: false });
+		expect((await call(app, '/v1/deployment-health')).status).toBe(401);
+		expect(
+			(
+				await call(app, '/v1/deployment-health', {
+					headers: { Authorization: `Bearer ${token()}` },
+				})
+			).status,
+		).toBe(401);
+		const signed = healthToken();
+		const response = await call(app, '/v1/deployment-health', {
+			headers: { Authorization: `Bearer ${signed}` },
+		});
+		expect(response.status).toBe(200);
+		const body = await response.json();
+		expect(body).toEqual({
+			protocol_version: 1,
+			observed_at: expect.any(String),
+			ready: false,
+			reason_code: 'renderer_unavailable',
+			configured_capacity: 1,
+			active_count: 0,
+			available_count: 1,
+		});
+		expect(validUtcTimestamp(body.observed_at)).toBe(true);
+		expect(
+			(
+				await call(app, '/v1/deployment-health', {
+					headers: { Authorization: `Bearer ${signed}` },
+				})
+			).status,
+		).toBe(200);
+	});
+
+	it('returns typed readiness before nonce persistence when the ledger is unavailable', async () => {
+		vi.spyOn(store, 'ready', 'get').mockReturnValue(false);
+		const consume = vi.spyOn(store, 'consumeJti');
+		const response = await call(
+			app,
+			'/v1/recordings',
+			authenticated('POST', { job: 'job' }),
+		);
+		expect(response.status).toBe(503);
+		expect(await response.json()).toEqual({
+			protocol_version: 1,
+			status: 'rejected',
+			job: 'job',
+			reason_code: 'readiness',
+		});
+		expect(consume).not.toHaveBeenCalled();
 	});
 
 	it('reserves, queries, grants, and stops with exact RecorderClient bodies', async () => {
@@ -1690,6 +1914,60 @@ describe('HTTP contract', () => {
 			job: 'job',
 			reason_code: 'storage',
 		});
+	});
+
+	it('preserves recorder readiness as an authoritative rejection', async () => {
+		Object.defineProperty(bridge, 'productionReady', { value: false });
+		const response = await call(
+			app,
+			'/v1/recordings',
+			authenticated('POST', { job: 'job' }),
+		);
+		expect([response.status, await response.json()]).toEqual([
+			503,
+			{
+				protocol_version: 1,
+				status: 'rejected',
+				job: 'job',
+				reason_code: 'readiness',
+			},
+		]);
+	});
+
+	it('preserves policy and invalid request as distinct reserve rejections', async () => {
+		const policy = await call(
+			app,
+			'/v1/recordings',
+			authenticated(
+				'POST',
+				{ job: 'job' },
+				token({ policy: { recording_allowed: false } }),
+			),
+		);
+		expect([policy.status, await policy.json()]).toEqual([
+			422,
+			{
+				protocol_version: 1,
+				status: 'rejected',
+				job: 'job',
+				reason_code: 'policy',
+			},
+		]);
+
+		const invalid = await call(
+			app,
+			'/v1/recordings',
+			authenticated('POST', { job: 'job', extra: true }),
+		);
+		expect([invalid.status, await invalid.json()]).toEqual([
+			422,
+			{
+				protocol_version: 1,
+				status: 'rejected',
+				job: 'job',
+				reason_code: 'invalid_request',
+			},
+		]);
 	});
 
 	it('authenticates control requests before parsing bounded JSON', async () => {

--- a/suite/meet/recorder-server/src/integration/RecorderSharedStage.integration.ts
+++ b/suite/meet/recorder-server/src/integration/RecorderSharedStage.integration.ts
@@ -400,6 +400,7 @@ try {
 		recording: 'recording-shared-stage',
 		job,
 		operation: 'reserve',
+		policy: { recording_allowed: true },
 		limits: {
 			budget_bytes: 100_000_000,
 			max_ends_at: new Date(Date.now() + 300_000).toISOString(),

--- a/suite/meet/recorder-server/src/logger.ts
+++ b/suite/meet/recorder-server/src/logger.ts
@@ -9,6 +9,7 @@ export type LogEvent =
 	| 'startup_callback_failed'
 	| 'replacement_ready_callback_failed'
 	| 'terminal_delivery_failed'
+	| 'service_initialization_failed'
 	| 'service_error';
 
 export interface LogEntry {

--- a/suite/meet/recorder-server/src/server.ts
+++ b/suite/meet/recorder-server/src/server.ts
@@ -15,7 +15,6 @@ async function main(): Promise<void> {
 	await mkdir(config.dataRoot, { recursive: true, mode: 0o700 });
 	const disk = new DiskGuard(config.dataRoot, config.minimumFreeBytes);
 	const store = new JobStore(config.ledgerPath);
-	await store.initialize();
 	let capture!: CaptureWorkerManager;
 	const renderer = new ChromiumRendererBridge({
 		executablePath: config.chromiumExecutable,
@@ -29,7 +28,6 @@ async function main(): Promise<void> {
 		configureTimeoutMs: config.rendererConfigureTimeoutMs,
 		workerEnvironment: (job) => capture.workerEnvironment(job),
 	});
-	await renderer.initialize();
 	capture = new CaptureWorkerManager(renderer, {
 		dataRoot: config.dataRoot,
 		segmentSeconds: config.segmentSeconds,
@@ -119,7 +117,6 @@ async function main(): Promise<void> {
 		},
 		(job, capturedBytes) => callbacks.segmentProgress(job, capturedBytes),
 	);
-	await jobs.initialize();
 	const auth = new AuthManager(
 		config.secret,
 		config.site,
@@ -127,6 +124,16 @@ async function main(): Promise<void> {
 		store,
 	);
 	const server = createApp(config, auth, jobs, logger).listen(config.port);
+	try {
+		await store.initialize();
+		await renderer.initialize();
+		await jobs.initialize();
+	} catch (error) {
+		logger.error({
+			event: 'service_initialization_failed',
+			reason: error instanceof Error ? error.message : 'initialization_failed',
+		});
+	}
 	let shuttingDown = false;
 	const shutdown = async () => {
 		if (shuttingDown) return;

--- a/suite/meet/recorder-server/src/server.ts
+++ b/suite/meet/recorder-server/src/server.ts
@@ -124,16 +124,6 @@ async function main(): Promise<void> {
 		store,
 	);
 	const server = createApp(config, auth, jobs, logger).listen(config.port);
-	try {
-		await store.initialize();
-		await renderer.initialize();
-		await jobs.initialize();
-	} catch (error) {
-		logger.error({
-			event: 'service_initialization_failed',
-			reason: error instanceof Error ? error.message : 'initialization_failed',
-		});
-	}
 	let shuttingDown = false;
 	const shutdown = async () => {
 		if (shuttingDown) return;
@@ -143,6 +133,19 @@ async function main(): Promise<void> {
 	};
 	process.once('SIGINT', () => void shutdown());
 	process.once('SIGTERM', () => void shutdown());
+	try {
+		await store.initialize();
+		await renderer.initialize();
+		await jobs.initialize();
+	} catch (error) {
+		logger.error({
+			event: 'service_initialization_failed',
+			reason: error instanceof Error ? error.message : 'initialization_failed',
+		});
+		await new Promise((resolve) => setTimeout(resolve, 5_000));
+		await shutdown();
+		throw error;
+	}
 }
 
 main().catch((error: unknown) => {

--- a/suite/meet/recorder-server/src/types.ts
+++ b/suite/meet/recorder-server/src/types.ts
@@ -1,7 +1,27 @@
 export const COMMAND_AUDIENCE = 'meet-recorder-control';
 export const COMMAND_TYPE = 'meet-recorder-command+jwt';
+export const HEALTH_AUDIENCE = 'meet-recorder-health';
+export const HEALTH_TYPE = 'meet-recorder-health+jwt';
 export const PROTOCOL_VERSION = 1;
 export type CommandOperation = 'reserve' | 'query' | 'grant' | 'stop';
+export type CommandRejectionReason =
+	| 'capacity'
+	| 'storage'
+	| 'readiness'
+	| 'recovery_required'
+	| 'policy'
+	| 'invalid_request'
+	| 'invalid_job';
+export type DeploymentReadinessReason =
+	| 'ready'
+	| 'ledger_unavailable'
+	| 'renderer_unavailable'
+	| 'recovery_required'
+	| 'storage_unavailable';
+
+export interface RecordingPolicy {
+	recording_allowed: boolean;
+}
 
 export interface RecordingLimits {
 	budget_bytes: number;
@@ -20,9 +40,32 @@ export interface CommandClaims {
 	job: string;
 	operation: CommandOperation;
 	limits: RecordingLimits;
+	policy: RecordingPolicy;
 	jti: string;
 	iat: number;
 	exp: number;
+}
+
+export interface HealthClaims {
+	protocol_version: typeof PROTOCOL_VERSION;
+	iss: string;
+	aud: typeof HEALTH_AUDIENCE;
+	site: string;
+	origin: string;
+	operation: 'deployment_health';
+	jti: string;
+	iat: number;
+	exp: number;
+}
+
+export interface DeploymentHealthResponse {
+	protocol_version: typeof PROTOCOL_VERSION;
+	observed_at: string;
+	ready: boolean;
+	reason_code: DeploymentReadinessReason;
+	configured_capacity: number;
+	active_count: number;
+	available_count: number;
 }
 
 export interface PublicJwk {

--- a/suite/meet/recording/contracts/v1.json
+++ b/suite/meet/recording/contracts/v1.json
@@ -5,6 +5,7 @@
   "timestamp_format": "UTC RFC 3339 with exactly millisecond precision and Z",
   "vocabularies": {
     "command_operations": ["reserve", "query", "grant", "stop"],
+    "health_operations": ["deployment_health"],
     "command_states": [
       "reserved",
       "configured",
@@ -18,7 +19,22 @@
       "complete",
       "partial"
     ],
-    "command_rejection_reason_codes": ["capacity", "storage", "policy", "invalid_job"],
+    "command_rejection_reason_codes": [
+      "capacity",
+      "storage",
+      "readiness",
+      "recovery_required",
+      "policy",
+      "invalid_request",
+      "invalid_job"
+    ],
+    "deployment_readiness_reason_codes": [
+      "ready",
+      "ledger_unavailable",
+      "renderer_unavailable",
+      "recovery_required",
+      "storage_unavailable"
+    ],
     "health_reason_codes": [
       "browser_disconnected",
       "capture_interrupted",
@@ -114,10 +130,37 @@
         "limits",
         "operation",
         "origin",
+        "policy",
         "protocol_version",
         "recording",
         "room",
         "site"
+      ],
+      "optional": []
+    },
+    "health_claims": {
+      "required": [
+        "aud",
+        "exp",
+        "iat",
+        "iss",
+        "jti",
+        "operation",
+        "origin",
+        "protocol_version",
+        "site"
+      ],
+      "optional": []
+    },
+    "deployment_health_response": {
+      "required": [
+        "active_count",
+        "available_count",
+        "configured_capacity",
+        "observed_at",
+        "protocol_version",
+        "ready",
+        "reason_code"
       ],
       "optional": []
     },
@@ -539,13 +582,121 @@
           "max_ends_at": "2026-08-30T12:00:00.000Z",
           "output": { "width": 1920, "height": 1080, "fps": 30, "video": "h264", "audio": "aac" }
         },
+        "policy": { "recording_allowed": true },
         "jti": "jti-vector",
         "iat": 1700000000,
         "exp": 1700000030
       }],
       "rejected": [
         { "protocol_version": 2 },
-        { "protocol_version": 1, "unknown": true }
+        { "protocol_version": 1, "unknown": true },
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-control",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "room": "room-vector",
+          "recording": "recording-vector",
+          "job": "job-vector",
+          "operation": "reserve",
+          "limits": {
+            "budget_bytes": 1000000,
+            "max_ends_at": "2026-08-30T12:00:00.000Z",
+            "output": { "width": 1920, "height": 1080, "fps": 30, "video": "h264", "audio": "aac" }
+          },
+          "jti": "jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030
+        },
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-control",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "room": "room-vector",
+          "recording": "recording-vector",
+          "job": "job-vector",
+          "operation": "reserve",
+          "limits": {
+            "budget_bytes": 1000000,
+            "max_ends_at": "2026-08-30T12:00:00.000Z",
+            "output": { "width": 1920, "height": 1080, "fps": 30, "video": "h264", "audio": "aac" }
+          },
+          "policy": { "recording_allowed": "true" },
+          "jti": "jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030
+        },
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-control",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "room": "room-vector",
+          "recording": "recording-vector",
+          "job": "job-vector",
+          "operation": "reserve",
+          "limits": {
+            "budget_bytes": 1000000,
+            "max_ends_at": "2026-08-30T12:00:00.000Z",
+            "output": { "width": 1920, "height": 1080, "fps": 30, "video": "h264", "audio": "aac" }
+          },
+          "policy": { "recording_allowed": true, "unknown": true },
+          "jti": "jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030
+        }
+      ]
+    },
+    "health_claims": {
+      "accepted": [{
+        "protocol_version": 1,
+        "iss": "frappe-site:site.test",
+        "aud": "meet-recorder-health",
+        "site": "site.test",
+        "origin": "https://site.test",
+        "operation": "deployment_health",
+        "jti": "health-jti-vector",
+        "iat": 1700000000,
+        "exp": 1700000030
+      }],
+      "rejected": [
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-health",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "jti": "health-jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030
+        },
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-health",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "operation": "health",
+          "jti": "health-jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030
+        },
+        {
+          "protocol_version": 1,
+          "iss": "frappe-site:site.test",
+          "aud": "meet-recorder-health",
+          "site": "site.test",
+          "origin": "https://site.test",
+          "operation": "deployment_health",
+          "jti": "health-jti-vector",
+          "iat": 1700000000,
+          "exp": 1700000030,
+          "unknown": true
+        }
       ]
     },
     "command_requests": {
@@ -585,7 +736,10 @@
       "accepted": [
         { "http_status": 429, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "capacity" } },
         { "http_status": 507, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "storage" } },
+        { "http_status": 503, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "readiness" } },
+        { "http_status": 503, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "recovery_required" } },
         { "http_status": 422, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "policy" } },
+        { "http_status": 422, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "invalid_request" } },
         { "http_status": 422, "body": { "protocol_version": 1, "status": "rejected", "job": "job-vector", "reason_code": "invalid_job" } }
       ],
       "rejected": [
@@ -800,8 +954,10 @@
     },
     "finite_values": {
       "command_operations": ["reserve", "query", "grant", "stop"],
+      "health_operations": ["deployment_health"],
       "command_states": ["reserved", "configured", "proof_complete", "joined", "capture_ready", "interrupted", "failed", "recovery_required", "stopping", "complete", "partial"],
-      "command_rejection_reason_codes": ["capacity", "storage", "policy", "invalid_job"],
+      "command_rejection_reason_codes": ["capacity", "storage", "readiness", "recovery_required", "policy", "invalid_request", "invalid_job"],
+      "deployment_readiness_reason_codes": ["ready", "ledger_unavailable", "renderer_unavailable", "recovery_required", "storage_unavailable"],
       "health_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "duration_limit", "ffmpeg_exited", "interruption_timeout", "media_attachment_failed", "media_subscription_failed", "page_crashed", "projection_invalid", "quota_limit", "receive_transport_failed", "room_empty", "service_shutdown", "sfu_disconnected", "worker_missing_after_restart"],
       "startup_milestones": ["configured", "proof_complete", "joined", "capture_started"],
       "interruption_reason_codes": ["browser_disconnected", "capture_interrupted", "configuration_failed", "ffmpeg_exited", "media_attachment_failed", "media_subscription_failed", "page_crashed", "projection_invalid", "receive_transport_failed", "sfu_disconnected"],

--- a/suite/meet/recording/recorder_client.py
+++ b/suite/meet/recording/recorder_client.py
@@ -20,8 +20,24 @@ COMMAND_TYPE = "meet-recorder-command+jwt"
 PROTOCOL_VERSION = 1
 MAX_RESPONSE_BYTES = 16 * 1024
 TIMEOUT = (2, 5)
-REJECTION_REASONS = {"capacity", "storage", "policy", "invalid_job"}
-REJECTION_STATUSES = {"capacity": 429, "storage": 507, "policy": 422, "invalid_job": 422}
+REJECTION_REASONS = {
+    "capacity",
+    "storage",
+    "readiness",
+    "recovery_required",
+    "policy",
+    "invalid_request",
+    "invalid_job",
+}
+REJECTION_STATUSES = {
+    "capacity": 429,
+    "storage": 507,
+    "readiness": 503,
+    "recovery_required": 503,
+    "policy": 422,
+    "invalid_request": 422,
+    "invalid_job": 422,
+}
 HEALTH_REASON_CODES = {
     "browser_disconnected",
     "capture_interrupted",
@@ -92,8 +108,25 @@ class RecorderClient:
         self.session.mount("http://", adapter)
         self.session.mount("https://", adapter)
 
-    def reserve(self, *, room: str, recording: str, job: str, limits: dict[str, Any]) -> RecorderOutcome:
-        return self._request("reserve", "POST", "/v1/recordings", room, recording, job, limits)
+    def reserve(
+        self,
+        *,
+        room: str,
+        recording: str,
+        job: str,
+        limits: dict[str, Any],
+        recording_allowed: bool,
+    ) -> RecorderOutcome:
+        return self._request(
+            "reserve",
+            "POST",
+            "/v1/recordings",
+            room,
+            recording,
+            job,
+            limits,
+            recording_allowed,
+        )
 
     def query(self, *, room: str, recording: str, job: str, limits: dict[str, Any]) -> RecorderOutcome:
         return self._request("query", "GET", f"/v1/recordings/{job}", room, recording, job, limits)
@@ -160,6 +193,7 @@ class RecorderClient:
         recording: str,
         job: str,
         limits: dict[str, Any],
+        recording_allowed: bool = True,
     ) -> RecorderOutcome:
         result = self._raw_request(
             operation,
@@ -170,6 +204,7 @@ class RecorderClient:
             job,
             limits,
             {"protocol_version": PROTOCOL_VERSION, "job": job},
+            recording_allowed,
         )
         if result is None:
             return RecorderOutcome("indeterminate")
@@ -265,7 +300,7 @@ class RecorderClient:
                 interruption=interruption,
                 replacement_ready_at=replacement_ready_at,
             )
-        if response.status_code in (409, 422, 429, 507) and set(body) == {
+        if response.status_code in (422, 429, 503, 507) and set(body) == {
             "protocol_version",
             "status",
             "job",
@@ -293,8 +328,9 @@ class RecorderClient:
         job: str,
         limits: dict[str, Any],
         body: dict[str, Any],
+        recording_allowed: bool = True,
     ) -> tuple[requests.Response, Any] | None:
-        token = self._command_token(operation, room, recording, job, limits)
+        token = self._command_token(operation, room, recording, job, limits, recording_allowed)
         try:
             response = self.session.request(
                 method,
@@ -323,7 +359,13 @@ class RecorderClient:
             return None
 
     def _command_token(
-        self, operation: str, room: str, recording: str, job: str, limits: dict[str, Any]
+        self,
+        operation: str,
+        room: str,
+        recording: str,
+        job: str,
+        limits: dict[str, Any],
+        recording_allowed: bool,
     ) -> str:
         now = int(time.time())
         payload = {
@@ -337,6 +379,7 @@ class RecorderClient:
             "job": job,
             "operation": operation,
             "limits": limits,
+            "policy": {"recording_allowed": recording_allowed},
             "jti": str(uuid.uuid4()),
             "iat": now,
             "exp": now + 30,

--- a/suite/meet/recording/test_protocol_contract.py
+++ b/suite/meet/recording/test_protocol_contract.py
@@ -167,25 +167,25 @@ class TestRecordingProtocolContract(TestCase):
         }
         for value in CONTRACT["vectors"]["command_responses"]["accepted"]:
             session.request.return_value = _response(202, value)
-            self.assertEqual(client.reserve(**arguments).outcome, "accepted")
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).outcome, "accepted")
         for value in CONTRACT["vectors"]["command_responses"]["rejected"]:
             session.request.return_value = _response(202, value)
-            self.assertEqual(client.reserve(**arguments).outcome, "indeterminate")
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).outcome, "indeterminate")
 
         base = CONTRACT["vectors"]["command_responses"]["accepted"][0]
         for state in CONTRACT["vectors"]["finite_values"]["command_states"]:
             session.request.return_value = _response(202, {**base, "state": state})
-            self.assertEqual(client.reserve(**arguments).state, state)
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).state, state)
         for reason_code in CONTRACT["vectors"]["finite_values"]["health_reason_codes"]:
             session.request.return_value = _response(202, {**base, "reason_code": reason_code})
-            self.assertEqual(client.reserve(**arguments).reason_code, reason_code)
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).reason_code, reason_code)
 
         for value in CONTRACT["vectors"]["command_rejected_responses"]["accepted"]:
             session.request.return_value = _response(value["http_status"], value["body"])
-            self.assertEqual(client.reserve(**arguments).outcome, "rejected")
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).outcome, "rejected")
         for value in CONTRACT["vectors"]["command_rejected_responses"]["rejected"]:
             session.request.return_value = _response(value["http_status"], value["body"])
-            self.assertEqual(client.reserve(**arguments).outcome, "indeterminate")
+            self.assertEqual(client.reserve(**arguments, recording_allowed=True).outcome, "indeterminate")
 
         for value in CONTRACT["vectors"]["grant_responses"]["accepted"]:
             session.request.return_value = _response(value["http_status"], value["body"])

--- a/suite/meet/recording/test_recorder_client.py
+++ b/suite/meet/recording/test_recorder_client.py
@@ -36,7 +36,12 @@ class TestRecorderClient(unittest.TestCase):
             allow_http=True,
             session=self.session,
         )
-        self.arguments = {"room": "room", "recording": "recording", "job": "job", "limits": {"x": 1}}
+        self.arguments = {
+            "room": "room",
+            "recording": "recording",
+            "job": "job",
+            "limits": {"x": 1},
+        }
 
     @patch("suite.meet.recording.recorder_client.time.time", return_value=100)
     def test_accepted_response_and_exact_command_claims(self, _time):
@@ -54,7 +59,7 @@ class TestRecorderClient(unittest.TestCase):
             },
         )
 
-        outcome = self.client.reserve(**self.arguments)
+        outcome = self.client.reserve(**self.arguments, recording_allowed=True)
 
         self.assertEqual(outcome.outcome, "accepted")
         self.assertEqual(outcome.accepted_at.isoformat(), "2026-07-31T10:11:12.123000+00:00")
@@ -81,6 +86,7 @@ class TestRecorderClient(unittest.TestCase):
                 "job",
                 "operation",
                 "limits",
+                "policy",
                 "jti",
                 "iat",
                 "exp",
@@ -88,6 +94,7 @@ class TestRecorderClient(unittest.TestCase):
             },
         )
         self.assertEqual(claims["protocol_version"], 1)
+        self.assertEqual(claims["policy"], {"recording_allowed": True})
         self.assertEqual(call.kwargs["json"], {"protocol_version": 1, "job": "job"})
         self.assertEqual(claims["operation"], "reserve")
         self.assertEqual(call.kwargs["timeout"], (2, 5))
@@ -97,19 +104,21 @@ class TestRecorderClient(unittest.TestCase):
         self.session.request.return_value = response(
             429, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "capacity"}
         )
-        self.assertEqual(self.client.reserve(**self.arguments).outcome, "rejected")
+        self.assertEqual(self.client.reserve(**self.arguments, recording_allowed=True).outcome, "rejected")
 
         self.session.request.return_value = response(
             507, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "storage"}
         )
-        outcome = self.client.reserve(**self.arguments)
+        outcome = self.client.reserve(**self.arguments, recording_allowed=True)
         self.assertEqual(outcome.outcome, "rejected")
         self.assertEqual(outcome.reason_code, "storage")
 
         self.session.request.return_value = response(
             429, {"protocol_version": 1, "status": "rejected", "job": "job", "reason_code": "anything"}
         )
-        self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+        self.assertEqual(
+            self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+        )
 
     def test_interrupted_response_preserves_unrecovered_timestamps(self):
         self.session.request.return_value = response(
@@ -156,7 +165,9 @@ class TestRecorderClient(unittest.TestCase):
         for generation in (-1, True, "0", None):
             with self.subTest(generation=generation):
                 self.session.request.return_value = response(202, {**body, "endpoint_generation": generation})
-                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+                self.assertEqual(
+                    self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+                )
 
     def test_timeout_invalid_json_wrong_job_and_5xx_are_indeterminate(self):
         cases = [
@@ -169,7 +180,9 @@ class TestRecorderClient(unittest.TestCase):
             with self.subTest(result=result):
                 self.session.request.side_effect = result if isinstance(result, Exception) else None
                 self.session.request.return_value = None if isinstance(result, Exception) else result
-                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+                self.assertEqual(
+                    self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+                )
 
     def test_rejects_missing_wrong_and_unknown_response_protocol_fields(self):
         accepted = {
@@ -189,7 +202,9 @@ class TestRecorderClient(unittest.TestCase):
         ):
             with self.subTest(body=body):
                 self.session.request.return_value = response(202, body)
-                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+                self.assertEqual(
+                    self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+                )
 
     def test_unhashable_state_and_reason_values_are_indeterminate(self):
         accepted = {
@@ -205,7 +220,9 @@ class TestRecorderClient(unittest.TestCase):
         for body in ({**accepted, "state": []}, {**accepted, "reason_code": {}}):
             with self.subTest(body=body):
                 self.session.request.return_value = response(202, body)
-                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+                self.assertEqual(
+                    self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+                )
 
     def test_timestamp_requires_exact_millisecond_precision(self):
         base = {
@@ -225,7 +242,9 @@ class TestRecorderClient(unittest.TestCase):
         ):
             with self.subTest(timestamp=timestamp):
                 self.session.request.return_value = response(202, {**base, "accepted_at": timestamp})
-                self.assertEqual(self.client.reserve(**self.arguments).outcome, "indeterminate")
+                self.assertEqual(
+                    self.client.reserve(**self.arguments, recording_allowed=True).outcome, "indeterminate"
+                )
 
     def test_rejects_untrusted_urls(self):
         for url in (


### PR DESCRIPTION
## Summary
- add a dedicated authenticated recorder deployment-health contract and endpoint
- keep advisory readiness separate from atomic, immediate reservation admission
- preserve typed policy, capacity, storage, readiness, recovery, and request outcomes across the recorder adapter