### PR TITLE
fix(meet): show meet avatar fallback in join/leave toasts

### DIFF
--- a/frontend/src/apps/meet/composables/useSFUConnection.ts
+++ b/frontend/src/apps/meet/composables/useSFUConnection.ts
@@ -25,6 +25,7 @@ import {
 } from "../utils/SFUClient";
 import { SFUMeetingManager } from "../utils/SFUMeetingManager";
 import { getClientTelemetry } from "../utils/telemetry/ClientTelemetry";
+import MeetAvatar from "../components/MeetAvatar.vue";
 import { useChatStore } from "./useChatStore";
 import {
 	clearGuestSession,
@@ -311,17 +312,12 @@ export function useSFUConnection(deps: {
 			participant.user_id,
 		);
 
-		const LucideUserIcon = defineAsyncComponent(
-			() => import("~icons/lucide/user"),
-		);
-
 		toast(`${participantName} joined the meeting`, {
-			icon: participant.avatar
-				? h("img", {
-						src: participant.avatar as string,
-						class: "h-5 w-5 rounded-full object-cover",
-					})
-				: h(LucideUserIcon),
+			icon: h(MeetAvatar, {
+				image: participant.avatar,
+				label: participant.user_name || participant.user_id,
+				size: "sm",
+			}),
 			duration: 3000,
 		});
 	};
@@ -340,17 +336,12 @@ export function useSFUConnection(deps: {
 			return;
 		}
 
-		const LucideUserIcon = defineAsyncComponent(
-			() => import("~icons/lucide/user"),
-		);
-
 		toast(`${participantName} left the meeting`, {
-			icon: participant?.avatar
-				? h("img", {
-						src: participant.avatar as string,
-						class: "h-4 w-4 rounded-full object-cover",
-					})
-				: h(LucideUserIcon),
+			icon: h(MeetAvatar, {
+				image: participant?.avatar,
+				label: participantName,
+				size: "xs",
+			}),
 			duration: 3000,
 		});
 	};


### PR DESCRIPTION
Show the Meet avatar (themed initials fallback) in the join/leave notification toasts instead of a generic user icon when a participant has no uploaded image.

The grid tiles, people panel, chat, waiting room, and shared-stage recorder already render a `MeetAvatar` fallback. The join/leave toasts were the remaining surface using `LucideUserIcon` when no avatar image was present.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.5% (+0%) · Frontend 35.0% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.5%** (21,163 / 37,444) (+0%) | **29.4%** (2,843 / 9,668) (+0%) |
| Frontend | **35.0%** (14,199 / 40,569) (+0%) | **29.6%** (9,174 / 31,042) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33502242904) for commit `95d641a`.</sub>

</details>
<!-- suite-coverage:end -->
