### PR TITLE
test(meet): remove low-value tests

### DIFF
--- a/suite/meet/api/test/test_callback_security.py
+++ b/suite/meet/api/test/test_callback_security.py
@@ -306,23 +306,6 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
             claims["jti"],
         )
 
-    def test_mutating_callbacks_are_post_only(self):
-        for callback in (
-            recorder_interrupted,
-            recorder_replacement_ready,
-            recorder_recovered,
-            recorder_segment_progress,
-            recorder_stopped,
-            recorder_upload_chunk,
-            recorder_complete_upload,
-            recorder_failed,
-        ):
-            with self.subTest(callback=callback.__name__):
-                self.assertEqual(
-                    frappe.allowed_http_methods_for_whitelisted_func[callback],
-                    ("POST",),
-                )
-
     def test_upload_endpoint_rejects_type_and_size_before_reading_body(self):
         digest = hashlib.sha256(b"chunk").hexdigest()
         with patch("suite.meet.api.recording.authenticate_callback"):

--- a/suite/meet/api/test/test_meeting.py
+++ b/suite/meet/api/test/test_meeting.py
@@ -50,11 +50,6 @@ class IntegrationTestMeetingApi(IntegrationTestCase):
 
         self.meeting = self._create_meeting(self.host_email, meeting_type="restricted")
 
-    def test_scheduling_mutations_are_post_only(self):
-        for method in (create_scheduled_meeting, create_meet_link):
-            with self.subTest(method=method.__name__):
-                self.assertEqual(set(frappe.allowed_http_methods_for_whitelisted_func[method]), {"POST"})
-
     def test_member_can_get_sfu_connection_details(self):
         self.meeting.add_user_to_table("members", self.member_email, save=True, ignore_permissions=True)
 

--- a/suite/meet/doctype/meet_recording/test_meet_recording.py
+++ b/suite/meet/doctype/meet_recording/test_meet_recording.py
@@ -7,11 +7,7 @@ import frappe
 from frappe.exceptions import ValidationError
 from frappe.tests import IntegrationTestCase
 
-from suite.meet.doctype.meet_recording.meet_recording import (
-    ALLOWED_TRANSITIONS,
-    get_permission_query_conditions,
-    has_permission,
-)
+from suite.meet.doctype.meet_recording.meet_recording import get_permission_query_conditions, has_permission
 
 
 class TestMeetRecording(IntegrationTestCase):
@@ -74,38 +70,6 @@ class TestMeetRecording(IntegrationTestCase):
         )
         with self.assertRaisesRegex(ValidationError, "must match"):
             recording.insert(ignore_links=True)
-
-    def test_recording_state_transition_matrix(self):
-        room = frappe.get_doc({"doctype": "Meet Room", "meeting_type": "open"}).insert()
-        statuses = (
-            "Pending",
-            "Starting",
-            "Recording",
-            "Interrupted",
-            "Stopping",
-            "Processing",
-            "Ready",
-            "Partial",
-            "Failed",
-            "Cancelled",
-        )
-
-        for source in statuses:
-            for target in statuses:
-                if source == target:
-                    continue
-                with self.subTest(source=source, target=target):
-                    recording = self._recording_in_status(room, source)
-                    self._prepare_target(recording, target)
-                    allowed = target in ALLOWED_TRANSITIONS.get(source, set())
-                    if allowed:
-                        recording.save(ignore_permissions=True)
-                        self.assertEqual(recording.status, target)
-                    else:
-                        with self.assertRaisesRegex(
-                            ValidationError, "Invalid recording state transition|terminal recording"
-                        ):
-                            recording.save(ignore_permissions=True)
 
     def test_terminal_recording_cannot_be_modified(self):
         room = frappe.get_doc({"doctype": "Meet Room", "meeting_type": "open"}).insert()

--- a/suite/meet/doctype/meet_room/test_meet_room.py
+++ b/suite/meet/doctype/meet_room/test_meet_room.py
@@ -79,24 +79,6 @@ class IntegrationTestMeetRoom(IntegrationTestCase):
         room.reload()
         self.assertEqual(room.get_waiting_room(), [user])
 
-    def test_room_api_methods_are_post_only(self):
-        room = frappe.get_doc({"doctype": "Meet Room", "meeting_type": "open"}).insert()
-
-        for method_name in (
-            "approve_join_request",
-            "approve_all_join_requests",
-            "reject_join_request",
-            "get_waiting_room_details",
-            "ban_guest",
-            "promote_to_cohost",
-            "enable_e2ee",
-            "update_settings",
-        ):
-            with self.subTest(method=method_name):
-                method = getattr(room, method_name)
-                fn = getattr(method, "__func__", method)
-                self.assertEqual(set(frappe.allowed_http_methods_for_whitelisted_func[fn]), {"POST"})
-
     def test_every_access_field_rejects_generic_document_updates(self):
         user = self._ensure_user("room-protected@example.com", "Room Protected")
         mutations = {
@@ -162,11 +144,3 @@ class TestMeetRoomAPI(FrappeAPITestCase):
         returned_room = response.json["docs"][0]
         self.assertEqual(returned_room["waiting_room"], [])
         self.assertIn("guest:test", [row["user"] for row in returned_room["members"]])
-
-    def test_removed_module_method_is_not_routable(self):
-        response = self.post(
-            self.method("suite.meet.api.meeting.get_meeting_e2ee_details"),
-            {"sid": self.sid, "meeting_id": "missing"},
-        )
-
-        self.assertNotEqual(response.status_code, 200)

--- a/suite/meet/recording/test_protocol_contract.py
+++ b/suite/meet/recording/test_protocol_contract.py
@@ -201,16 +201,6 @@ class TestRecordingProtocolContract(TestCase):
             session.request.return_value = _response(value["http_status"], value["body"])
             self.assertFalse(client.stop(**arguments, operation_id="stop-vector"))
 
-    def test_startup_mapping_covers_every_recorder_milestone(self):
-        mapping = CONTRACT["mappings"]["startup_milestone_to_frappe_state"]
-        self.assertEqual(set(mapping), set(CONTRACT["vocabularies"]["startup_milestones"]))
-        self.assertEqual(set(mapping.values()), {"Starting", "Recording"})
-
-    def test_first_version_accepts_no_unversioned_predecessor(self):
-        self.assertEqual(CONTRACT["protocol_version"], 1)
-        self.assertEqual(CONTRACT["accepted_protocol_versions"], [1])
-        self.assertEqual(CONTRACT["vectors"]["protocol_versions"]["accepted"], [1])
-
     def test_shared_finalization_requests_use_the_production_parser(self):
         vectors = FINALIZATION_CONTRACT["vectors"]["status_requests"]
         for value in vectors["accepted"]:


### PR DESCRIPTION
## Summary

Remove seven Meet tests that inspect framework metadata, assert fixture self-consistency, preserve removed-route history, or derive expectations from production implementation details.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.5% (-0.1%) · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.5%** (21,169 / 37,469) (-0.1%) | **29.3%** (2,829 / 9,658) (-0.2%) |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33590910517) for commit `e7f6f11`.</sub>

</details>
<!-- suite-coverage:end -->
