### PR TITLE
fix(mail, calendar): actions that stopped at a removed toast call

### DIFF
--- a/frontend/src/apps/calendar/utils/index.ts
+++ b/frontend/src/apps/calendar/utils/index.ts
@@ -19,16 +19,21 @@ export const raisePromiseToast = (
 	success: string,
 	undoAction?: () => void,
 ) => {
-	toast.removeAll()
+	toast.dismiss()
 
 	const error = __('Action failed. Please try again later.')
 
 	if (undoAction)
 		return toast.promise(action(), {
 			loading,
-			success,
+			// The button rides on the success slot itself. `successAction` was a frappe-ui 0.1.x
+			// extension to toast.promise, dropped in v1 — sonner has no such key, so it went
+			// nowhere and the toast came up without its Undo.
+			success: {
+				message: success,
+				action: { label: __('Undo'), onClick: () => undoAction() },
+			},
 			error,
-			successAction: { label: __('Undo'), onClick: () => undoAction() },
 		})
 
 	toast.promise(action(), { loading, success, error })

--- a/frontend/src/apps/mail/utils/composables.ts
+++ b/frontend/src/apps/mail/utils/composables.ts
@@ -318,9 +318,9 @@ export const useUndo = () => {
 		outlivingAction = outlivesView ? action : undefined
 		// Clearing the undo with no replacement toast (e.g. leaving the mailbox) leaves a lingering toast
 		// whose "Undo" button is now dead — dismiss toasts. When a new action is set instead, the toast it
-		// raises right after (via raiseOptimisticToast/raisePromiseToast) does the removeAll, and doing it
+		// raises right after (via raiseOptimisticToast/raisePromiseToast) does the dismiss, and doing it
 		// here too would dismiss the reconcile paths' in-flight loading toast — so only clear on undefined.
-		if (!action) toast.removeAll()
+		if (!action) toast.dismiss()
 	}
 
 	// What a view does on the way out: its own undo goes, toast and all, so nothing can undo into a

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -92,7 +92,7 @@ export const raisePromiseToast = (
 	success: string,
 	undoAction?: () => void,
 ) => {
-	toast.removeAll()
+	toast.dismiss()
 
 	const error = __('Action failed. Please try again later.')
 
@@ -117,7 +117,7 @@ export const raiseOptimisticToast = (
 	success: string,
 	undoAction?: () => void,
 ) => {
-	toast.removeAll()
+	toast.dismiss()
 	const id = toast.success(
 		success,
 		undoAction ? { action: { label: __('Undo'), onClick: () => undoAction() } } : undefined,

--- a/frontend/src/test/toastApi.test.ts
+++ b/frontend/src/test/toastApi.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+// Reaches past the alias on purpose: every other test resolves `frappe-ui` to the stub in
+// recorder/frappeUi.ts, which carries no toast at all.
+import { toast } from '../../../node_modules/frappe-ui/src/components/Toast/toast'
+
+/**
+ * The toast surface mail's and calendar's helpers depend on.
+ *
+ * They reach into frappe-ui's toast namespace by name, and a bump that drops one of those names
+ * — 695aa923e dropped `create`, `remove` and `removeAll` — says nothing at build time: the
+ * frontend has no typecheck in CI, and under test the namespace is a stub. It surfaces as a
+ * TypeError at the worst possible moment, because `setUndoAction` and `raiseOptimisticToast`
+ * clear the toasts BEFORE the request goes out — the row leaves the list, the server is never
+ * told, and the mail is back on the next reload.
+ */
+const METHODS_CALLED = ['success', 'error', 'promise', 'dismiss'] as const
+
+describe('frappe-ui toast', () => {
+	it('still has every method the toast helpers call', () => {
+		for (const method of METHODS_CALLED)
+			expect(typeof (toast as unknown as Record<string, unknown>)[method]).toBe('function')
+	})
+})


### PR DESCRIPTION
`toast.removeAll` is gone. The frappe-ui bump on develop brought in [695aa923e](https://github.com/frappe/frappe-ui/commit/695aa923e) ("refactor(Toast)!: remove the compat shims"), where it is now `undefined` — frappe-ui's own tests assert that. We still call it in four places, and in three of them it is the first statement, before the request goes out:

- `mail/utils/composables.ts` — `setUndoAction`
- `mail/utils/index.ts` — `raiseOptimisticToast`, `raisePromiseToast`
- `calendar/utils/index.ts` — `raisePromiseToast`

So the TypeError aborted the handler after the optimistic UI removal and before the fetch. Deleting a mail, moving it, marking it junk: the row left the list, the server never heard about it, and it came back on the next reload. No toast was raised either, so there was no undo to reach for.

`toast.dismiss()` is sonner's own, and dismisses all when called bare.

While in there: calendar's `raisePromiseToast` passed `successAction` to `toast.promise`, a frappe-ui 0.1.x key dropped in May (bd653c1c9). Sonner has no such thing, so it went nowhere and those toasts came up without their Undo. Moved to the `success: { message, action }` shape mail's copy already uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPDdovnpyUjuV1PEWXBHbL