### PR TITLE
fix(mail): triage that reaches the end of a list keeps going

### DIFF
--- a/frontend/src/apps/mail/composables/useListRows.ts
+++ b/frontend/src/apps/mail/composables/useListRows.ts
@@ -21,9 +21,17 @@ export interface ListRowsOptions {
 	threads: () => Thread[]
 	/** A thread row's key. The all-accounts views prefix it with the account. */
 	rowKey: (thread: Thread) => string
+	/**
+	 * A thread's identity, for every lookup below: which row stands for the open thread, which
+	 * stack is expanded, which threads a date group holds. The thread id by default, and NOT the
+	 * row key — the mailbox list keys its rows by mail name, while `openThreadID` names a thread.
+	 * The merged All Inboxes list qualifies it with the account, since one thread id can name a
+	 * thread in each of two accounts.
+	 */
+	threadKey?: (thread: Thread) => string
 	/** Whether runs of look-alike threads collapse into stack rows. On everywhere by default. */
 	stackingEnabled?: () => boolean
-	/** The open thread, if any — folding a row that hides it has to move the reading pane. */
+	/** The open thread's key, if any — folding a row that hides it has to move the reading pane. */
 	openThreadID: () => string | undefined
 	/** Called when a fold is about to hide the open thread: leave the pane. */
 	onOpenThreadHidden: () => void
@@ -49,6 +57,7 @@ export interface ListRowsOptions {
 export const useListRows = ({
 	threads,
 	rowKey,
+	threadKey = (thread: Thread) => thread.thread_id,
 	stackingEnabled = () => true,
 	openThreadID,
 	onOpenThreadHidden,
@@ -77,7 +86,7 @@ export const useListRows = ({
 		}, {}),
 	)
 
-	const getGroupThreads = (group: string) => groupedThreads.value[group]?.map((t) => t.thread_id)
+	const getGroupThreads = (group: string) => groupedThreads.value[group]?.map(threadKey)
 
 	// The last group never collapses — it's where infinite scroll appends, so hiding it would swallow
 	// newly loaded rows.
@@ -93,13 +102,13 @@ export const useListRows = ({
 	// notification sender can't bury the rest of the list. This is a display layer over groupedThreads:
 	// runs are detected within a date group and never span one.
 
-	// The thread_ids of every member of every expanded stack. In-memory only — stacks re-collapse on a
-	// mailbox switch. Keyed by member id rather than by stack key so a run keeps its expanded state as
+	// The keys of every member of every expanded stack. In-memory only — stacks re-collapse on a
+	// mailbox switch. Keyed by member rather than by stack key so a run keeps its expanded state as
 	// it grows in either direction (appended by infinite scroll, prepended by a refresh), and so
 	// routing to a thread can expand its stack without having to locate the run first.
 	const expandedStacks = ref(new Set<string>())
 
-	const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(t.thread_id))
+	const isRunExpanded = (run: Thread[]) => run.some((t) => expandedStacks.value.has(threadKey(t)))
 
 	const groupedRows = computed<Record<string, ListRow[]>>(() =>
 		Object.fromEntries(
@@ -191,25 +200,25 @@ export const useListRows = ({
 	 * hides it, or — when its whole day is folded away — that day's header. Callers name a thread ("go
 	 * to the first mail", "open the thread that just loaded"); this is how that lands somewhere visible.
 	 */
-	const rowForThread = (threadID?: string): NavRow | undefined => {
-		if (!threadID) return
+	const rowForThread = (key?: string): NavRow | undefined => {
+		if (!key) return
 
 		const row = navigableRows.value.find(
 			(row) =>
-				(row.type === 'thread' && row.thread.thread_id === threadID) ||
+				(row.type === 'thread' && threadKey(row.thread) === key) ||
 				// Only a collapsed stack stands in for its members. An expanded one precedes its member
 				// rows, so without this guard every member would resolve to the stack row above it.
 				(row.type === 'stack' &&
 					!row.expanded &&
-					row.threads.some((t) => t.thread_id === threadID)),
+					row.threads.some((t) => threadKey(t) === key)),
 		)
 		if (row) return row
 
-		const dateKey = collapsedGroups.value.find((key) => getGroupThreads(key)?.includes(threadID))
+		const dateKey = collapsedGroups.value.find((group) => getGroupThreads(group)?.includes(key))
 		return navigableRows.value.find((row) => row.key === `group:${dateKey}`)
 	}
 
-	const focusOnThread = (threadID?: string) => focusRow(rowForThread(threadID))
+	const focusOnThread = (key?: string) => focusRow(rowForThread(key))
 
 	/**
 	 * What a rendered row looks like in its list, as opposed to in itself: the cursor's left marker,
@@ -223,14 +232,14 @@ export const useListRows = ({
 		'border-l-transparent sm:border-l': true,
 		'!border-l-outline-blue-5': row.key === focusedRowKey.value,
 		'!bg-surface-blue-1':
-			row.type === 'thread' && row.thread.thread_id === openThreadID() && !isMobile.value,
+			row.type === 'thread' && threadKey(row.thread) === openThreadID() && !isMobile.value,
 		'!pl-10 sm:!pl-12': row.type === 'thread' && !!row.inStack,
 	})
 
 	// ── Folding ─────────────────────────────────────────────────────────────────────────────────────
 
 	const toggleStack = (row: StackRow) => {
-		const ids = row.threads.map((t) => t.thread_id)
+		const ids = row.threads.map(threadKey)
 		// The cursor follows the click, as it does when you open a mail. This also covers the fold: the
 		// members are about to be hidden, so the stack row that now stands for them is where the cursor
 		// belongs, and Enter-fold-Enter-unfold stays a round trip rather than a way to lose your place.
@@ -271,13 +280,13 @@ export const useListRows = ({
 	 * The focus is deferred a tick because the row may only just have been revealed by the two lines
 	 * above it, and because callers run this from a watcher whose immediate run fires mid-setup.
 	 */
-	const revealThread = (threadID: string) => {
-		expandedStacks.value.add(threadID)
+	const revealThread = (key: string) => {
+		expandedStacks.value.add(key)
 
-		setTimeout(() => focusOnThread(threadID))
+		setTimeout(() => focusOnThread(key))
 
 		for (const group of collapsedGroups.value) {
-			if (getGroupThreads(group)?.includes(threadID))
+			if (getGroupThreads(group)?.includes(key))
 				return (collapsedGroups.value = collapsedGroups.value.filter((d) => d !== group))
 		}
 	}

--- a/frontend/src/apps/mail/composables/usePaginatedThreads.ts
+++ b/frontend/src/apps/mail/composables/usePaginatedThreads.ts
@@ -134,8 +134,14 @@ export const usePaginatedThreads = ({
 
 	const list = () => resource().data ?? []
 
-	/** The loaded threads' ids, in list order — what the reading pane pages through. */
-	const threadIDs = computed(() => list().map((thread: Thread) => thread.thread_id))
+	/**
+	 * The loaded threads' ids, in list order — what the reading pane pages through.
+	 *
+	 * In `threadKey` space, which is the thread id itself for a single-account list and the
+	 * account-qualified key for a merged one: two accounts can hold the same thread id, and paging
+	 * that walks bare ids there lands on whichever duplicate comes first.
+	 */
+	const threadIDs = computed(() => list().map(threadKey))
 
 	/** Whether any fetch is in flight. Gates the Refresh affordance and a new refresh. */
 	const isFetching = computed(() => resource().loading || loadingMore.value)

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -185,6 +185,7 @@ import {
 	hasCursor,
 	isNavigationKey,
 	navigationOffset,
+	neighbourAfterRemoval,
 	stepFromKey,
 	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
@@ -874,7 +875,8 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = rowM
 const goToNextThreadOrClose = (movedThreadID: string) => {
 	if (threadID !== movedThreadID) return
 	const ids = threadIDs.value
-	const next = ids.slice(ids.indexOf(movedThreadID) + 1).find((id) => id !== movedThreadID)
+	// Below first, then above — the same turn-around the mailbox makes at the end of the list.
+	const next = neighbourAfterRemoval(ids, ids.indexOf(movedThreadID), (id) => id !== movedThreadID)
 	if (next) openThread(next)
 	else closeThread()
 }

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -125,7 +125,7 @@
 					:account="openRow?.account"
 					:mailbox="openRow?.inbox || ''"
 					:thread-i-d="threadID"
-					:threads="threadIDs"
+					:threads="headerThreadIDs"
 					:can-go-next="canGoNext"
 					:messages="openRow?.messages"
 					@reload-mails="reloadPaneThread()"
@@ -216,13 +216,14 @@ import type { Mail, Mailbox, MailboxData, Thread, UserResource } from '@/apps/ma
 const { isMobile } = useScreenSize()
 const { listReloadRequest } = useListReload()
 
-// The `mail-all-inboxes-mail` route also carries the open thread's owning accountId and mailbox, but
-// nothing here reads them: every row already carries its own account and folder ids, which is what the
-// pane and its actions target. They fall through as plain attributes, which this component (a fragment)
-// cannot inherit — so it inherits nothing.
+// The `mail-all-inboxes-mail` route carries the open thread's owning accountId and mailbox. The
+// mailbox falls through as a plain attribute — every row carries its own folder ids, which is what
+// the pane and its actions target — and this component (a fragment) cannot inherit attributes, so it
+// inherits nothing. accountId is read: it is half of the open thread's identity here (see openKey).
 defineOptions({ inheritAttrs: false })
 
-const { threadID } = defineProps<{
+const { accountId, threadID } = defineProps<{
+	accountId?: string
 	threadID?: string
 }>()
 
@@ -238,6 +239,16 @@ const store = userStore()
 // around it — the epochs, the refresh merge, the sentinel, the edge crossing. Rows are keyed by
 // account + thread_id since the same thread_id can recur across accounts in this merged view.
 const threadKey = (thread: Thread) => `${thread.account}:${thread.thread_id}`
+
+/**
+ * The open thread's key, from the two route params that name it.
+ *
+ * A thread id is only unique within its account — they are short per-account counters, so two
+ * inboxes of similar size hold the same ones — and this list spans accounts. Everything that
+ * resolves or steps through threads works in key space for that reason: the row the pane is
+ * showing, the cursor, the prev/next step, and the row a verdict moves on from.
+ */
+const openKey = computed(() => (accountId && threadID ? `${accountId}:${threadID}` : undefined))
 
 const {
 	container: mailListRef,
@@ -259,10 +270,10 @@ const {
 } = usePaginatedThreads({
 	resource: () => threads,
 	fetchMore: () => loadMoreThreads.reload(),
-	openThreadID: () => threadID,
+	openThreadID: () => openKey.value,
 	// A step off the loaded edge opens the appended thread when the pane is showing, and otherwise
 	// just takes the cursor to it — onto whatever row stands for it (see rowForThread).
-	onEdgeThread: (id, action) => (action === 'open' ? openThread(id) : focusOnThread(id)),
+	onEdgeThread: (key, action) => (action === 'open' ? openThread(key) : focusOnThread(key)),
 	threadKey,
 	// Deferred read — visibleThreadCount is declared below, with the rows it counts.
 	fillProgress: () => visibleThreadCount.value,
@@ -381,17 +392,26 @@ const {
 	revealThread,
 } = useListRows({
 	threads: () => threads.data ?? [],
-	// A thread's row key is its id, so the cursor can be pointed straight at a thread.
-	rowKey: (thread: Thread) => thread.thread_id,
-	openThreadID: () => threadID,
+	// Account-qualified, both of them: the cursor can be pointed straight at a thread, and it lands
+	// on the right account's row when two of them share a thread id.
+	rowKey: threadKey,
+	threadKey,
+	openThreadID: () => openKey.value,
 	onOpenThreadHidden: () => closeThread(),
 	container: mailListRef,
 })
 
+// ThreadHeader's prev/next arrows compare their list against the route's plain thread id, so they
+// get plain ids. Key space is for stepping and resolution — where landing on the wrong account's
+// duplicate actually shows the wrong mail; here it would only mis-grey an arrow.
+const headerThreadIDs = computed(() => (threads.data ?? []).map((t: Thread) => t.thread_id))
+
 // The loaded row the open thread belongs to. Every mutation reads its account/archive/trash
 // off the row, so the pane acts on the owning account without consulting the active one.
 const openRow = computed(() =>
-	threadID ? (threads.data ?? []).find((t: Thread) => t.thread_id === threadID) : undefined,
+	openKey.value
+		? (threads.data ?? []).find((t: Thread) => threadKey(t) === openKey.value)
+		: undefined,
 )
 
 // MailThread's slide name while a swipe navigation renders; cleared on its slide-done, and left
@@ -430,8 +450,8 @@ const gPrefix = useGPrefix()
 // itself, so a shortcut in the merged list targets the owning account like a click does.
 // Returns true when it consumed the key.
 const actionTarget = computed(() => {
-	const key = threadID ?? focusedRowKey.value
-	return (threads.data ?? []).find((t: Thread) => t.thread_id === key)
+	const key = openKey.value ?? focusedRowKey.value
+	return (threads.data ?? []).find((t: Thread) => threadKey(t) === key)
 })
 
 const handleThreadActions = (e: KeyboardEvent, key: string) => {
@@ -523,7 +543,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
 const activateFocusedRow = () => {
 	const row = focusedRow.value
 	if (!row) return
-	if (row.type === 'thread') return openThread(row.thread.thread_id)
+	if (row.type === 'thread') return openThread(threadKey(row.thread))
 	if (row.type === 'stack') return toggleStack(row)
 	if (!isLastGroup(row.dateKey)) toggleGroupCollapse(row.dateKey)
 }
@@ -531,8 +551,8 @@ const activateFocusedRow = () => {
 // The open thread keeps its row in view, as the mailbox list does: stepping prev/next or deep-linking
 // scrolls the merged list along, and the cursor follows so keyboard navigation resumes from it.
 watch(
-	() => threadID,
-	(val) => val && revealThread(val),
+	openKey,
+	(key) => key && revealThread(key),
 	{ immediate: true },
 )
 
@@ -546,13 +566,15 @@ const goToEdge = (index: number) => {
 	focusRow(navigableRows.value.at(index))
 }
 
-const openThread = (nextThreadID: string) => {
+const openThread = (key: string) => {
 	threadSlide.value = pendingThreadSlide
-	const row = (threads.data ?? []).find((t: Thread) => t.thread_id === nextThreadID)
+	const row = (threads.data ?? []).find((t: Thread) => threadKey(t) === key)
 	if (!row) return
 	router.push({
 		name: 'mail-all-inboxes-mail',
-		params: { accountId: row.account, mailbox: row.inbox, threadID: nextThreadID },
+		// The row's own ids, which is what the key was made of — and what the pane, its actions and
+		// the URL all need in their plain form.
+		params: { accountId: row.account, mailbox: row.inbox, threadID: row.thread_id },
 		query: route.query,
 	})
 }
@@ -563,7 +585,7 @@ const moveOpenThread = (mailboxId: string) => {
 	if (!row) return
 	if (mailboxId === row.archive) return handleArchive(row)
 	if (mailboxId === row.trash) return handleTrash(row)
-	goToNextThreadOrClose(row.thread_id)
+	goToNextThreadOrClose(threadKey(row))
 	const restore = removeFromList(row)
 	const folder = folderName(mailboxId)
 	raiseOptimisticToast(
@@ -736,7 +758,7 @@ const handleRemoveFromMailbox = (mailboxId: string) => {
 const handleSetSpamStatus = (spam: boolean, target?: Thread) => {
 	const thread = target ?? openRow.value
 	if (!thread) return
-	goToNextThreadOrClose(thread.thread_id)
+	goToNextThreadOrClose(threadKey(thread))
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		paneCall('set_mails_spam_status', { ids: messageIdsOf(thread), spam }, thread.account).catch(
@@ -814,7 +836,7 @@ const handleSetSeen = (thread: Thread, seen: boolean, silent = false) => {
 
 	// Marking the open thread unread means "come back to this later", so leave the pane — staying
 	// in it would just mark it read again. Same exit as useThreadActions does for the mailbox list.
-	if (!seen && threadID === thread.thread_id) closeThread()
+	if (!seen && openKey.value === threadKey(thread)) closeThread()
 	const applySeen = (value: 0 | 1) => {
 		thread.seen = value
 		thread.messages?.forEach((m) => (m.seen = value))
@@ -849,7 +871,7 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = rowM
 		if (rowChanged) thread.flagged = value
 	}
 	const applyPane = (value: boolean) => {
-		if (threadID === thread.thread_id) mailThread.value?.syncFlagged(ids, value)
+		if (openKey.value === threadKey(thread)) mailThread.value?.syncFlagged(ids, value)
 	}
 
 	applyRow(flagged ? 1 : 0)
@@ -872,11 +894,11 @@ const handleSetFlagged = (thread: Thread, flagged: boolean, ids: string[] = rowM
 // Acting on the open thread from the pane should leave you on the next one, not on a thread that
 // is no longer in the list. Resolved before the row is removed, so the index is still meaningful;
 // falls back to closing the pane at the end of the list. Mirrors MailboxView.
-const goToNextThreadOrClose = (movedThreadID: string) => {
-	if (threadID !== movedThreadID) return
-	const ids = threadIDs.value
+const goToNextThreadOrClose = (movedKey: string) => {
+	if (openKey.value !== movedKey) return
+	const keys = threadIDs.value
 	// Below first, then above — the same turn-around the mailbox makes at the end of the list.
-	const next = neighbourAfterRemoval(ids, ids.indexOf(movedThreadID), (id) => id !== movedThreadID)
+	const next = neighbourAfterRemoval(keys, keys.indexOf(movedKey), (key) => key !== movedKey)
 	if (next) openThread(next)
 	else closeThread()
 }
@@ -922,7 +944,7 @@ const moveThreadOut = (thread: Thread, mailbox: string, restore: () => void) => 
 
 const handleArchive = (thread: Thread) => {
 	if (!thread.archive) return raiseToast(__('No Archive folder for this account.'), 'error')
-	goToNextThreadOrClose(thread.thread_id)
+	goToNextThreadOrClose(threadKey(thread))
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.archive!, restore),
@@ -933,7 +955,7 @@ const handleArchive = (thread: Thread) => {
 
 const handleTrash = (thread: Thread) => {
 	if (!thread.trash) return raiseToast(__('No Trash folder for this account.'), 'error')
-	goToNextThreadOrClose(thread.thread_id)
+	goToNextThreadOrClose(threadKey(thread))
 	const restore = removeFromList(thread)
 	raiseOptimisticToast(
 		moveThreadOut(thread, thread.trash!, restore),

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -497,6 +497,7 @@ import {
 	hasCursor,
 	isNavigationKey,
 	navigationOffset,
+	neighbourAfterRemoval,
 	stepFromKey,
 	useGPrefix,
 } from '@/apps/mail/utils/listNavigation'
@@ -1391,9 +1392,14 @@ const {
 const threadSlide = ref('')
 let pendingThreadSlide = ''
 
+// Down the list first, then up: triaging from the oldest mail lives at the bottom, where there is
+// never anything below (see neighbourAfterRemoval). Only an emptied list falls back to the mailbox.
 const goToNextThreadOrMailbox = (excludedThreads: string[] = []) => {
-	const idx = threadIDs.value.indexOf(threadID)
-	const next = threadIDs.value.slice(idx + 1).find((id) => !excludedThreads.includes(id))
+	const next = neighbourAfterRemoval(
+		threadIDs.value,
+		threadIDs.value.indexOf(threadID),
+		(id) => !excludedThreads.includes(id),
+	)
 	if (next) goToThread(next)
 	else goToMailbox()
 }

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -451,7 +451,11 @@ import {
 } from 'frappe-ui'
 
 import { raiseToast, shouldIgnoreKeypress } from '@/apps/mail/utils'
-import { isNavigationKey, navigationOffset } from '@/apps/mail/utils/listNavigation'
+import {
+	isNavigationKey,
+	navigationOffset,
+	neighbourAfterRemoval,
+} from '@/apps/mail/utils/listNavigation'
 import {
 	useListReload,
 	useReadingPane,
@@ -912,8 +916,10 @@ const runAction = (
 ) => {
 	if (!fromEmails.length) return
 
-	// When acting on the sender open in the detail view, line up the next one down so you can triage
-	// straight through — resolved before the optimistic removal.
+	// When acting on the sender open in the detail view, line up the next one so you can triage
+	// straight through — the one below, or the one above at the end of the queue, since a pass that
+	// starts at the oldest sender spends all of itself there (see neighbourAfterRemoval). Resolved
+	// before the optimistic removal.
 	const list = senders.data ?? []
 	const actingOnOpen = !!openSender.value && matchSender(openSender.value)
 	let nextSender: ScreeningSender | undefined
@@ -921,7 +927,11 @@ const runAction = (
 		const idx = list.findIndex(
 			(s: ScreeningSender) => s.from_email === openSender.value!.from_email,
 		)
-		nextSender = list.slice(idx + 1).find((s: ScreeningSender) => !matchSender(s))
+		nextSender = neighbourAfterRemoval(
+			list as ScreeningSender[],
+			idx,
+			(s: ScreeningSender) => !matchSender(s),
+		)
 	}
 
 	// Optimistically drop the acted senders so the rows leave immediately and every other row stays

--- a/frontend/src/apps/mail/utils/listNavigation.test.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { neighbourAfterRemoval } from './listNavigation'
+
+const rows = ['a', 'b', 'c', 'd']
+const leaving =
+	(...gone: string[]) =>
+	(id: string) =>
+		!gone.includes(id)
+
+describe('neighbourAfterRemoval', () => {
+	it('takes the next one down', () => {
+		expect(neighbourAfterRemoval(rows, 1, leaving('b'))).toBe('c')
+	})
+
+	it('turns around at the end of the list', () => {
+		// The bottom-up triage pass: every verdict is on the last row, and there is never
+		// anything below it to advance to.
+		expect(neighbourAfterRemoval(rows, 3, leaving('d'))).toBe('c')
+	})
+
+	it('skips the others leaving in the same action, in both directions', () => {
+		expect(neighbourAfterRemoval(rows, 1, leaving('b', 'c'))).toBe('d')
+		expect(neighbourAfterRemoval(rows, 3, leaving('c', 'd'))).toBe('b')
+	})
+
+	it('has nothing to hand back when the whole list is going', () => {
+		expect(neighbourAfterRemoval(rows, 2, leaving(...rows))).toBeUndefined()
+		expect(neighbourAfterRemoval([], 0, leaving())).toBeUndefined()
+	})
+
+	it('searches the whole list forwards when the item is no longer in it', () => {
+		expect(neighbourAfterRemoval(rows, -1, leaving())).toBe('a')
+	})
+})

--- a/frontend/src/apps/mail/utils/listNavigation.ts
+++ b/frontend/src/apps/mail/utils/listNavigation.ts
@@ -39,6 +39,30 @@ export const hasCursor = <T extends { key: string }>(rows: T[], currentKey: stri
 	rows.some((row) => row.key === currentKey)
 
 /**
+ * What to open once the item at `index` leaves the list: the nearest survivor below it, and
+ * failing that the nearest above.
+ *
+ * Downwards alone is the obvious reading of "the next one", and it is right for a pass that
+ * starts at the top. It runs out at the bottom — which is where a pass that starts at the
+ * oldest mail spends its whole time, so every verdict there closed the pane and asked for the
+ * list to be re-aimed at. Turning around instead keeps a bottom-up run going the same way a
+ * top-down one already ran.
+ *
+ * `survives` excludes the items leaving in the same action (the one acted on included), so a
+ * bulk verdict doesn't hand back a row that is about to go. An `index` of -1 — the open item
+ * is no longer in the list — searches the whole list forwards, as it did before.
+ */
+export const neighbourAfterRemoval = <T>(
+	items: T[],
+	index: number,
+	survives: (item: T) => boolean,
+): T | undefined => {
+	for (let i = index + 1; i < items.length; i++) if (survives(items[i])) return items[i]
+	for (let i = Math.min(index, items.length) - 1; i >= 0; i--) if (survives(items[i])) return items[i]
+	return undefined
+}
+
+/**
  * The `g` prefix: `g g` jumps to the first entry, `G` to the last. A lone `g` arms for
  * this long, then forgets — so `g`, pause, `g` is two separate presses, not a jump.
  */


### PR DESCRIPTION
Two things, the second found by review of the first.

## The end of the list

Acting on the last thread in a list — or the last sender in the screener — closed the reading pane and dropped you back on the list.

"The next one" only ever looked downward. That is right for a pass that starts at the top, and wrong for one that starts at the oldest mail: that pass spends all of itself at the bottom of the list, where there is never anything below, so every single verdict ended in a deselect.

Now: nearest survivor below, and failing that the nearest above. Only an emptied list closes. `survives` keeps out whatever is leaving in the same action, so a bulk verdict can't hand back a row that is about to go.

One rule in `listNavigation.ts`, since all three lists want it — the screener (`runAction`), the mailbox (`goToNextThreadOrMailbox`) and the merged All Inboxes (`goToNextThreadOrClose`).

## A thread id doesn't name a thread in All Inboxes

Greptile flagged the fallback above for passing an unqualified thread id into first-match resolution. The fallback wasn't the problem — the view was, everywhere.

A thread id is unique within its account and nowhere else. They're short per-account counters (`ih` holds `jn0`, `jpk`, `jq1`; `q9` holds `1`, `b`, `c`, `j`), so two inboxes of similar size hold the same ones, and this list spans accounts. `usePaginatedThreads` already knew that — the merge, the dedup and the removal suppression all work in `threadKey` space. Resolution and navigation didn't, and asked the loaded list for `thread_id === id`. First match wins, so with a duplicate loaded the pane could open the other account's thread, the cursor could land on its row, and prev/next could step onto it.

The open thread's account was in the route the whole time (`mail-all-inboxes-mail` carries `accountId`); the view just never read it. It does now, and everything that resolves or steps through threads works in key space: `openRow`, the keyboard's action target, the prev/next step, the reveal, the unread exit and the flag sync.

`useListRows` gets its own `threadKey`, deliberately **not** its `rowKey`: the mailbox list keys rows by mail name while `openThreadID` names a thread, so folding the two together would have quietly broken the open-row highlight, the reveal and stack expansion there. It defaults to the thread id, leaving the mailbox list and the screener untouched.

ThreadHeader's prev/next arrows keep the plain ids — they compare against the route's own thread id, and the worst a duplicate does there is grey an arrow that should be live.

## Testing

`listNavigation.test.ts` covers next-below, the turn-around at the end, skipping co-removed items in both directions, nothing-survives, and the item no longer being in the list. Full mail suite green (261), production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPDdovnpyUjuV1PEWXBHbL