### PR TITLE
refactor(router): register app routes statically

### DIFF
--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, inject, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import {
 	Bell,
 	Briefcase,
@@ -30,6 +31,7 @@ import EventParticipantList from '@/apps/calendar/components/EventParticipantLis
 import LinkifiedText from '@/components/LinkifiedText.vue'
 
 const { calendarEvent } = defineProps<{ calendarEvent: any }>()
+const router = useRouter()
 
 const emit = defineEmits(['close', 'edit', 'reloadEvents', 'emailParticipants'])
 
@@ -256,7 +258,7 @@ const copyMeetLink = async () => {
 const joinMeet = () => {
 	if (!meetUrl.value) return
 	// Same-origin paths stay in-app; foreign links open in a new tab.
-	if (meetUrl.value.startsWith('/')) window.location.href = meetUrl.value
+	if (meetUrl.value.startsWith('/')) router.push(meetUrl.value)
 	else window.open(meetUrl.value, '_blank', 'noopener')
 }
 

--- a/frontend/src/apps/calendar/router.ts
+++ b/frontend/src/apps/calendar/router.ts
@@ -1,4 +1,4 @@
-import type { RouteLocationNormalized, Router } from 'vue-router'
+import type { RouteLocationNormalized } from 'vue-router'
 
 import suiteRouter from '@/router'
 
@@ -35,25 +35,21 @@ const resolveShortcut = (
 	}
 }
 
-function installCalendarGuard(r: Router) {
-	r.beforeEach(async (to: RouteLocationNormalized) => {
-		// Only act on calendar routes; let the suite handle everything else.
-		if (typeof to.name !== 'string' || !to.name.startsWith('calendar-')) return
+export const calendarGuard = async (to: RouteLocationNormalized) => {
+	// Only act on calendar routes; let the suite handle everything else.
+	if (typeof to.name !== 'string' || !to.name.startsWith('calendar-')) return
 
-		// Wait for user data, then resolve the active account.
-		const store = userStore()
-		await store.userResource.promise
-		const user = store.userResource.data
+	// Wait for user data, then resolve the active account.
+	const store = userStore()
+	await store.userResource.promise
+	const user = store.userResource.data
 
-		store.resolveAccount(user?.accounts, to.params.accountId as string | undefined)
-		const accountId = store.accountId
+	store.resolveAccount(user?.accounts, to.params.accountId as string | undefined)
+	const accountId = store.accountId
 
-		// Expand shortcut routes to their full account-scoped equivalents. The
-		// query rides along — it carries the open event's deep link (?event=).
-		if (to.meta.shortcut) return { ...resolveShortcut(to.name, to.params, accountId), query: to.query }
-	})
+	// Expand shortcut routes to their full account-scoped equivalents. The
+	// query rides along — it carries the open event's deep link (?event=).
+	if (to.meta.shortcut) return { ...resolveShortcut(to.name, to.params, accountId), query: to.query }
 }
-
-installCalendarGuard(router)
 
 export default router

--- a/frontend/src/apps/calendar/routes.ts
+++ b/frontend/src/apps/calendar/routes.ts
@@ -1,11 +1,5 @@
 import type { RouteRecordRaw } from 'vue-router'
 
-import { createResource } from 'frappe-ui'
-
-// Install the calendar-local navigation guard (account resolution + shortcut
-// expansion) on the shared suite router. Importing for side effects only.
-import '@/apps/calendar/router'
-
 /**
  * Calendar route module — mounted by the suite router under the '/calendar'
  * prefix. Paths are RELATIVE to '/calendar' (no leading slash; the empty-path
@@ -79,20 +73,3 @@ export const routes: RouteRecordRaw[] = [
 ]
 
 export default routes
-
-/* -------------------------------------------------------------------------- */
-/* Translations                                                                */
-/*                                                                             */
-/* The suite installs ONE global translation plugin (foundation                */
-/* src/boot/translation.ts) so bare `__('text')` works everywhere. We only     */
-/* need to populate `window.translatedMessages`. Port calendar's translations  */
-/* fetch as a side-effect on module load. Backend method path preserved as-is. */
-/* -------------------------------------------------------------------------- */
-
-const translations = createResource({
-	url: 'suite.mail.api.get_translations',
-	cache: 'translations',
-	transform: (data) => (window.translatedMessages = data),
-})
-
-if (!window.translatedMessages) translations.fetch()

--- a/frontend/src/apps/calendar/runtime.ts
+++ b/frontend/src/apps/calendar/runtime.ts
@@ -1,0 +1,15 @@
+import { createResource } from 'frappe-ui'
+
+import { calendarGuard } from '@/apps/calendar/router'
+
+export function bootstrap() {
+  if (!window.translatedMessages) {
+    createResource({
+      url: 'suite.mail.api.get_translations',
+      cache: 'translations',
+      transform: (data) => (window.translatedMessages = data),
+    }).fetch()
+  }
+}
+
+export const beforeEach = calendarGuard

--- a/frontend/src/apps/drive/pages/Dummy.vue
+++ b/frontend/src/apps/drive/pages/Dummy.vue
@@ -1,1 +1,0 @@
-<template>Wait...</template>

--- a/frontend/src/apps/drive/pages/File.vue
+++ b/frontend/src/apps/drive/pages/File.vue
@@ -107,7 +107,8 @@ onKeyStroke('ArrowRight', (e) => {
 const onSuccess = async (entity) => {
   // temporary hack: #475
   if (isWriterDocument(entity)) {
-    window.location.href = '/writer/w/' + entity.name
+    await router.push({ name: 'writer-document', params: { id: entity.name } })
+    return
   }
   document.title = entity.file_name
   setCrumbEntity(entity)

--- a/frontend/src/apps/drive/router.ts
+++ b/frontend/src/apps/drive/router.ts
@@ -1,31 +1,9 @@
 import suiteRouter from '@/router'
-import { setActiveEntity } from '@/apps/drive/data/selection'
 
 /**
- * Drive-local navigation guard on the shared suite router, scoped to `drive-*`
- * routes so it never runs for other apps:
- *   - clears the active entity on every navigation,
- *   - stores the current route in sessionStorage.
- * Auth itself is the suite router's `beforeEach` (redirects guests for
- * non-`meta.allowGuest` routes).
- *
- * Re-exports the suite router instance for drive utils that read
+ * Re-exports the suite router instance for Drive utilities that read
  * `router.currentRoute` / call `router.push`.
+ * Drive's navigation hooks are loaded by the suite from `runtime.ts`.
  */
-const isDriveRoute = (route: { name?: unknown; path?: string }) =>
-  (typeof route.name === 'string' && route.name.startsWith('drive-')) ||
-  (route.path?.startsWith('/drive') ?? false)
-
-suiteRouter.beforeEach((to, _from, next) => {
-  if (!isDriveRoute(to)) return next()
-  setActiveEntity(null)
-  next()
-})
-
-suiteRouter.afterEach((to) => {
-  if (!isDriveRoute(to)) return
-  sessionStorage.setItem('currentRoute', to.href)
-})
-
 export const router = suiteRouter
 export default suiteRouter

--- a/frontend/src/apps/drive/routes.ts
+++ b/frontend/src/apps/drive/routes.ts
@@ -2,8 +2,6 @@ import type { RouteRecordRaw } from 'vue-router'
 import { createResource } from 'frappe-ui'
 
 import { useSessionStore } from '@/boot/session'
-import { translate } from '@/apps/drive/resources/files'
-import { setupTheme } from '@/utils/setupTheme'
 
 /**
  * Drive route module — mounted by the suite router under the '/drive' prefix.
@@ -25,6 +23,15 @@ import { setupTheme } from '@/utils/setupTheme'
 const setPageTitle = (to: any) => {
   if (useSessionStore().isLoggedIn) {
     document.title = __(String(to.name).replace(/^drive-/, ''))
+  }
+}
+
+const redirectLegacyEntity = async (to: any, name: string) => {
+  const { translate } = await import('@/apps/drive/resources/files')
+  await translate.fetch({ old_name: to.params.entityName })
+  return {
+    name,
+    params: { entityName: translate.data || to.params.entityName },
   }
 }
 
@@ -99,7 +106,6 @@ export const routes: RouteRecordRaw[] = [
       },
       {
         path: 'g/:entityName/',
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         meta: { allowGuest: true },
         beforeEnter: async (to) => {
           const entity = createResource({
@@ -139,7 +145,6 @@ export const routes: RouteRecordRaw[] = [
         path: 'w/:entityName/:slug?',
         name: 'drive-Document',
         meta: { allowGuest: true },
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         beforeEnter: (props) => {
           window.location.href = '/writer/w/' + props.params.entityName
         },
@@ -148,49 +153,20 @@ export const routes: RouteRecordRaw[] = [
       {
         path: 'folder/:entityName',
         meta: { allowGuest: true },
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
-        beforeEnter: async (to) => {
-          await translate.fetch({ old_name: to.params.entityName })
-          return {
-            name: 'drive-Folder',
-            params: {
-              // Untranslatable ids fall through so the page shows its error state
-              entityName: translate.data || to.params.entityName,
-            },
-          }
-        },
+        beforeEnter: (to) => redirectLegacyEntity(to, 'drive-Folder'),
       },
       {
         path: 'document/:entityName',
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         meta: { allowGuest: true },
-        beforeEnter: async (to) => {
-          await translate.fetch({ old_name: to.params.entityName })
-          return {
-            name: 'drive-Document',
-            params: {
-              entityName: translate.data || to.params.entityName,
-            },
-          }
-        },
+        beforeEnter: (to) => redirectLegacyEntity(to, 'drive-Document'),
       },
       {
         path: 'file/:entityName',
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         meta: { allowGuest: true },
-        beforeEnter: async (to) => {
-          await translate.fetch({ old_name: to.params.entityName })
-          return {
-            name: 'drive-File',
-            params: {
-              entityName: translate.data || to.params.entityName,
-            },
-          }
-        },
+        beforeEnter: (to) => redirectLegacyEntity(to, 'drive-File'),
       },
       {
         path: 't/:team/:letter/:entityName/:slug?',
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         meta: { allowGuest: true },
         beforeEnter: async (to) => {
           return {
@@ -204,7 +180,6 @@ export const routes: RouteRecordRaw[] = [
         // recorded — falling back to Home when there is nothing to point at, or
         // when the team was never theirs.
         path: 't/:team/',
-        component: () => import('@/apps/drive/pages/Dummy.vue'),
         meta: { allowGuest: true },
         beforeEnter: async (to) => {
           const legacy = createResource({
@@ -223,20 +198,3 @@ export const routes: RouteRecordRaw[] = [
 ]
 
 export default routes
-
-/* -------------------------------------------------------------------------- */
-/* Boot side-effects the suite main.ts does not run, so trigger them on drive  */
-/* module load.                                                                */
-/* -------------------------------------------------------------------------- */
-
-// Apply the persisted theme (can't gate the shared mount, so fire-and-forget).
-setupTheme()
-
-// The suite installs ONE global translation plugin so bare `__()` works. We
-// only need to populate `window.translatedMessages`. Backend path preserved.
-const translations = createResource({
-  url: 'suite.drive.api.product.get_translations',
-  cache: 'translations',
-  transform: (data: unknown) => ((window as any).translatedMessages = data),
-})
-if (!(window as any).translatedMessages) translations.fetch()

--- a/frontend/src/apps/drive/routes.ts
+++ b/frontend/src/apps/drive/routes.ts
@@ -145,9 +145,10 @@ export const routes: RouteRecordRaw[] = [
         path: 'w/:entityName/:slug?',
         name: 'drive-Document',
         meta: { allowGuest: true },
-        beforeEnter: (props) => {
-          window.location.href = '/writer/w/' + props.params.entityName
-        },
+        redirect: (to) => ({
+          name: 'writer-document',
+          params: { id: to.params.entityName, slug: to.params.slug },
+        }),
       },
       // old redirects
       {

--- a/frontend/src/apps/drive/runtime.ts
+++ b/frontend/src/apps/drive/runtime.ts
@@ -1,0 +1,25 @@
+import type { RouteLocationNormalized } from 'vue-router'
+import { createResource } from 'frappe-ui'
+
+import { setActiveEntity } from '@/apps/drive/data/selection'
+import { setupTheme } from '@/utils/setupTheme'
+
+export function bootstrap() {
+  setupTheme()
+
+  if (!window.translatedMessages) {
+    createResource({
+      url: 'suite.drive.api.product.get_translations',
+      cache: 'translations',
+      transform: (data: unknown) => (window.translatedMessages = data),
+    }).fetch()
+  }
+}
+
+export const beforeEach = (_to: RouteLocationNormalized) => {
+  setActiveEntity(null)
+}
+
+export function afterEach(to: { fullPath: string }) {
+  sessionStorage.setItem('currentRoute', to.fullPath)
+}

--- a/frontend/src/apps/drive/ui/drive/js/utils.js
+++ b/frontend/src/apps/drive/ui/drive/js/utils.js
@@ -2,6 +2,8 @@ import { toast } from 'frappe-ui'
 import slugify from 'slugify'
 import { useTimeAgo } from '@vueuse/core'
 
+import router from '@/apps/drive/router'
+
 import dayjs from 'dayjs'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import utc from 'dayjs/plugin/utc'
@@ -109,32 +111,23 @@ export const formatDate = (date) => {
   return `${formattedDate}, ${formattedTime}`
 }
 
-
 export const openEntity = (entity, new_tab = false) => {
-  if (new_tab) {
-    return window.open(getFileLink(entity, false), '_blank')
-  }
+  if (new_tab) return window.open(getFileLink(entity, false), '_blank')
 
   if (entity.name === '') {
-    window.location.href = '/drive/'
+    router.push({ name: 'drive-Home' })
   } else if (entity.is_folder) {
-    window.location.href = '/drive/d/' + entity.name
+    router.push({ name: 'drive-Folder', params: { entityName: entity.name } })
   } else if (entity.file_type === 'Link') {
     const origin = new URL(entity.file_url).origin
-    if (
-      confirm(
-        `This will open an external link to ${origin} - are you sure you want to open?`,
-      )
-    )
+    if (confirm(`This will open an external link to ${origin} - are you sure you want to open?`)) {
       window.open(entity.file_url, '_blank')
+    }
   } else if (entity.file_type === 'Presentation') {
-    window.location.href = '/slides/presentation/' + entity.name
-  } else if (
-    entity.file_type === 'Document' ||
-    entity.file_type === 'Markdown'
-  ) {
-    window.location.href = '/writer/w/' + entity.name
+    router.push({ name: 'slides-editor', params: { presentationId: entity.name } })
+  } else if (entity.file_type === 'Document' || entity.file_type === 'Markdown') {
+    router.push({ name: 'writer-document', params: { id: entity.name } })
   } else {
-    window.location.href = '/drive/f/' + entity.name
+    router.push({ name: 'drive-File', params: { entityName: entity.name } })
   }
 }

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -154,14 +154,20 @@ export const openEntity = (entity, new_tab = false) => {
     )
       window.open(entity.file_url, '_blank')
   } else if (isPresentation(entity)) {
-    window.location.href = '/slides/presentation/' + entity.content_docname
+    router.push({
+      name: 'slides-editor',
+      params: { presentationId: entity.content_docname },
+    })
   } else if (
     entity.file_type === 'Document' ||
     entity.file_type === 'Markdown'
   ) {
-    window.location.href = '/writer/w/' + entity.name
+    router.push({ name: 'writer-document', params: { id: entity.name } })
   } else if (isSheet(entity)) {
-    window.location.href = '/sheets/' + (entity.content_docname || entity.name)
+    router.push({
+      name: 'sheets-editor',
+      params: { id: entity.content_docname || entity.name },
+    })
   } else {
     router.push({
       name: 'drive-File',
@@ -714,9 +720,10 @@ export function getRandomColor() {
 }
 export const newExternal = async (type) => {
   if (type === 'Presentation') {
-    window.location.href = `/slides/presentation/new?parent=${
-      currentFolder.value.name
-    }`
+    router.push({
+      name: 'slides-editor-new',
+      query: { parent: currentFolder.value.name },
+    })
     return
   }
   if (type === 'Spreadsheet') {
@@ -724,7 +731,7 @@ export const newExternal = async (type) => {
     // sheet (its after_insert backs it with the Drive File in this folder)
     // then hand off to the Sheets SPA.
     const name = await createSheet.submit({ parent: currentFolder.value.name })
-    window.location.href = '/sheets/' + name
+    router.push({ name: 'sheets-editor', params: { id: name } })
     return
   }
   const data = await createDocument.submit({
@@ -733,7 +740,7 @@ export const newExternal = async (type) => {
   prettyData([data])
   data.file_type = type
   getDocuments.data?.push?.(data)
-  window.location.href = '/writer/w/' + data.name
+  router.push({ name: 'writer-document', params: { id: data.name } })
 }
 
 export function isApple() {

--- a/frontend/src/apps/drive/utils/openEntity.test.ts
+++ b/frontend/src/apps/drive/utils/openEntity.test.ts
@@ -25,11 +25,10 @@ vi.mock('frappe-ui', () => ({ useFileUpload: () => ({}), toast: vi.fn() }))
 
 import { openEntity, folderRoute } from './files'
 
-const location = { href: '', origin: 'http://localhost' }
+const location = { origin: 'http://localhost' }
 
 beforeEach(() => {
   vi.clearAllMocks()
-  location.href = ''
   Object.defineProperty(window, 'location', { configurable: true, value: location })
   window.open = mocks.open
   window.confirm = mocks.confirm
@@ -60,7 +59,10 @@ describe('openEntity', () => {
         content_docname: 'pres-9',
       })
     )
-    expect(location.href).toBe('/slides/presentation/pres-9')
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'slides-editor',
+      params: { presentationId: 'pres-9' },
+    })
   })
 
   it('previews an uploaded .pptx instead of opening Slides', () => {
@@ -71,7 +73,6 @@ describe('openEntity', () => {
           'application/vnd.openxmlformats-officedocument.presentationml.presentation',
       })
     )
-    expect(location.href).toBe('')
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: 'drive-File',
       params: { entityName: 'file-1' },
@@ -86,12 +87,14 @@ describe('openEntity', () => {
         content_docname: 'sheet-4',
       })
     )
-    expect(location.href).toBe('/sheets/sheet-4')
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'sheets-editor',
+      params: { id: 'sheet-4' },
+    })
   })
 
   it('previews an uploaded spreadsheet instead of opening Sheets', () => {
     openEntity(entity({ file_type: 'Spreadsheet', mime_type: 'text/csv' }))
-    expect(location.href).toBe('')
     expect(mocks.routerPush).toHaveBeenCalledWith({
       name: 'drive-File',
       params: { entityName: 'file-1' },
@@ -106,7 +109,10 @@ describe('openEntity', () => {
         content_docname: 'doc-2',
       })
     )
-    expect(location.href).toBe('/writer/w/file-1')
+    expect(mocks.routerPush).toHaveBeenCalledWith({
+      name: 'writer-document',
+      params: { id: 'file-1' },
+    })
   })
 
   it('confirms before following a link entity', () => {

--- a/frontend/src/apps/mail/router.ts
+++ b/frontend/src/apps/mail/router.ts
@@ -1,4 +1,4 @@
-import type { RouteLocationNormalized, Router } from 'vue-router'
+import type { RouteLocationNormalized } from 'vue-router'
 
 import suiteRouter from '@/router'
 import { useSessionStore } from '@/boot/session'
@@ -56,73 +56,69 @@ const resolveShortcut = (
 	}
 }
 
-function installMailGuard(r: Router) {
-	r.beforeEach(async (to: RouteLocationNormalized) => {
-		// Only act on mail routes; let the suite handle everything else.
-		if (typeof to.name !== 'string' || !to.name.startsWith('mail-')) return
+export const mailGuard = async (to: RouteLocationNormalized) => {
+	// Only act on mail routes; let the suite handle everything else.
+	if (typeof to.name !== 'string' || !to.name.startsWith('mail-')) return
 
-		handleSetupWizardEscape()
+	handleSetupWizardEscape()
 
-		// Auth: the suite guard already redirects guests on non-public routes,
-		// but public mail routes (login/signup/...) must short-circuit here so
-		// we don't trigger user-data resolution for a guest.
-		const { isLoggedIn } = useSessionStore()
-		if (!isLoggedIn) return
+	// Auth: the suite guard already redirects guests on non-public routes,
+	// but public mail routes (login/signup/...) must short-circuit here so
+	// we don't trigger user-data resolution for a guest.
+	const { isLoggedIn } = useSessionStore()
+	if (!isLoggedIn) return
 
-		// Wait for user data.
-		const { userResource, mailboxes, resolveAccount } = userStore()
-		await userResource.promise
-		const user = userResource.data
+	// Wait for user data.
+	const { userResource, mailboxes, resolveAccount } = userStore()
+	await userResource.promise
+	const user = userResource.data
 
-		// Admin / dashboard access control.
-		if (!user?.is_jmap_configured) {
-			if (!user?.is_suite_admin) window.location.replace('/desk')
-			if (to.meta.isDashboard) return
-			return { name: 'mail-overview' }
-		}
+	// Admin / dashboard access control.
+	if (!user?.is_jmap_configured) {
+		if (!user?.is_suite_admin) window.location.replace('/desk')
+		if (to.meta.isDashboard) return
+		return { name: 'mail-overview' }
+	}
 
-		// Resolve active account. The merged All Inboxes thread route carries the thread's
-		// owning account purely to scope the pane (see utils/accountScope) — opening a
-		// thread there must not switch the active account out from under the merged list.
-		const routeAccountId =
-			to.name === 'mail-all-inboxes-mail' ? undefined : (to.params.accountId as string | undefined)
-		resolveAccount(user?.accounts, routeAccountId)
-		const accountId = userStore().accountId
+	// Resolve active account. The merged All Inboxes thread route carries the thread's
+	// owning account purely to scope the pane (see utils/accountScope) — opening a
+	// thread there must not switch the active account out from under the merged list.
+	const routeAccountId =
+		to.name === 'mail-all-inboxes-mail' ? undefined : (to.params.accountId as string | undefined)
+	resolveAccount(user?.accounts, routeAccountId)
+	const accountId = userStore().accountId
 
-		// Wait for mailbox list. The fetch rejects when the mail server is temporarily down;
-		// swallow that so navigation still completes — otherwise the initial navigation aborts,
-		// the app never mounts and the user gets a blank page instead of the unavailable banner.
-		await mailboxes.promise?.catch(() => {})
-		const defaultRoute = buildDefaultRoute(accountId, mailboxes)
+	// Wait for mailbox list. The fetch rejects when the mail server is temporarily down;
+	// swallow that so navigation still completes — otherwise the initial navigation aborts,
+	// the app never mounts and the user gets a blank page instead of the unavailable banner.
+	await mailboxes.promise?.catch(() => {})
+	const defaultRoute = buildDefaultRoute(accountId, mailboxes)
 
-		// Validate mailbox param for mailbox routes.
-		if (to.name === 'mail-mailbox' || to.name === 'mail-mail') {
-			// The screener mailbox has its own dedicated view (Allow/Block UI). Redirect its
-			// plain mailbox URL to the screener route so direct navigation and reloads land on
-			// the screener view, matching the sidebar link (which already targets 'mail-screener').
-			const screenerId = userStore().mailboxIds.screener
-			if (screenerId && to.params.mailbox === screenerId)
-				return { name: 'mail-screener', params: { accountId } }
+	// Validate mailbox param for mailbox routes.
+	if (to.name === 'mail-mailbox' || to.name === 'mail-mail') {
+		// The screener mailbox has its own dedicated view (Allow/Block UI). Redirect its
+		// plain mailbox URL to the screener route so direct navigation and reloads land on
+		// the screener view, matching the sidebar link (which already targets 'mail-screener').
+		const screenerId = userStore().mailboxIds.screener
+		if (screenerId && to.params.mailbox === screenerId)
+			return { name: 'mail-screener', params: { accountId } }
 
-			// With no mailbox list (fetch failed above) the param can't be validated — keep the
-			// requested route rather than bouncing the user off the URL they asked for.
-			const mailboxExists =
-				!mailboxes.data ||
-				mailboxes.data.some((m: { id: string }) => m.id === to.params.mailbox) ||
-				['starred', 'search'].includes(to.params.mailbox as string)
-			if (!mailboxExists) return defaultRoute
-		}
+		// With no mailbox list (fetch failed above) the param can't be validated — keep the
+		// requested route rather than bouncing the user off the URL they asked for.
+		const mailboxExists =
+			!mailboxes.data ||
+			mailboxes.data.some((m: { id: string }) => m.id === to.params.mailbox) ||
+			['starred', 'search'].includes(to.params.mailbox as string)
+		if (!mailboxExists) return defaultRoute
+	}
 
-		// Expand shortcut routes to their full account-scoped equivalents. The
-		// query rides along — it can carry a compose deep link (?compose=1&to=).
-		if (to.meta.shortcut)
-			return { ...resolveShortcut(to.name, to.params, accountId, defaultRoute), query: to.query }
+	// Expand shortcut routes to their full account-scoped equivalents. The
+	// query rides along — it can carry a compose deep link (?compose=1&to=).
+	if (to.meta.shortcut)
+		return { ...resolveShortcut(to.name, to.params, accountId, defaultRoute), query: to.query }
 
-		// Login pages redirect already-authenticated users to their mailbox.
-		if (to.meta.isLogin) return defaultRoute
-	})
+	// Login pages redirect already-authenticated users to their mailbox.
+	if (to.meta.isLogin) return defaultRoute
 }
-
-installMailGuard(router)
 
 export default router

--- a/frontend/src/apps/mail/routes.ts
+++ b/frontend/src/apps/mail/routes.ts
@@ -1,12 +1,5 @@
 import type { RouteRecordRaw } from 'vue-router'
 
-import { createResource } from 'frappe-ui'
-
-// Install the mail-local navigation guard (auth-aware account resolution,
-// dashboard access control, mailbox validation + shortcut expansion) on the
-// shared suite router. Imported for side effects only.
-import '@/apps/mail/router'
-
 /**
  * Mail route module — mounted by the suite router under the '/mail' prefix.
  * Paths are RELATIVE to '/mail' (no leading slash; the empty-path '' is the
@@ -448,20 +441,3 @@ export const routes: RouteRecordRaw[] = [
 ]
 
 export default routes
-
-/* -------------------------------------------------------------------------- */
-/* Translations                                                               */
-/*                                                                            */
-/* The suite installs ONE global translation plugin (foundation              */
-/* src/boot/translation.ts) so bare `__('text')` works everywhere. We only   */
-/* need to populate `window.translatedMessages`. Mail's translation.ts plugin */
-/* was DELETED; this side-effect replaces it. Backend method preserved as-is. */
-/* -------------------------------------------------------------------------- */
-
-const translations = createResource({
-	url: 'suite.mail.api.get_translations',
-	cache: 'translations',
-	transform: (data) => (window.translatedMessages = data),
-})
-
-if (!window.translatedMessages) translations.fetch()

--- a/frontend/src/apps/mail/runtime.ts
+++ b/frontend/src/apps/mail/runtime.ts
@@ -1,0 +1,15 @@
+import { createResource } from 'frappe-ui'
+
+import { mailGuard } from '@/apps/mail/router'
+
+export function bootstrap() {
+  if (!window.translatedMessages) {
+    createResource({
+      url: 'suite.mail.api.get_translations',
+      cache: 'translations',
+      transform: (data) => (window.translatedMessages = data),
+    }).fetch()
+  }
+}
+
+export const beforeEach = mailGuard

--- a/frontend/src/apps/meet/router.ts
+++ b/frontend/src/apps/meet/router.ts
@@ -1,4 +1,4 @@
-import type { RouteLocationNormalized, Router } from "vue-router";
+import type { RouteLocationNormalized } from "vue-router";
 
 import suiteRouter from "@/router";
 import { userResource } from "@/boot/session";
@@ -15,37 +15,33 @@ import { isUnknownRecord } from "./types";
  */
 export const router = suiteRouter;
 
-function installMeetGuard(r: Router) {
-	r.beforeEach(async (to: RouteLocationNormalized) => {
-		// Only act on meet routes; let the suite handle everything else.
-		if (typeof to.name !== "string" || !to.name.startsWith("meet-")) return;
+export const meetGuard = async (to: RouteLocationNormalized) => {
+	// Only act on meet routes; let the suite handle everything else.
+	if (typeof to.name !== "string" || !to.name.startsWith("meet-")) return;
 
-		if (to.meta?.requiresAdmin) {
-			try {
-				if (!userResource.fetched) {
-					await userResource.fetch();
-				}
-			} catch {
-				// userResource onError already redirects to /login on auth errors.
-				return false;
+	if (to.meta?.requiresAdmin) {
+		try {
+			if (!userResource.fetched) {
+				await userResource.fetch();
 			}
-			const user = userResource.data;
-			const roles =
-				isUnknownRecord(user) &&
-				Array.isArray(user.roles) &&
-				user.roles.every((role) => typeof role === "string")
-					? user.roles
-					: [];
-			const isAdmin = roles.some((r) =>
-				["System Manager", "Administrator"].includes(r),
-			);
-			if (!isAdmin) {
-				return { name: "meet-home" };
-			}
+		} catch {
+			// userResource onError already redirects to /login on auth errors.
+			return false;
 		}
-	});
-}
-
-installMeetGuard(router);
+		const user = userResource.data;
+		const roles =
+			isUnknownRecord(user) &&
+			Array.isArray(user.roles) &&
+			user.roles.every((role) => typeof role === "string")
+				? user.roles
+				: [];
+		const isAdmin = roles.some((r) =>
+			["System Manager", "Administrator"].includes(r),
+		);
+		if (!isAdmin) {
+			return { name: "meet-home" };
+		}
+	}
+};
 
 export default router;

--- a/frontend/src/apps/meet/routes.ts
+++ b/frontend/src/apps/meet/routes.ts
@@ -1,17 +1,5 @@
 import type { RouteRecordRaw } from "vue-router";
 
-// Install the meet-local navigation guard (requiresAdmin role check) on the
-// shared suite router. Imported for side effects only.
-import "@/apps/meet/router";
-
-// Boot side-effects the suite's shared main.ts does not run, so trigger them
-// on meet module load.
-import { loadMediaPreferences } from "@/apps/meet/data/mediaPreferences";
-import { installConsoleBuffer } from "@/apps/meet/utils/diagnostics/consoleBuffer";
-
-loadMediaPreferences();
-installConsoleBuffer();
-
 /**
  * Meet route module — mounted by the suite router under the '/meet' prefix.
  * Paths are RELATIVE to '/meet' (no leading slash; the empty-path child '' is

--- a/frontend/src/apps/meet/runtime.ts
+++ b/frontend/src/apps/meet/runtime.ts
@@ -1,0 +1,10 @@
+import { loadMediaPreferences } from '@/apps/meet/data/mediaPreferences'
+import { installConsoleBuffer } from '@/apps/meet/utils/diagnostics/consoleBuffer'
+import { meetGuard } from '@/apps/meet/router'
+
+export function bootstrap() {
+  loadMediaPreferences()
+  installConsoleBuffer()
+}
+
+export const beforeEach = meetGuard

--- a/frontend/src/apps/slides/router.ts
+++ b/frontend/src/apps/slides/router.ts
@@ -1,24 +1,16 @@
-import type { RouteLocationNormalized } from 'vue-router'
-
 import suiteRouter from '@/router'
+export {
+  editorAccess,
+  previousRoute,
+  setEditorAccess,
+  setPreviousRoute,
+} from './routerState'
 
 /**
  * Slides router shim: re-exports the single suite router instance as `router`
  * for slides' module-singleton stores, and tracks the `previousRoute` +
  * per-presentation `editorAccess` that slides' views read.
  *
- * The actual tracking/guard is installed from `routes.ts` (`installSlidesGuards`)
- * which runs once the slides route module is lazy-loaded.
+ * Navigation tracking and access checks are loaded lazily from `runtime.ts`.
  */
 export const router = suiteRouter
-
-export let previousRoute: RouteLocationNormalized | null = null
-export let editorAccess = 'none'
-
-export function setPreviousRoute(route: RouteLocationNormalized | null) {
-  previousRoute = route
-}
-
-export function setEditorAccess(access: string) {
-  editorAccess = access
-}

--- a/frontend/src/apps/slides/routerState.ts
+++ b/frontend/src/apps/slides/routerState.ts
@@ -1,0 +1,12 @@
+import type { RouteLocationNormalized } from 'vue-router'
+
+export let previousRoute: RouteLocationNormalized | null = null
+export let editorAccess = 'none'
+
+export function setPreviousRoute(route: RouteLocationNormalized | null) {
+  previousRoute = route
+}
+
+export function setEditorAccess(access: string) {
+  editorAccess = access
+}

--- a/frontend/src/apps/slides/routes.ts
+++ b/frontend/src/apps/slides/routes.ts
@@ -1,12 +1,6 @@
-import type { RouteLocationNormalized, RouteRecordRaw, Router } from 'vue-router'
+import type { RouteLocationNormalized, RouteRecordRaw } from 'vue-router'
 
-import { createResource } from 'frappe-ui'
-
-import { router, setEditorAccess, setPreviousRoute } from '@/apps/slides/router'
-import SlidesShell from '@/apps/slides/SlidesShell.vue'
-import { getSessionUser, useSessionStore } from '@/boot/session'
-import { claimSlidesCachesFor, postToServiceWorker } from '@/apps/slides/utils/serviceWorker'
-import { removeOfflineCopy } from '@/apps/slides/stores/offlineCopy'
+import { editorAccess } from './routerState'
 
 /**
  * Slides route module — mounted by the suite router under the '/slides' prefix.
@@ -16,8 +10,6 @@ import { removeOfflineCopy } from '@/apps/slides/stores/offlineCopy'
  * suite router. Views are lazy so slides' heavy editor deps stay code-split.
  */
 
-let currentEditorAccess = 'none'
-
 const withPresentationProps = (route: RouteLocationNormalized) => {
   const slide = parseInt(route.query.slide as string)
   const activeSlideId = Number.isFinite(slide) ? slide : 1
@@ -25,16 +17,19 @@ const withPresentationProps = (route: RouteLocationNormalized) => {
   return {
     presentationId: route.params.presentationId,
     activeSlideId,
-    editorAccess: currentEditorAccess,
+    editorAccess,
   }
 }
 
 export const routes: RouteRecordRaw[] = [
   {
     path: '',
-    component: SlidesShell,
+    component: () => import('@/apps/slides/SlidesShell.vue'),
     // before the route components resolve, so the whole graph loads as slides
-    beforeEnter: () => postToServiceWorker('slides-entered'),
+    beforeEnter: async () => {
+      const { postToServiceWorker } = await import('@/apps/slides/utils/serviceWorker')
+      return postToServiceWorker('slides-entered')
+    },
     children: [
       {
         path: '',
@@ -80,73 +75,3 @@ export const routes: RouteRecordRaw[] = [
 ]
 
 export default routes
-
-/* -------------------------------------------------------------------------- */
-/* Slides navigation guards: maintain `previousRoute` and gate the editor      */
-/* route on the per-presentation access level. Installed once, the first time  */
-/* this module is loaded (see bottom of file).                                 */
-/* -------------------------------------------------------------------------- */
-
-const getEditorAccess = async (presentationId: string) => {
-  try {
-    const response = await createResource({
-      url: 'suite.slides.doctype.presentation.presentation.get_editor_access',
-      method: 'GET',
-    }).submit({
-      doctype: 'Presentation',
-      presentation_id: presentationId,
-    })
-    return response
-  } catch (error) {
-    console.error('Failed to fetch presentation access level:', error)
-    return false
-  }
-}
-
-const SLIDES_GUARDED = new Set(['slides-slideshow', 'slides-editor', 'slides-home'])
-
-function installSlidesGuards(r: Router) {
-  r.beforeEach(async (to, from, next) => {
-    // Only act on slides routes; let the suite handle everything else.
-    if (typeof to.name !== 'string' || !to.name.startsWith('slides-')) {
-      return next()
-    }
-
-    setPreviousRoute(from)
-
-    // before the first slides request of this visit is cached; a guest may be
-    // this user with an expired session, so their copy stays
-    const user = getSessionUser()
-    if (user) await claimSlidesCachesFor(user).catch(() => {})
-
-    if (!SLIDES_GUARDED.has(to.name)) {
-      return next()
-    }
-
-    if (to.name === 'slides-slideshow' && !from.name) {
-      return next({ name: 'slides-editor', params: to.params, query: to.query })
-    } else if (to.name === 'slides-slideshow') {
-      return next()
-    } else if (to.name === 'slides-editor') {
-      if (from.name !== to.name || from.params.presentationId !== to.params.presentationId) {
-        currentEditorAccess = (await getEditorAccess(to.params.presentationId as string)) as string
-        setEditorAccess(currentEditorAccess)
-      }
-      if (['edit', 'view'].includes(currentEditorAccess)) {
-        return next()
-      }
-      if (!useSessionStore().isLoggedIn) {
-        window.location.href = `/login?redirect-to=${encodeURIComponent(to.fullPath)}`
-        return next(false)
-      }
-      // the server has withdrawn this presentation, so the offline copy goes with it
-      if (currentEditorAccess === 'none') {
-        removeOfflineCopy(to.params.presentationId as string).catch(() => {})
-      }
-      return next({ name: 'slides-not-permitted' })
-    }
-    return next()
-  })
-}
-
-installSlidesGuards(router)

--- a/frontend/src/apps/slides/runtime.ts
+++ b/frontend/src/apps/slides/runtime.ts
@@ -1,0 +1,56 @@
+import type { RouteLocationNormalized, RouteLocationNormalizedLoaded } from 'vue-router'
+import { createResource } from 'frappe-ui'
+
+import { getSessionUser, useSessionStore } from '@/boot/session'
+import { removeOfflineCopy } from '@/apps/slides/stores/offlineCopy'
+import { claimSlidesCachesFor } from '@/apps/slides/utils/serviceWorker'
+import { editorAccess, setEditorAccess, setPreviousRoute } from './routerState'
+
+const getEditorAccess = async (presentationId: string) => {
+  try {
+    return await createResource({
+      url: 'suite.slides.doctype.presentation.presentation.get_editor_access',
+      method: 'GET',
+    }).submit({
+      doctype: 'Presentation',
+      presentation_id: presentationId,
+    })
+  } catch (error) {
+    console.error('Failed to fetch presentation access level:', error)
+    return false
+  }
+}
+
+const SLIDES_GUARDED = new Set(['slides-slideshow', 'slides-editor', 'slides-home'])
+
+export const beforeEach = async (
+  to: RouteLocationNormalized,
+  from: RouteLocationNormalizedLoaded,
+) => {
+  setPreviousRoute(from)
+
+  const user = getSessionUser()
+  if (user) await claimSlidesCachesFor(user).catch(() => {})
+
+  if (typeof to.name !== 'string' || !SLIDES_GUARDED.has(to.name)) return
+
+  if (to.name === 'slides-slideshow' && !from.name) {
+    return { name: 'slides-editor', params: to.params, query: to.query }
+  }
+  if (to.name === 'slides-slideshow') return
+
+  if (to.name === 'slides-editor') {
+    if (from.name !== to.name || from.params.presentationId !== to.params.presentationId) {
+      setEditorAccess((await getEditorAccess(to.params.presentationId as string)) as string)
+    }
+    if (['edit', 'view'].includes(editorAccess)) return
+    if (!useSessionStore().isLoggedIn) {
+      window.location.href = `/login?redirect-to=${encodeURIComponent(to.fullPath)}`
+      return false
+    }
+    if (editorAccess === 'none') {
+      removeOfflineCopy(to.params.presentationId as string).catch(() => {})
+    }
+    return { name: 'slides-not-permitted' }
+  }
+}

--- a/frontend/src/apps/writer/routes.ts
+++ b/frontend/src/apps/writer/routes.ts
@@ -1,14 +1,5 @@
 import type { RouteRecordRaw } from 'vue-router'
 
-import { createResource } from 'frappe-ui'
-
-// Boot side-effects the suite's shared main.ts does not run, so trigger them
-// on writer module load.
-import { allUsers } from '@/apps/drive/sdk'
-import { getSessionUser } from '@/boot/session'
-
-if (getSessionUser()) allUsers.fetch()
-
 /**
  * Writer route module — mounted by the suite router under the '/writer' prefix.
  * Paths are RELATIVE to '/writer' (no leading slash; the empty-path child '' is
@@ -44,19 +35,3 @@ export const routes: RouteRecordRaw[] = [
 ]
 
 export default routes
-
-/* -------------------------------------------------------------------------- */
-/* Translations                                                                */
-/*                                                                             */
-/* The suite installs ONE global translation plugin (foundation                */
-/* src/boot/translation.ts) so bare `__('text')` works everywhere. We only     */
-/* need to populate `window.translatedMessages`.                               */
-/* -------------------------------------------------------------------------- */
-
-const translations = createResource({
-  url: 'suite.drive.api.product.get_translations',
-  cache: 'translations',
-  transform: (data) => (window.translatedMessages = data),
-})
-
-if (!window.translatedMessages) translations.fetch()

--- a/frontend/src/apps/writer/runtime.ts
+++ b/frontend/src/apps/writer/runtime.ts
@@ -1,0 +1,16 @@
+import { createResource } from 'frappe-ui'
+
+import { allUsers } from '@/apps/drive/sdk'
+import { getSessionUser } from '@/boot/session'
+
+export function bootstrap() {
+  if (getSessionUser()) allUsers.fetch()
+
+  if (!window.translatedMessages) {
+    createResource({
+      url: 'suite.drive.api.product.get_translations',
+      cache: 'translations',
+      transform: (data: Record<string, string>) => (window.translatedMessages = data),
+    }).fetch()
+  }
+}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -50,6 +50,10 @@ const appRoutes: Record<string, RouteRecordRaw[]> = {
   calendar: calendarRoutes,
 }
 
+/**
+ * Lazy app lifecycle: bootstrap runs once before the first navigation,
+ * beforeEach gates every app navigation, and afterEach runs after completion.
+ */
 type AppRuntime = {
   bootstrap?: () => void | Promise<void>
   beforeEach?: (

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,12 +1,21 @@
 import {
   createRouter,
   createWebHistory,
+  type NavigationGuardReturn,
+  type RouteLocationNormalized,
   type RouteLocationNormalizedLoaded,
   type RouteRecordRaw,
 } from 'vue-router'
 import { createResource } from 'frappe-ui'
 
 import { SUITE_APPS, SUITE_LOGO } from '@/apps/registry'
+import { routes as calendarRoutes } from '@/apps/calendar/routes'
+import { routes as driveRoutes } from '@/apps/drive/routes'
+import { routes as mailRoutes } from '@/apps/mail/routes'
+import { routes as meetRoutes } from '@/apps/meet/routes'
+import { routes as sheetsRoutes } from '@/apps/sheets/routes'
+import { routes as slidesRoutes } from '@/apps/slides/routes'
+import { routes as writerRoutes } from '@/apps/writer/routes'
 import { hasServerBoot, useSessionStore } from '@/boot/session'
 import APPLE_SPLASH_DEVICES from './pwa-splash-devices.json'
 
@@ -23,43 +32,74 @@ declare module 'vue-router' {
 /**
  * ONE Vue Router for the whole suite.
  *
- * Each of the 7 apps contributes a route GROUP mounted at its original prefix
- * (/drive /slides /writer /sheets /meet /mail /calendar). Every group lazy-loads
- * `src/apps/<id>/routes.ts`, which exports a `routes: RouteRecordRaw[]` array
- * RELATIVE to that prefix (paths without a leading slash; the empty-path child
- * is the app's index). This keeps per-app bundles code-split so the shell stays
- * small (heavy app deps — mediasoup, firebase, xlsx, docx — load only on demand).
+ * Each app contributes lightweight route definitions mounted at its original
+ * prefix. Views and app-specific runtime behavior remain lazy, while the full
+ * route table and metadata are available on the first navigation.
  *
  * `/suite` is the launcher (app switcher).
  *
- * Lazy registration: each app's prefix initially resolves to a placeholder
- * record carrying `meta.appId`. The first navigation into a prefix loads that
- * app's route module, replaces the placeholder with a real group containing the
- * module's `routes`, and re-resolves the navigation (see `beforeEach`).
  */
 
-// Dynamic-import loaders for each app's route module. The import is a dynamic
-// `import()` so the app's actual views/components stay code-split.
-const appRouteLoaders: Record<string, () => Promise<{ routes: RouteRecordRaw[] }>> = {
-  drive: () => import('@/apps/drive/routes'),
-  slides: () => import('@/apps/slides/routes'),
-  writer: () => import('@/apps/writer/routes'),
-  sheets: () => import('@/apps/sheets/routes'),
-  meet: () => import('@/apps/meet/routes'),
-  mail: () => import('@/apps/mail/routes'),
-  calendar: () => import('@/apps/calendar/routes'),
+const appRoutes: Record<string, RouteRecordRaw[]> = {
+  drive: driveRoutes,
+  slides: slidesRoutes,
+  writer: writerRoutes,
+  sheets: sheetsRoutes,
+  meet: meetRoutes,
+  mail: mailRoutes,
+  calendar: calendarRoutes,
+}
+
+type AppRuntime = {
+  bootstrap?: () => void | Promise<void>
+  beforeEach?: (
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalizedLoaded,
+  ) => NavigationGuardReturn | Promise<NavigationGuardReturn>
+  afterEach?: (to: RouteLocationNormalizedLoaded) => void
+}
+
+const appRuntimeLoaders: Record<string, () => Promise<AppRuntime>> = {
+  drive: () => import('@/apps/drive/runtime'),
+  slides: () => import('@/apps/slides/runtime'),
+  writer: () => import('@/apps/writer/runtime'),
+  meet: () => import('@/apps/meet/runtime'),
+  mail: () => import('@/apps/mail/runtime'),
+  calendar: () => import('@/apps/calendar/runtime'),
+}
+
+const appRuntimePromises = new Map<string, Promise<AppRuntime>>()
+const loadedAppRuntimes = new Map<string, AppRuntime>()
+
+function ensureAppRuntime(appId: string): Promise<AppRuntime> | undefined {
+  const loader = appRuntimeLoaders[appId]
+  if (!loader) return
+
+  let promise = appRuntimePromises.get(appId)
+  if (!promise) {
+    promise = loader()
+      .then(async (runtime) => {
+        await runtime.bootstrap?.()
+        loadedAppRuntimes.set(appId, runtime)
+        return runtime
+      })
+      .catch((error) => {
+        appRuntimePromises.delete(appId)
+        throw error
+      })
+    appRuntimePromises.set(appId, promise)
+  }
+  return promise
 }
 
 const SUITE_FAVICON = SUITE_LOGO
 let currentFaviconScope: string | undefined
 
-// Placeholder record per app: matches the prefix + everything under it and
-// carries `meta.appId`. `beforeEach` swaps it for the real routes on first hit.
-const placeholderGroups: RouteRecordRaw[] = SUITE_APPS.map((app) => ({
-  path: `${app.prefix}/:pathMatch(.*)*`,
-  name: `${app.id}-placeholder`,
+const appGroups: RouteRecordRaw[] = SUITE_APPS.map((app) => ({
+  path: app.prefix,
   component: () => import('@/shell/AppContainer.vue'),
   meta: { appId: app.id, title: `Frappe ${app.name}`, favicon: app.logo },
+  children: appRoutes[app.id],
 }))
 
 const routes: RouteRecordRaw[] = [
@@ -79,7 +119,18 @@ const routes: RouteRecordRaw[] = [
     component: () => import('@/shell/SetupView.vue'),
     meta: { isShell: true, title: 'Set up Frappe Suite', favicon: SUITE_FAVICON },
   },
-  ...placeholderGroups,
+  {
+    path: '/suite/load-error',
+    name: 'app-load-error',
+    component: () => import('@/shell/AppLoadErrorView.vue'),
+    meta: {
+      isShell: true,
+      allowGuest: true,
+      title: 'Frappe Suite',
+      favicon: SUITE_FAVICON,
+    },
+  },
+  ...appGroups,
   {
     path: '/:pathMatch(.*)*',
     name: 'not-found',
@@ -93,9 +144,6 @@ const router = createRouter({
   history: createWebHistory('/'),
   routes,
 })
-
-// Apps whose real route groups have already been registered.
-const registeredApps = new Set<string>()
 
 // First-run onboarding state: boot globals in prod, fetch in dev.
 type OnboardingState = { isOnboarded: boolean; canOnboard: boolean }
@@ -123,53 +171,15 @@ function ensureOnboardingState(): OnboardingState | Promise<OnboardingState> {
   return onboardingStatePromise
 }
 
-/**
- * Load `src/apps/<appId>/routes.ts`, register its routes under the app prefix
- * inside an AppContainer group, and drop the placeholder so future navigations
- * resolve straight to the real routes.
- */
-async function ensureAppRoutesLoaded(appId: string): Promise<void> {
-  if (registeredApps.has(appId)) return
-
-  const loader = appRouteLoaders[appId]
-  const app = SUITE_APPS.find((a) => a.id === appId)
-  if (!loader || !app) return
-
-  const mod = await loader()
-
-  router.addRoute({
-    path: app.prefix,
-    component: () => import('@/shell/AppContainer.vue'),
-    meta: { appId, title: `Frappe ${app.name}`, favicon: app.logo },
-    children: mod.routes,
-  })
-
-  // Remove the catch-all placeholder so it no longer shadows the real routes.
-  if (router.hasRoute(`${appId}-placeholder`)) {
-    router.removeRoute(`${appId}-placeholder`)
-  }
-
-  registeredApps.add(appId)
-}
-
-router.beforeEach(async (to) => {
-  // 1. Lazy-load the target app's route module before resolving the route.
-  const appId = to.meta.appId
-  if (appId && !registeredApps.has(appId)) {
-    await ensureAppRoutesLoaded(appId)
-    // Re-resolve now that the real routes exist without replacing the previous
-    // page in browser history.
-    return to.fullPath
-  }
-
-  // 2. Auth gate (shell launcher + every app require a logged-in user).
+router.beforeEach(async (to, from) => {
+  // 1. Auth gate (shell launcher + every app require a logged-in user).
   const session = useSessionStore()
   if (!session.isLoggedIn && !to.meta.allowGuest) {
     window.location.href = `/login?redirect-to=${encodeURIComponent(to.fullPath)}`
     return false
   }
 
-  // 3. First-run onboarding gate. Only System Managers are sent to /suite/setup —
+  // 2. First-run onboarding gate. Only System Managers are sent to /suite/setup —
   // they alone can complete it; everyone else uses the site as-is.
   const onboarding = await ensureOnboardingState()
   const onSetupPage = to.path === '/suite/setup'
@@ -179,7 +189,21 @@ router.beforeEach(async (to) => {
     return '/suite'
   }
 
-  return true
+  // 3. Load only the target app's initialization and local guard behavior.
+  const appId = to.meta.appId
+  if (!appId) return true
+
+  let runtime: AppRuntime | undefined
+  try {
+    runtime = await ensureAppRuntime(appId)
+  } catch (error) {
+    console.error(`Failed to load ${appId} runtime`, error)
+    return {
+      name: 'app-load-error',
+      query: { app: appId, redirect: to.fullPath },
+    }
+  }
+  return (await runtime?.beforeEach?.(to, from)) ?? true
 })
 
 router.afterEach((to, from, failure) => {
@@ -190,6 +214,8 @@ router.afterEach((to, from, failure) => {
   setDocumentTitle(to, from)
   setFavicon(to)
   setPwaTags(to)
+  const appId = to.meta.appId
+  if (appId) loadedAppRuntimes.get(appId)?.afterEach?.(to)
 })
 
 export function setDocumentTitle(

--- a/frontend/src/router/staticRoutes.test.ts
+++ b/frontend/src/router/staticRoutes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import router from './index'
+
+describe('suite route table', () => {
+  it.each([
+    ['/drive', 'drive-Home'],
+    ['/slides', 'slides-home'],
+    ['/writer', 'writer-home'],
+    ['/sheets/new', 'sheets-editor'],
+    ['/meet/room-1', 'meet-meeting'],
+    ['/mail/login', 'mail-login'],
+    ['/calendar', 'calendar-root-shortcut'],
+  ])('resolves %s before any navigation', (path, name) => {
+    expect(router.resolve(path).name).toBe(name)
+  })
+
+  it.each(['/slides/presentation/demo', '/writer/w/demo', '/meet/demo', '/mail/login'])(
+    'exposes guest metadata immediately for %s',
+    (path) => {
+      expect(router.resolve(path).meta.allowGuest).toBe(true)
+    },
+  )
+
+  it('does not register placeholder routes', () => {
+    expect(router.getRoutes().some((route) => String(route.name).endsWith('-placeholder'))).toBe(false)
+  })
+
+  it('keeps the runtime load error available to guests', () => {
+    expect(router.resolve('/suite/load-error').meta.allowGuest).toBe(true)
+  })
+})

--- a/frontend/src/shell/AppLoadErrorView.vue
+++ b/frontend/src/shell/AppLoadErrorView.vue
@@ -1,0 +1,23 @@
+<template>
+  <div class="flex h-full flex-col items-center justify-center gap-3 p-8 text-center">
+    <h1 class="text-2xl-semibold text-ink-gray-9">Could not load {{ appName }}</h1>
+    <p class="text-sm text-ink-gray-6">Check your connection and try again.</p>
+    <div class="flex items-center gap-3">
+      <button class="text-sm text-ink-blue-link hover:underline" @click="retry">Try again</button>
+      <router-link to="/suite" class="text-sm text-ink-gray-6 hover:underline">
+        Back to launcher
+      </router-link>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+const appName = computed(() => String(route.query.app || 'app'))
+
+const retry = () => router.replace(String(route.query.redirect || '/suite'))
+</script>


### PR DESCRIPTION
## Summary

- register every app route group when the suite router is created
- lazy-load app bootstrap and guard behavior through cached runtime modules
- remove Drive placeholder components from redirect-only legacy routes
- navigate between suite apps without full-page reloads, including legacy Drive callers
- show a retryable shell view when an app runtime cannot load
- document the lazy app runtime lifecycle contract

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.9% (+0%) · Frontend 35.1% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.9%** (21,489 / 37,754) (+0%) | **29.8%** (2,891 / 9,702) (+0%) |
| Frontend | **35.1%** (14,241 / 40,560) (+0%) | **29.6%** (9,196 / 31,061) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33606732876) for commit `467b17f`.</sub>

</details>
<!-- suite-coverage:end -->
