### PR TITLE
fix(calendar): time edits the event modal wouldn't take

### DIFF
--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -128,12 +128,15 @@ const defaultAlert = (isAllDay: boolean, startDate: string) =>
 				relative_to: 'Start',
 			}
 
+// When an event on this day starts, absent a slot to put it in: the next full hour today,
+// ten in the morning on any other day.
+const defaultStartTime = (date: string) =>
+	dayjs(date).isToday() ? dayjs().add(1, 'hour').startOf('hour').format('HH:mm') : '10:00'
+
 const getDefaultEventData = () => {
 	const startTime = selectedEvent?.time
 		? dayjs(selectedEvent.time, 'h a').format('HH:mm')
-		: dayjs(selectedEvent.date).isToday()
-			? dayjs().add(1, 'hour').startOf('hour').format('HH:mm')
-			: '10:00'
+		: defaultStartTime(selectedEvent.date)
 
 	const identity = store.organizerIdentity
 
@@ -717,6 +720,16 @@ const setAllDay = (isAllDay: boolean) => {
 		JSON.stringify(event.alerts[0]) === JSON.stringify(defaultAlert(event.isAllDay, event.startDate))
 	event.isAllDay = isAllDay
 	if (untouched) event.alerts = [defaultAlert(isAllDay, event.startDate)]
+
+	// A saved all-day event carries midnight at both ends of the same day: its duration counts
+	// whole days, so taking the exclusive last day off the end lands it back on the start. As a
+	// timed event that is a zero-length range, which the form won't save — and the reader is left
+	// with a disabled Save and nothing saying why. Give it the slot a new event on that day would
+	// get; the end follows an hour later, dragged along by the start watcher (the gap it reads is
+	// zero, so it falls back to the default duration). A range that already spans days is a real
+	// one and keeps its own hours.
+	if (!isAllDay && !endsAt.value.isAfter(startsAt.value))
+		event.startTime = defaultStartTime(event.startDate)
 }
 
 // --- Delete ---

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -28,7 +28,12 @@ import {
 import meetLogo from '@/assets/app-logos/meet.png'
 import { submit as submitCall } from '@/apps/meet/utils/request'
 import { getMeetUrl, getReorderedParticipants } from '@/apps/calendar/utils'
-import { fromEventZone, fromWallClock, inUserTimeZone } from '@/apps/calendar/utils/datetime'
+import {
+	fromEventZone,
+	fromWallClock,
+	inUserTimeZone,
+	shiftedMasterStart,
+} from '@/apps/calendar/utils/datetime'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
 import { userStore } from '@/apps/calendar/stores/user'
 import type { ParticipantIdentity } from '@/apps/calendar/types/doctypes'
@@ -67,13 +72,16 @@ const isTitleFocused = ref(false)
 
 // --- Event initialization ---
 
+// The occurrence's own start, as the form reads it. Timed events edit in the viewer's zone
+// (saving re-zones them to it, see eventParams); all-day events keep their calendar date.
+const occurrenceStart = (ev: any) =>
+	ev.isAllDay ? dayjs(ev.start) : fromEventZone(ev.start, ev.time_zone)
+
 const getEventData = () => {
 	if (isNew.value) return getDefaultEventData()
 
 	const { calendarEvent: ev } = selectedEvent
-	// Timed events edit in the viewer's zone (saving re-zones them to it, see eventParams);
-	// all-day events keep their calendar date.
-	const start = ev.isAllDay ? dayjs(ev.start) : fromEventZone(ev.start, ev.time_zone)
+	const start = occurrenceStart(ev)
 	const end = start.add(dayjs.duration(ev.duration))
 	const displayEnd = ev.isAllDay ? end.subtract(1, 'day') : end
 
@@ -218,11 +226,20 @@ const eventParams = computed(() => {
 	if (event.title) params.title = event.title
 	if (dayjs?.tz) params.time_zone = dayjs.tz.guess()
 
-	if (selectedEvent.calendarEvent?.recurrence_id && !isUpdateInstance.value) {
-		// The master's start passes through unchanged, so it must keep the master's zone —
-		// pairing it with the browser's would silently shift the whole series.
-		params.start = selectedEvent.calendarEvent.master_start
-		params.time_zone = selectedEvent.calendarEvent.time_zone || params.time_zone
+	// Saving the whole series from one of its occurrences. The start on screen belongs to that
+	// occurrence, so what reaches the master is the shift the reader made to it — nothing at all
+	// when they made none, which is how the anchor used to pass through untouched. It keeps the
+	// master's zone either way: pairing the master's wall clock with the browser's zone would
+	// move the series on its own.
+	const ev = selectedEvent?.calendarEvent
+	if (ev?.recurrence_id && !isUpdateInstance.value) {
+		// An unresolved master (no master_start) is already past saving — the update is addressed by
+		// master_id too, and falls back to an id the server won't take — so it is left exactly as it
+		// was rather than given a start of this occurrence's, or of now.
+		params.start = ev.master_start
+			? shiftedMasterStart(ev.master_start, occurrenceStart(ev), startsAt.value)
+			: ev.master_start
+		params.time_zone = ev.time_zone || params.time_zone
 	}
 	if (event.recurrence_rule && Object.keys(event.recurrence_rule).length)
 		params.recurrence_rule = event.recurrence_rule

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -839,17 +839,20 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 						<!-- lead title. The field sizes to its own text — a mirror span shares
 						     the grid cell and sets the width — so the pencil sits against the
 						     title instead of adrift at the column's edge. The mirror falls back
-						     to the placeholder so an empty title still leaves something to click,
+						     to the placeholder so an empty title still leaves something to read,
 						     and max-w-full keeps a long one inside the column, where the input
-						     scrolls internally as it did at full width. w-fit ends the hover
-						     group at the pencil, so the underline answers the title and the
-						     pencil only — not the empty column beside them, and the pb sits on
-						     a wrapper so the band below the title is outside it too. The click
-						     is on the row rather than its two children, which is what makes the
-						     gap between title and pencil live rather than dead space. -->
+						     scrolls internally as it did at full width. The click is on the row
+						     rather than its two children, which is what makes the gap between
+						     title and pencil live rather than dead space — and the row runs the
+						     width of the column, so the whole line answers, not just the words:
+						     an empty title is a short word to aim at, and the line beside it read
+						     as dead. The underline still only spans the title, since it is the
+						     input that carries it and the input is only as wide as its text. The
+						     pb sits on a wrapper so the band below the title stays outside the
+						     target. -->
 						<div class="pb-4">
 							<div
-								class="group flex w-fit max-w-full items-center gap-2"
+								class="group flex w-full items-center gap-2"
 								:class="{ 'cursor-pointer': !isTitleFocused }"
 								@click="titleInput?.focus()"
 							>

--- a/frontend/src/apps/calendar/utils/datetime.test.ts
+++ b/frontend/src/apps/calendar/utils/datetime.test.ts
@@ -85,13 +85,25 @@ describe('calendar datetime helpers', () => {
 			)
 		})
 
-		it('counts wall clocks, so a DST boundary cannot add an hour of its own', async () => {
+		it('adds to the anchor in wall-clock time, whatever the date it lands on does', async () => {
 			const { shiftedMasterStart } = await load()
-			// Europe/Vienna springs forward on 2026-03-29. The arithmetic runs in UTC, so an hour
-			// asked for is an hour given, whatever the browser's zone does that night.
+			// An anchor sitting on the morning Europe/Vienna springs forward. An hour asked for is
+			// an hour given: the master is a clock face in its own zone, not an instant here.
 			expect(shiftedMasterStart('2026-03-29T01:30:00', opened, dayjs('2026-09-14T16:00:00'))).toBe(
 				'2026-03-29T02:30:00',
 			)
+		})
+
+		it('measures the edit in wall-clock time too, across a DST boundary', async () => {
+			const { shiftedMasterStart } = await load()
+			// Europe/Vienna falls back on 2026-10-25, so 10:00 on the 18th and 10:00 on the 25th are
+			// seven days apart on the calendar and seven days *and an hour* apart in elapsed time.
+			// The reader moved the occurrence a week, and a week is what the series moves.
+			const before = dayjs.tz('2026-10-18T10:00:00', 'Europe/Vienna')
+			const after = dayjs.tz('2026-10-25T10:00:00', 'Europe/Vienna')
+			expect(shiftedMasterStart('2026-09-07T15:00:00', before, after)).toBe('2026-09-14T15:00:00')
+			// And the other way: back a week is back a week, not an hour short of it.
+			expect(shiftedMasterStart('2026-09-14T15:00:00', after, before)).toBe('2026-09-07T15:00:00')
 		})
 	})
 })

--- a/frontend/src/apps/calendar/utils/datetime.test.ts
+++ b/frontend/src/apps/calendar/utils/datetime.test.ts
@@ -54,4 +54,44 @@ describe('calendar datetime helpers', () => {
 		expect(formatDateTime(null)).toBe('')
 		expect(fromWallClock('')).toBe('')
 	})
+
+	describe('shiftedMasterStart', () => {
+		// The series anchors on Sep 7; the reader has the Sep 14 occurrence open.
+		const master = '2026-09-07T15:00:00'
+		const opened = dayjs('2026-09-14T15:00:00')
+
+		it('leaves the anchor where it is when the time was not touched', async () => {
+			const { shiftedMasterStart } = await load()
+			expect(shiftedMasterStart(master, opened, dayjs('2026-09-14T15:00:00'))).toBe(master)
+		})
+
+		it('moves the series by what the reader changed, not to the occurrence', async () => {
+			const { shiftedMasterStart } = await load()
+			// 3 PM to 5 PM on the occurrence: the anchor keeps its own date and moves two hours.
+			expect(shiftedMasterStart(master, opened, dayjs('2026-09-14T17:00:00'))).toBe(
+				'2026-09-07T17:00:00',
+			)
+			// And backwards, across midnight into the previous day.
+			expect(shiftedMasterStart(master, opened, dayjs('2026-09-13T23:00:00'))).toBe(
+				'2026-09-06T23:00:00',
+			)
+		})
+
+		it('carries a date change through as the same shift', async () => {
+			const { shiftedMasterStart } = await load()
+			// Dragged a day later and an hour earlier: the whole series follows.
+			expect(shiftedMasterStart(master, opened, dayjs('2026-09-15T14:00:00'))).toBe(
+				'2026-09-08T14:00:00',
+			)
+		})
+
+		it('counts wall clocks, so a DST boundary cannot add an hour of its own', async () => {
+			const { shiftedMasterStart } = await load()
+			// Europe/Vienna springs forward on 2026-03-29. The arithmetic runs in UTC, so an hour
+			// asked for is an hour given, whatever the browser's zone does that night.
+			expect(shiftedMasterStart('2026-03-29T01:30:00', opened, dayjs('2026-09-14T16:00:00'))).toBe(
+				'2026-03-29T02:30:00',
+			)
+		})
+	})
 })

--- a/frontend/src/apps/calendar/utils/datetime.ts
+++ b/frontend/src/apps/calendar/utils/datetime.ts
@@ -54,6 +54,15 @@ export const utcDayStart = (date?: string | null): string =>
 export const utcDayEnd = (date?: string | null): string =>
 	date ? dayjs.tz(date, userTimeZone()).endOf('day').utc().format(UTC_FORMAT) : ''
 
+const WALL_FORMAT = 'YYYY-MM-DD[T]HH:mm:ss'
+
+/**
+ * The clock face a moment shows, read back as UTC. Two of these subtract to the difference a
+ * reader would count off a calendar — which is not the time that elapsed between them whenever a
+ * DST boundary sits in between.
+ */
+const asWallClock = (moment: Dayjs) => dayjs.utc(moment.format(WALL_FORMAT))
+
 /**
  * Where a recurring series' anchor lands when the reader edits the time on one of its occurrences
  * and saves the whole series.
@@ -63,11 +72,15 @@ export const utcDayEnd = (date?: string | null): string =>
  * is the difference the reader made, applied to the master's own start: no edit moves nothing, and
  * an edit moves the series by exactly what they changed, as every other calendar does.
  *
- * A JSCalendar `start` is a wall clock with no offset, and the master keeps its own zone, so the
- * arithmetic runs in UTC — in the browser's zone a DST boundary would add an hour of its own.
+ * Both halves of that are wall-clock work, and neither can be done on instants. The difference is
+ * what the reader typed against what they were shown — move an occurrence across the day the
+ * clocks change and an hour of elapsed time appears that nobody asked for. The master is a
+ * JSCalendar `start`: a clock face with no offset, kept in the master's own zone, so adding to it
+ * in the browser's zone would find a second boundary to trip over. Hence UTC on both sides, where
+ * an hour is always an hour.
  */
 export const shiftedMasterStart = (masterStart: string, opened: Dayjs, edited: Dayjs): string =>
 	dayjs
 		.utc(masterStart)
-		.add(edited.diff(opened, 'minute'), 'minute')
-		.format('YYYY-MM-DD[T]HH:mm:ss')
+		.add(asWallClock(edited).diff(asWallClock(opened), 'minute'), 'minute')
+		.format(WALL_FORMAT)

--- a/frontend/src/apps/calendar/utils/datetime.ts
+++ b/frontend/src/apps/calendar/utils/datetime.ts
@@ -11,6 +11,8 @@ import { userStore } from '@/apps/calendar/stores/user'
 
 const UTC_FORMAT = 'YYYY-MM-DDTHH:mm:ss[Z]'
 
+type Dayjs = ReturnType<typeof dayjs>
+
 /**
  * The zone timestamps are displayed and typed in: the browser's, falling back to `time_zone` on
  * the User doc for the rare environment where the browser cannot say (`get_user_info` resolves
@@ -51,3 +53,21 @@ export const utcDayStart = (date?: string | null): string =>
 /** The end of a `YYYY-MM-DD` day in the user's zone, as a UTC timestamp the APIs take. */
 export const utcDayEnd = (date?: string | null): string =>
 	date ? dayjs.tz(date, userTimeZone()).endOf('day').utc().format(UTC_FORMAT) : ''
+
+/**
+ * Where a recurring series' anchor lands when the reader edits the time on one of its occurrences
+ * and saves the whole series.
+ *
+ * The form is showing one occurrence, so its start is that occurrence's — sending it as the
+ * master's would drag the anchor onto this week and re-base every date after it. What carries over
+ * is the difference the reader made, applied to the master's own start: no edit moves nothing, and
+ * an edit moves the series by exactly what they changed, as every other calendar does.
+ *
+ * A JSCalendar `start` is a wall clock with no offset, and the master keeps its own zone, so the
+ * arithmetic runs in UTC — in the browser's zone a DST boundary would add an hour of its own.
+ */
+export const shiftedMasterStart = (masterStart: string, opened: Dayjs, edited: Dayjs): string =>
+	dayjs
+		.utc(masterStart)
+		.add(edited.diff(opened, 'minute'), 'minute')
+		.format('YYYY-MM-DD[T]HH:mm:ss')


### PR DESCRIPTION
Three things in the event modal, all reported from use.

## A recurring event's time can't be changed

Changing the time on a recurring event and saving put it straight back where it was. `EventModal.vue`, saving a series from one of its occurrences:

```js
if (selectedEvent.calendarEvent?.recurrence_id && !isUpdateInstance.value) {
	params.start = selectedEvent.calendarEvent.master_start
	…
}
```

The edited start is overwritten with the master's existing one, unconditionally. The save goes through and everything else lands — title, description, participants — so the time is the one field that silently doesn't. The event redraws at whatever the series already had; for the event this was reported on that's midnight, so it reads as "goes back to 12:00 am" however many times you try.

Reproduced against Stalwart on a local bench: a weekly 15:00 series, second occurrence opened, the modal's exact "All events" payload sent. Master start before `2026-09-07T15:00:00`, after `2026-09-07T15:00:00`. `master_start` was present and correct throughout — the value is just discarded. "This event only" is unaffected: that path skips the clobber and the patch diff picks the start up.

The line was guarding something real. `eventParams.start` is *this occurrence's* start, so sending it as the master's would drag the series anchor onto that week and re-base every date after it. It just threw away deliberate edits along with accidental ones.

What carries over now is the shift the reader made, applied to the master's own start. No edit is a shift of zero, so the anchor still passes through untouched and today's behaviour is preserved exactly; an edit moves the whole series by that much. The master keeps its own zone, and the arithmetic runs in UTC so a DST boundary in the browser's zone can't add an hour of its own. An unresolved master (no `master_start`) is left exactly as it was rather than given a start of the occurrence's, or of now — that event is already past saving, since the update is addressed by `master_id` too.

Same series after, moved 15:00 → 17:00 from its second occurrence:

```
MASTER after:      2026-09-07T17:00:00
OCCURRENCES after: 2026-09-07T17:00, 2026-09-14T17:00, 2026-09-21T17:00, 2026-09-28T17:00
```

## Turning All Day off leaves Save disabled

On any *saved* all-day event, unticking All Day greys Save out with nothing on screen saying why — the button is disabled, so the "end after the start" message never fires.

Its duration counts whole days, so it reads back as midnight at both ends of the same date (the end is exclusive; taking the last day off lands it back on the start). All Day hides that. Turn it off and those midnights become the range, and a zero-length range is exactly what `isDateTimeValid` refuses.

It now takes the slot a new event on that day would get — next full hour today, ten in the morning otherwise, one rule shared with the defaults. Only the start is set: the end is dragged along by the existing start watcher, which reads a gap of zero and falls back to the default hour. Setting the end here too would fight that watcher, which would measure the new end against the old midnight start and push it out to nine in the evening. A range that already spans days is a real one and keeps its own hours.

## The title only answered where the words were

The title row carried the click and the pointer cursor but hugged its content, so everything right of the words was dead — and an empty title is "Add title", a short grey word with the rest of the column beside it looking like the same field. The row runs the width of the column now. The pencil still sits against the title (the grid is sized by its mirror span, not by the row), and the underline still spans the title alone, since the input carries it and is only as wide as its text.

## Testing

`shiftedMasterStart` is a pure helper in `utils/datetime.ts`, tested alongside the existing zone helpers: untouched time leaves the anchor alone, a time change moves the series without moving it to the occurrence, backwards across midnight, a date change carried through as the same shift, and a DST boundary that must not gain an hour. Calendar suite green (64), production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPDdovnpyUjuV1PEWXBHbL