### PR TITLE
test(drive): keep the broken-file-log compensation test off stderr

### DIFF
--- a/suite/drive/webdav/tests/test_put_get.py
+++ b/suite/drive/webdav/tests/test_put_get.py
@@ -512,6 +512,8 @@ class TestWebDAVPut(IntegrationTestCase):
         # the file log sits on the very disk that may have failed the
         # promotion — a failure opening or writing it must not gate the
         # database record or the queued repair, which ride other services
+        import contextlib
+        import io
         from unittest.mock import patch
 
         from suite.drive.webdav import put as put_module
@@ -537,6 +539,7 @@ class TestWebDAVPut(IntegrationTestCase):
             patch.object(put_module, "apply_file_size_delta", side_effect=frappe.QueryTimeoutError),
             patch("frappe.logger", side_effect=broken_drive_logger),
             patch("frappe.enqueue") as enqueue_mock,
+            contextlib.redirect_stderr(io.StringIO()),  # the stderr rung fires; keep it off the runner's console
             self.assertRaises(OSError),
         ):
             frappe.db.commit()

--- a/suite/drive/webdav/tests/test_put_get.py
+++ b/suite/drive/webdav/tests/test_put_get.py
@@ -539,7 +539,8 @@ class TestWebDAVPut(IntegrationTestCase):
             patch.object(put_module, "apply_file_size_delta", side_effect=frappe.QueryTimeoutError),
             patch("frappe.logger", side_effect=broken_drive_logger),
             patch("frappe.enqueue") as enqueue_mock,
-            contextlib.redirect_stderr(io.StringIO()),  # the stderr rung fires; keep it off the runner's console
+            # the stderr rung fires; keep it off the runner's console
+            contextlib.redirect_stderr(io.StringIO()),
             self.assertRaises(OSError),
         ):
             frappe.db.commit()


### PR DESCRIPTION
## Summary
- `test_put_compensation_survives_a_broken_file_log` deliberately breaks the `drive` logger, so `_file_log` falls back to printing the full drift traceback and repair spec to stderr. On CI that print landed in the runner's console mid-dots, looking like a hidden failure even though the test passes.
- Wrap the failure block in `contextlib.redirect_stderr(io.StringIO())`, the same capture the sibling `test_put_compensation_spec_reaches_stderr_when_all_else_fails` already uses. No production code changes; the Error Log and enqueue assertions are unchanged.

## Test plan
- `bench --site <site> run-tests --module suite.drive.webdav.tests.test_put_get --test test_put_compensation_survives_a_broken_file_log --test test_put_compensation_spec_reaches_stderr_when_all_else_fails` passes locally with no traceback in the console.
- CI backend tests should run green without the `drive.webdav: File ...: metadata left ahead of bytes after failed promotion` block in the output.