### PR TITLE
fix(frontend): align writer and sheets navbars

### DIFF
--- a/frontend/src/apps/drive/components/EditableBreadcrumbs.vue
+++ b/frontend/src/apps/drive/components/EditableBreadcrumbs.vue
@@ -10,7 +10,7 @@
         <Breadcrumbs :items="parentItems" />
         <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
       </template>
-      <InlineRenameInput :entity="entity" class="text-md-medium" />
+      <InlineRenameInput :entity="entity" appearance="breadcrumb" />
     </template>
     <Breadcrumbs v-else :items="displayItems" />
   </div>

--- a/frontend/src/apps/drive/components/InlineRenameInput.vue
+++ b/frontend/src/apps/drive/components/InlineRenameInput.vue
@@ -7,8 +7,10 @@
     spellcheck="false"
     style="field-sizing: content"
     :class="[
-      'min-w-[4ch] max-w-full rounded-1 bg-surface-base px-1.5 py-0.5 text-ink-gray-9 border border-outline-gray-2 outline-none focus:border-outline-gray-4 focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none',
-      $attrs.class || 'text-base',
+      appearance === 'breadcrumb'
+        ? 'min-w-[4ch] max-w-full rounded-1 border-0 bg-surface-base px-0.5 py-1 text-lg-medium text-ink-gray-9 shadow-[inset_0_0_0_1px_var(--outline-gray-4)] outline-none focus:outline-none focus:ring-0 focus-visible:outline-none'
+        : 'min-w-[4ch] max-w-full rounded-1 border border-outline-gray-2 bg-surface-base px-1.5 py-0.5 text-ink-gray-9 outline-none focus:border-outline-gray-4 focus:outline-none focus:ring-0 focus:shadow-none focus-visible:outline-none',
+      $attrs.class || (appearance === 'breadcrumb' ? '' : 'text-base'),
     ]"
     @click.stop
     @mousedown.stop
@@ -34,6 +36,7 @@ const props = defineProps({
   entity: Object,
   modelValue: String,
   editing: { type: Boolean, default: undefined },
+  appearance: { type: String, default: 'default' },
 })
 const emit = defineEmits(['update:modelValue', 'submit', 'cancel', 'blur'])
 

--- a/frontend/src/apps/drive/components/InlineRenameInput.vue
+++ b/frontend/src/apps/drive/components/InlineRenameInput.vue
@@ -2,7 +2,7 @@
   <input
     v-if="isEditing"
     ref="input"
-    v-model="draft"
+    v-model="value"
     type="text"
     spellcheck="false"
     style="field-sizing: content"
@@ -16,34 +16,62 @@
     @keydown.stop
     @keyup.stop
     @keyup.space.prevent
-    @keydown.enter.prevent="submit"
-    @keydown.escape.prevent="cancel"
-    @focus="selectBaseName"
-    @blur="blur"
+    @keydown.enter.prevent="submitValue"
+    @keydown.escape.prevent="cancelValue"
+    @focus="selectValue"
+    @blur="blurValue"
   />
   <slot v-else />
 </template>
 <script setup>
-import { computed, onMounted, watch } from 'vue'
+import { computed, nextTick, onMounted, watch } from 'vue'
 import { renamingEntity } from '@/apps/drive/data/selection'
 import { useInlineRename } from '@/apps/drive/utils/useInlineRename'
 
 defineOptions({ inheritAttrs: false })
 
-const props = defineProps({ entity: Object })
+const props = defineProps({
+  entity: Object,
+  modelValue: String,
+  editing: { type: Boolean, default: undefined },
+})
+const emit = defineEmits(['update:modelValue', 'submit', 'cancel', 'blur'])
 
 const { draft, input, start, submit, blur, selectBaseName, cancel } = useInlineRename(
   () => props.entity,
 )
-const isEditing = computed(() => renamingEntity.value === props.entity?.name)
+const isControlled = computed(() => props.editing !== undefined)
+const isEditing = computed(() =>
+  isControlled.value ? props.editing : renamingEntity.value === props.entity?.name,
+)
+const value = computed({
+  get: () => (isControlled.value ? props.modelValue ?? '' : draft.value),
+  set: (value) => isControlled.value ? emit('update:modelValue', value) : (draft.value = value),
+})
+
+function startEditing() {
+  if (!isControlled.value) {
+    start()
+    return
+  }
+  nextTick(() => {
+    input.value?.focus()
+    input.value?.select()
+  })
+}
+
+const submitValue = () => isControlled.value ? emit('submit') : submit()
+const cancelValue = () => isControlled.value ? emit('cancel') : cancel()
+const blurValue = () => isControlled.value ? emit('blur') : blur()
+const selectValue = () => isControlled.value ? input.value?.select() : selectBaseName()
 
 // List/grid rows keep this component mounted and toggle isEditing, so the watch
 // catches the transition. The breadcrumb only renders it while editing, so it
 // mounts already-editing — onMounted handles that case.
 watch(isEditing, (editing) => {
-  if (editing) start()
+  if (editing) startEditing()
 })
 onMounted(() => {
-  if (isEditing.value) start()
+  if (isEditing.value) startEditing()
 })
 </script>

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -3902,8 +3902,6 @@ function cancelTitleEditing() {
   isTitleEditing.value = false
 }
 
-watch(isSaving, (cur, prev) => { if (prev && !cur && !saveError.value) isDirty.value = false })
-
 function onSave() { _doAutoSave() }
 
 // ── Formula bar ───────────────────────────────────────────────────────────────

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -46,25 +46,22 @@
           </template>
         </Dropdown>
         <Breadcrumbs v-if="!isTitleEditing" :items="sheetBreadcrumbs" />
-        <!-- Auto-sizing title. A hidden ::after pseudo mirrors the text and
-             sizes the box via real DOM text layout, so the input grows
-             pixel-perfect and smooth per keystroke, with no JS canvas measuring
-             and no width animation lagging behind the caret. -->
         <template v-else>
-          <Breadcrumbs :items="sheetHomeBreadcrumbs" />
-          <span class="text-base text-ink-gray-4" aria-hidden="true">/</span>
-          <span class="sn-title-fit" :data-value="currentTitle || 'Untitled Sheet'">
-          <input
-            ref="titleInputRef"
-            name="sheet-title"
-            class="sn-title-input"
-            v-model="currentTitle"
-            placeholder="Untitled Sheet"
-            spellcheck="false"
-            @blur="finishTitleEditing"
-            @keydown.enter="titleInputRef?.blur()"
-          />
-          </span>
+          <div class="flex min-w-0 items-center">
+            <Breadcrumbs class="sn-parent-breadcrumb" :items="sheetHomeBreadcrumbs" />
+            <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
+            <input
+              ref="titleInputRef"
+              name="sheet-title"
+              class="min-w-[4ch] max-w-[520px] rounded-4 border border-outline-gray-4 bg-surface-base px-0.5 py-1 text-lg-medium text-ink-gray-9 outline-none"
+              style="field-sizing: content"
+              v-model="currentTitle"
+              placeholder="Untitled Sheet"
+              spellcheck="false"
+              @blur="finishTitleEditing"
+              @keydown.enter="titleInputRef?.blur()"
+            />
+          </div>
         </template>
         <!-- Save status — muted inline text; never competes with the title -->
         <span v-if="isSaving" class="sn-save-status">
@@ -6072,31 +6069,14 @@ function toggleShowFormulas() {
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
 .sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }
+.sn-parent-breadcrumb :deep(a) { color:var(--ink-gray-5); }
 
-/* Auto-sizing title. A hidden ::after mirror carries the exact same typography
-   and box as the input; being normal flow, ITS width sizes the wrapper to the
-   real rendered text. The input is positioned absolutely on top so its own
+/*
    intrinsic ~20ch width is taken out of the layout — otherwise it, not the
    text, would dictate the box. Result: the box hugs the text and grows smoothly
    per keystroke, with no width animation lagging the caret and no canvas
    measurement drifting from actual metrics. min/max-width keep the old
    click-target floor and runaway-title ceiling. */
-.sn-title-fit { position:relative; display:inline-block; min-width:56px; max-width:520px; }
-.sn-title-fit::after {
-  content:attr(data-value) ' ';
-  display:block;
-  visibility:hidden;
-  white-space:pre;
-  box-sizing:border-box;
-  height:32px; border:1px solid transparent; padding:0 10px;
-  max-width:520px; overflow:hidden;
-  font-size:15px; font-weight:600; font-family:inherit; letter-spacing:-.005em;
-}
-.sn-title-input { position:absolute; inset:0; box-sizing:border-box; width:100%; height:100%; border:1px solid transparent; border-radius:6px; padding:0 10px; font-size:15px; font-weight:600; color:var(--ink-gray-9); background:transparent; outline:none; font-family:inherit; letter-spacing:-.005em; transition:background-color .12s, border-color .12s; }
-
-.sn-title-input:hover { background:var(--surface-gray-2); }
-.sn-title-input:focus { border-color:var(--outline-gray-4); background:var(--surface-base); box-shadow:0 0 0 2px rgba(23,23,23,.10); }
-
 /* Hairline between action buttons and avatar — groups the cluster without
    relying on extra padding. */
 .sn-topbar-divider { width:1px; height:20px; background:var(--outline-gray-2); margin:0 4px; flex-shrink:0; }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -50,16 +50,13 @@
           <div class="flex min-w-0 items-center">
             <Breadcrumbs class="sn-parent-breadcrumb" :items="sheetHomeBreadcrumbs" />
             <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
-            <input
-              ref="titleInputRef"
-              name="sheet-title"
-              class="min-w-[4ch] max-w-[520px] rounded-4 border border-outline-gray-4 bg-surface-base px-0.5 py-1 text-lg-medium text-ink-gray-9 outline-none"
-              style="field-sizing: content"
+            <InlineRenameInput
               v-model="currentTitle"
-              placeholder="Untitled Sheet"
-              spellcheck="false"
+              :editing="isTitleEditing"
+              class="max-w-[520px] text-lg-medium"
+              @submit="finishTitleEditing"
+              @cancel="cancelTitleEditing"
               @blur="finishTitleEditing"
-              @keydown.enter="titleInputRef?.blur()"
             />
           </div>
         </template>
@@ -1328,6 +1325,7 @@ import { createChartEngine } from '../../engine/charts.js'
 import { useChartIntegration } from './useChartIntegration.js'
 import ChartDialog             from './ChartDialog.vue'
 import ChartOverlay            from './ChartOverlay.vue'
+import InlineRenameInput       from '@/apps/drive/components/InlineRenameInput.vue'
 import { createNamedRanges }   from '../../engine/named-ranges.js'
 import { getFunctionNames }    from '../../engine/formula.js'
 import NamedRangesDialog       from './NamedRangesDialog.vue'
@@ -1354,7 +1352,6 @@ const appsMenuOption = useAppSwitcher('sheets', async () => {
 })
 const themeMenuOption = useThemeMenuOption()
 const isTitleEditing = ref(false)
-const titleInputRef = ref(null)
 const sheetHomeBreadcrumbs = computed(() => [
   { label: 'Sheets', href: '/sheets', onClick: flushAndClose },
 ])
@@ -3861,15 +3858,16 @@ let _titleAtFocus = ''
 function startTitleEditing() {
   _titleAtFocus = currentTitle.value
   isTitleEditing.value = true
-  nextTick(() => {
-    titleInputRef.value?.focus()
-    titleInputRef.value?.select()
-  })
 }
 function finishTitleEditing() {
+  if (!isTitleEditing.value) return
   if (currentTitle.value !== _titleAtFocus) isDirty.value = true
   isTitleEditing.value = false
   _triggerAutoSave()
+}
+function cancelTitleEditing() {
+  currentTitle.value = _titleAtFocus
+  isTitleEditing.value = false
 }
 
 watch(isSaving, (cur, prev) => { if (prev && !cur && !saveError.value) isDirty.value = false })

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -53,7 +53,8 @@
             <InlineRenameInput
               v-model="currentTitle"
               :editing="isTitleEditing"
-              class="max-w-[520px] text-lg-medium"
+              appearance="breadcrumb"
+              class="max-w-[520px]"
               @submit="finishTitleEditing"
               @cancel="cancelTitleEditing"
               @blur="finishTitleEditing"

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -32,35 +32,37 @@
     <!-- Bar 1 · Identity -->
     <div class="sn-topbar">
       <div class="sn-topbar-left">
-        <Dropdown :options="brandMenuOptions" :offset="16">
-          <template #default="{ open }">
-            <div class="sn-app-menu-trigger" aria-label="Open Sheets menu" title="Open Sheets menu">
-              <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 118 118" fill="none" aria-hidden="true">
-                <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
-                <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
-                <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
-                <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
-              </svg>
-              <FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="size-4 text-ink-gray-7" />
+        <div class="sn-identity">
+          <Dropdown :options="brandMenuOptions" :offset="16">
+            <template #default="{ open }">
+              <div class="sn-app-menu-trigger" aria-label="Open Sheets menu" title="Open Sheets menu">
+                <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 118 118" fill="none" aria-hidden="true">
+                  <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
+                  <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
+                  <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
+                  <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
+                </svg>
+                <FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="size-4 text-ink-gray-7" />
+              </div>
+            </template>
+          </Dropdown>
+          <Breadcrumbs v-if="!isTitleEditing" :items="sheetBreadcrumbs" />
+          <template v-else>
+            <div class="flex min-w-0 items-center">
+              <Breadcrumbs class="sn-parent-breadcrumb" :items="sheetHomeBreadcrumbs" />
+              <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
+              <InlineRenameInput
+                v-model="currentTitle"
+                :editing="isTitleEditing"
+                appearance="breadcrumb"
+                class="max-w-[520px]"
+                @submit="finishTitleEditing"
+                @cancel="cancelTitleEditing"
+                @blur="finishTitleEditing"
+              />
             </div>
           </template>
-        </Dropdown>
-        <Breadcrumbs v-if="!isTitleEditing" :items="sheetBreadcrumbs" />
-        <template v-else>
-          <div class="flex min-w-0 items-center">
-            <Breadcrumbs class="sn-parent-breadcrumb" :items="sheetHomeBreadcrumbs" />
-            <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
-            <InlineRenameInput
-              v-model="currentTitle"
-              :editing="isTitleEditing"
-              appearance="breadcrumb"
-              class="max-w-[520px]"
-              @submit="finishTitleEditing"
-              @cancel="cancelTitleEditing"
-              @blur="finishTitleEditing"
-            />
-          </div>
-        </template>
+        </div>
         <!-- Save status — muted inline text; never competes with the title -->
         <span v-if="isSaving" class="sn-save-status">
           <FeatherIcon name="loader" class="sn-save-icon sn-save-spin" />
@@ -6065,6 +6067,7 @@ function toggleShowFormulas() {
    (gap:12) so the title reads as the focal point, not crowded by badges. */
 .sn-topbar-left  { display:flex; align-items:center; gap:8px; min-width:0; }
 .sn-topbar-right { display:flex; align-items:center; gap:6px; flex-shrink:0; }
+.sn-identity { display:flex; min-width:0; align-items:center; }
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
 .sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1265,7 +1265,7 @@
 </template>
 
 <script setup>
-import { h, ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
+import { h, ref, reactive, computed, customRef, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import { createGrid }          from '../../canvas/index.js'
 import { COL_HEADER_H, ROW_HEADER_W } from '../../canvas/constants.js'
 import { colLabel, parseCellId, cellId } from '../../utils/cells.js'
@@ -1729,7 +1729,22 @@ const hasActiveHyperlink   = computed(() => !!activeFormat.value?.hyperlink)
 const showFormulas      = ref(false)
 
 const selectionStats    = ref(null)
-const isDirty           = ref(false)
+let _dirtyRevision = 0
+const isDirty = customRef((track, trigger) => {
+  let value = false
+  return {
+    get() {
+      track()
+      return value
+    },
+    set(next) {
+      if (next) _dirtyRevision += 1
+      if (next === value) return
+      value = next
+      trigger()
+    },
+  }
+})
 const isPaintingFormat  = ref(false)
 
 // ── Comment UI state ──────────────────────────────────────────────────────────
@@ -3500,6 +3515,8 @@ function onBeforeUnloadGuard(e) {
 }
 
 let _autoSaveTimer = null
+let _savePromise = null
+let _pendingSaveBatch = null
 
 // Operation queue — populated by _queueOp() at write sites (paste, fill,
 // import, cell edit, etc.).  Flushed after each successful save so each
@@ -3780,6 +3797,7 @@ function _triggerAutoSave() {
 }
 
 async function _doAutoSave() {
+  if (_savePromise) await _savePromise
   if (!isDirty.value) return
   // Backstop: a viewer should never reach save_sheet (which would throw
   // PermissionError). The input layer already blocks their edits, so isDirty
@@ -3790,22 +3808,33 @@ async function _doAutoSave() {
   // bootstrap save failed for any reason, leave it to a subsequent reload
   // rather than spamming the server on every typed character.
   if (props.id === 'new') return
+  isDirty.value = false
   // Drain queued ops BEFORE the save so the batch lands atomically with the
   // implicit `save` op and keeps the canonical user-action ordering intact.
-  const { ops, count } = _opsForSave()
-  await saveExisting(props.id, currentTitle.value, { ops })
-  if (!saveError.value) {
-    _opQueue.splice(0, count)
-    isDirty.value   = false
-    justSaved.value = true
-    setTimeout(() => { justSaved.value = false }, 2500)
+  const batch = _pendingSaveBatch || { ..._opsForSave(), revision: _dirtyRevision }
+  _pendingSaveBatch = batch
+  _savePromise = _pendingSaveBatch.failed
+    ? retrySave()
+    : saveExisting(props.id, currentTitle.value, { ops: batch.ops })
+  await _savePromise
+  _savePromise = null
+  if (saveError.value) {
+    batch.failed = true
+    isDirty.value = true
+    return
   }
+  _opQueue.splice(0, batch.count)
+  _pendingSaveBatch = null
+  isDirty.value = _dirtyRevision > batch.revision
+  justSaved.value = true
+  setTimeout(() => { justSaved.value = false }, 2500)
 }
 
 async function flushSave() {
-  if (!isDirty.value) return
   clearTimeout(_autoSaveTimer)
-  await _doAutoSave()
+  do {
+    await _doAutoSave()
+  } while (isDirty.value && !saveError.value)
 }
 
 // Manual retry handler — bound to the refresh button next to the

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -45,25 +45,27 @@
             </div>
           </template>
         </Dropdown>
-        <div class="sn-breadcrumb">
-          <button type="button" class="sn-breadcrumb-home" @click="flushAndClose">Sheets</button>
-          <FeatherIcon name="chevron-right" class="size-4 text-ink-gray-5" />
-        </div>
+        <Breadcrumbs v-if="!isTitleEditing" :items="sheetBreadcrumbs" />
         <!-- Auto-sizing title. A hidden ::after pseudo mirrors the text and
              sizes the box via real DOM text layout, so the input grows
              pixel-perfect and smooth per keystroke, with no JS canvas measuring
              and no width animation lagging behind the caret. -->
-        <span class="sn-title-fit" :data-value="currentTitle || 'Untitled Sheet'">
+        <template v-else>
+          <Breadcrumbs :items="sheetHomeBreadcrumbs" />
+          <span class="text-base text-ink-gray-4" aria-hidden="true">/</span>
+          <span class="sn-title-fit" :data-value="currentTitle || 'Untitled Sheet'">
           <input
+            ref="titleInputRef"
             name="sheet-title"
             class="sn-title-input"
             v-model="currentTitle"
             placeholder="Untitled Sheet"
             spellcheck="false"
-            @focus="onTitleFocus"
-            @blur="onTitleBlur"
+            @blur="finishTitleEditing"
+            @keydown.enter="titleInputRef?.blur()"
           />
-        </span>
+          </span>
+        </template>
         <!-- Save status — muted inline text; never competes with the title -->
         <span v-if="isSaving" class="sn-save-status">
           <FeatherIcon name="loader" class="sn-save-icon sn-save-spin" />
@@ -1335,7 +1337,7 @@ import NamedRangesDialog       from './NamedRangesDialog.vue'
 import { useSmartFill }        from './useSmartFill.js'
 import * as versionsApi        from '../../services/versions.js'
 import {
-   Avatar, Badge, Button, Checkbox, Dialog, Dropdown, FormControl, KeyboardShortcut, KeyboardShortcutsDialog, Spinner, TextInput, Tooltip } from 'frappe-ui'
+   Avatar, Badge, Breadcrumbs, Button, Checkbox, Dialog, Dropdown, FormControl, KeyboardShortcut, KeyboardShortcutsDialog, Spinner, TextInput, Tooltip } from 'frappe-ui'
 import {
   CommandPalette,
   CommandPaletteEmpty,
@@ -1354,6 +1356,15 @@ const appsMenuOption = useAppSwitcher('sheets', async () => {
   return !saveError.value
 })
 const themeMenuOption = useThemeMenuOption()
+const isTitleEditing = ref(false)
+const titleInputRef = ref(null)
+const sheetHomeBreadcrumbs = computed(() => [
+  { label: 'Sheets', href: '/sheets', onClick: flushAndClose },
+])
+const sheetBreadcrumbs = computed(() => [
+  ...sheetHomeBreadcrumbs.value,
+  { label: currentTitle.value || 'Untitled Sheet', onClick: startTitleEditing },
+])
 const brandMenuOptions = computed(() => [
   {
     group: '',
@@ -3736,13 +3747,12 @@ function _diffRefs(before, after) {
 // the server returns an HTML 413 instead of JSON.
 const _MAX_OP_PAYLOAD_BYTES = 64 * 1024
 
-// Drains the queue and returns the ops as a single batch shaped for the
-// versioning save endpoint. We hand this directly to `saveExisting` so the
-// server allocates one contiguous block of op-log seqs in user-action order.
-function _drainOpsForSave() {
-	if (!_opQueue.length || props.id === 'new') return []
-	const batch = _opQueue.splice(0, _opQueue.length)
-	return batch.map(_serialiseOp)
+// Snapshot the queue without removing entries. They are removed only after the
+// save succeeds, so a failed save can retry without losing operation history.
+function _opsForSave() {
+	if (!_opQueue.length || props.id === 'new') return { ops: [], count: 0 }
+	const batch = _opQueue.slice()
+	return { ops: batch.map(_serialiseOp), count: batch.length }
 }
 
 function _serialiseOp(op) {
@@ -3785,9 +3795,10 @@ async function _doAutoSave() {
   if (props.id === 'new') return
   // Drain queued ops BEFORE the save so the batch lands atomically with the
   // implicit `save` op and keeps the canonical user-action ordering intact.
-  const ops = _drainOpsForSave()
+  const { ops, count } = _opsForSave()
   await saveExisting(props.id, currentTitle.value, { ops })
   if (!saveError.value) {
+    _opQueue.splice(0, count)
     isDirty.value   = false
     justSaved.value = true
     setTimeout(() => { justSaved.value = false }, 2500)
@@ -3850,9 +3861,17 @@ watch(showSortFilter, () => { grid?.render?.() })
 // → `flushSave` did the same. Snapshotting on focus avoids spurious saves
 // when the user just clicks into and out of the field without typing.
 let _titleAtFocus = ''
-function onTitleFocus() { _titleAtFocus = currentTitle.value }
-function onTitleBlur() {
+function startTitleEditing() {
+  _titleAtFocus = currentTitle.value
+  isTitleEditing.value = true
+  nextTick(() => {
+    titleInputRef.value?.focus()
+    titleInputRef.value?.select()
+  })
+}
+function finishTitleEditing() {
   if (currentTitle.value !== _titleAtFocus) isDirty.value = true
+  isTitleEditing.value = false
   _triggerAutoSave()
 }
 
@@ -6053,9 +6072,6 @@ function toggleShowFormulas() {
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
 .sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }
-.sn-breadcrumb { display:flex; align-items:center; gap:4px; flex-shrink:0; }
-.sn-breadcrumb-home { padding:0; border:0; background:transparent; color:var(--ink-gray-6); font-size:14px; cursor:pointer; }
-.sn-breadcrumb-home:hover { color:var(--ink-gray-8); }
 
 /* Auto-sizing title. A hidden ::after mirror carries the exact same typography
    and box as the input; being normal flow, ITS width sizes the wrapper to the

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -32,16 +32,19 @@
     <!-- Bar 1 · Identity -->
     <div class="sn-topbar">
       <div class="sn-topbar-left">
-        <!-- Brand mark doubles as the "back to home" action. Clicking it runs
-             flushAndClose so any pending edits are saved before navigation. -->
-        <button class="sn-app-icon-btn" type="button" aria-label="Back to home" title="Back to home" @click="flushAndClose">
-          <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 118 118" fill="none" aria-hidden="true">
-            <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
-            <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
-            <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
-            <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
-          </svg>
-        </button>
+        <Dropdown :options="brandMenuOptions" :offset="16">
+          <template #default="{ open }">
+            <div class="sn-app-menu-trigger" aria-label="Open Sheets menu" title="Open Sheets menu">
+              <svg class="sn-app-icon" width="28" height="28" viewBox="0 0 118 118" fill="none" aria-hidden="true">
+                <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
+                <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
+                <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
+                <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
+              </svg>
+              <FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="size-4 text-ink-gray-7" />
+            </div>
+          </template>
+        </Dropdown>
         <!-- Auto-sizing title. A hidden ::after pseudo mirrors the text and
              sizes the box via real DOM text layout, so the input grows
              pixel-perfect and smooth per keystroke, with no JS canvas measuring
@@ -1264,7 +1267,9 @@ import { createGrid }          from '../../canvas/index.js'
 import { COL_HEADER_H, ROW_HEADER_W } from '../../canvas/constants.js'
 import { colLabel, parseCellId, cellId } from '../../utils/cells.js'
 import { call } from '../../utils/api.js'
-import { useCurrentUser } from '@/boot/session'
+import { useCurrentUser, useSessionStore } from '@/boot/session'
+import { useAppSwitcher } from '@/composables/useAppSwitcher'
+import { useThemeMenuOption } from '@/composables/useThemeMenuOption'
 import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
@@ -1339,6 +1344,27 @@ import {
 
 const props = defineProps({ id: { type: String, default: 'new' } })
 const emit  = defineEmits(['close', 'saved'])
+const sessionStore = useSessionStore()
+const appsMenuOption = useAppSwitcher('sheets')
+const themeMenuOption = useThemeMenuOption()
+const brandMenuOptions = computed(() => [
+  {
+    group: '',
+    options: [
+      { label: 'Back to Home', icon: 'lucide-arrow-left', onClick: flushAndClose },
+      appsMenuOption.value,
+    ],
+  },
+  {
+    group: '',
+    options: [
+      themeMenuOption,
+      ...(sessionStore.isLoggedIn
+        ? [{ label: 'Log out', icon: 'lucide-log-out', onClick: () => sessionStore.logout.submit() }]
+        : []),
+    ],
+  },
+])
 
 // ── Engine instances ──────────────────────────────────────────────────────────
 
@@ -6015,21 +6041,14 @@ function toggleShowFormulas() {
 .sn-load-error-sub   { font-size: 13px; color: var(--ink-gray-6); margin: 0 0 8px; max-width: 360px; }
 
 /* ── Bar 1 · Identity / topbar ───────────────────────────────────────────── */
-.sn-topbar       { display:flex; align-items:center; justify-content:space-between; height:48px; padding:0 16px; border-bottom:1px solid var(--outline-gray-2); background:var(--surface-base); flex-shrink:0; }
+.sn-topbar       { position:relative; z-index:10; display:flex; align-items:center; justify-content:space-between; height:48px; padding:0 12px; border-bottom:1px solid var(--outline-elevation-1); background:var(--surface-elevation-1); flex-shrink:0; }
 /* Left cluster groups: brand+title tight (gap:4); status chips sit further away
    (gap:12) so the title reads as the focal point, not crowded by badges. */
 .sn-topbar-left  { display:flex; align-items:center; gap:8px; min-width:0; }
-.sn-topbar-left  > .sn-app-icon-btn + .sn-title-fit { margin-left:-8px; }
 .sn-topbar-right { display:flex; align-items:center; gap:6px; flex-shrink:0; }
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
-.sn-app-icon-btn {
-  display:inline-flex; align-items:center; justify-content:center;
-  width:36px; height:36px; padding:4px; margin:0; border:none; background:transparent; cursor:pointer;
-  border-radius:8px; transition:background-color .12s;
-}
-.sn-app-icon-btn:hover  { background:var(--surface-gray-2); }
-.sn-app-icon-btn:focus-visible { outline:2px solid var(--outline-gray-4); outline-offset:2px; }
+.sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }
 
 /* Auto-sizing title. A hidden ::after mirror carries the exact same typography
    and box as the input; being normal flow, ITS width sizes the wrapper to the

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -45,6 +45,10 @@
             </div>
           </template>
         </Dropdown>
+        <div class="sn-breadcrumb">
+          <button type="button" class="sn-breadcrumb-home" @click="flushAndClose">Sheets</button>
+          <FeatherIcon name="chevron-right" class="size-4 text-ink-gray-5" />
+        </div>
         <!-- Auto-sizing title. A hidden ::after pseudo mirrors the text and
              sizes the box via real DOM text layout, so the input grows
              pixel-perfect and smooth per keystroke, with no JS canvas measuring
@@ -1345,15 +1349,15 @@ import {
 const props = defineProps({ id: { type: String, default: 'new' } })
 const emit  = defineEmits(['close', 'saved'])
 const sessionStore = useSessionStore()
-const appsMenuOption = useAppSwitcher('sheets')
+const appsMenuOption = useAppSwitcher('sheets', async () => {
+  await flushSave()
+  return !saveError.value
+})
 const themeMenuOption = useThemeMenuOption()
 const brandMenuOptions = computed(() => [
   {
     group: '',
-    options: [
-      { label: 'Back to Home', icon: 'lucide-arrow-left', onClick: flushAndClose },
-      appsMenuOption.value,
-    ],
+    options: [appsMenuOption.value],
   },
   {
     group: '',
@@ -6049,6 +6053,9 @@ function toggleShowFormulas() {
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
 .sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }
+.sn-breadcrumb { display:flex; align-items:center; gap:4px; flex-shrink:0; }
+.sn-breadcrumb-home { padding:0; border:0; background:transparent; color:var(--ink-gray-6); font-size:14px; cursor:pointer; }
+.sn-breadcrumb-home:hover { color:var(--ink-gray-8); }
 
 /* Auto-sizing title. A hidden ::after mirror carries the exact same typography
    and box as the input; being normal flow, ITS width sizes the wrapper to the

--- a/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
+++ b/frontend/src/apps/sheets/components/SheetEditor/usePersistence.js
@@ -105,12 +105,11 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
   let _lastSaveArgs = null
   async function retrySave() {
     if (!_lastSaveArgs) return null
-    const { name, title, opts } = _lastSaveArgs
-    return _persist(name, title, opts)
+    const { args, keepalive } = _lastSaveArgs
+    return _send(args, keepalive)
   }
 
   async function _persist(name, title, { keepalive = false, ops } = {}) {
-    _lastSaveArgs = { name, title, opts: { keepalive, ops } }
     isSaving.value = true
     // Build the payload ONCE up-front. If we rebuilt on each retry the
     // snapshots could pick up mid-edit state that arrived between
@@ -143,6 +142,7 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
       args = {
         title,
         sheets_data: payload,
+        request_id: crypto.randomUUID(),
         ...(name ? { name } : {}),
         ...(ops && ops.length ? { ops: JSON.stringify(ops) } : {}),
       }
@@ -152,6 +152,12 @@ export function usePersistence({ sheet, formats, merge, comments, validation, pr
       return null
     }
 
+    _lastSaveArgs = { args, keepalive }
+    return _send(args, keepalive)
+  }
+
+  async function _send(args, keepalive) {
+    isSaving.value = true
     // keepalive saves fire from onBeforeUnmount — the browser may kill
     // the page before any backoff finishes, so don't retry them.
     const backoffMs = keepalive ? [0] : [0, 1000, 2500]

--- a/frontend/src/apps/sheets/pages/Home.vue
+++ b/frontend/src/apps/sheets/pages/Home.vue
@@ -2,17 +2,21 @@
   <div class="home">
     <!-- Top bar -->
     <div class="home-topbar">
-      <div class="home-brand">
-        <!-- Frappe Suite brand mark: green #278F5E rounded square, white
-             spreadsheet glyph. Matches the app-launcher and sheet-editor icons. -->
-        <svg width="28" height="28" viewBox="0 0 118 118" fill="none" style="flex-shrink:0">
-          <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
-          <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
-          <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
-          <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
-        </svg>
-        <span class="home-brand-name">Frappe Sheets</span>
-      </div>
+      <Dropdown :options="brandMenuOptions" :offset="16">
+        <template #default="{ open }">
+          <div class="home-brand home-brand--interactive">
+            <!-- Frappe Suite brand mark: green #278F5E rounded square, white
+                 spreadsheet glyph. Matches the app-launcher and sheet-editor icons. -->
+            <svg width="28" height="28" viewBox="0 0 118 118" fill="none" style="flex-shrink:0">
+              <path d="M93.9278 0H23.1013C10.3428 0 0 10.3428 0 23.1013V93.9278C0 106.686 10.3428 117.029 23.1013 117.029H93.9278C106.686 117.029 117.029 106.686 117.029 93.9278V23.1013C117.029 10.3428 106.686 0 93.9278 0Z" fill="#278F5E"/>
+              <path d="M77.757 25.9364H23.5215V36.437H77.757C80.6447 36.437 83.0073 38.7996 83.0073 41.6873V75.3942C83.0073 78.2818 80.6447 80.6445 77.757 80.6445H39.2724C36.3847 80.6445 34.0221 78.2818 34.0221 75.3942V50.6653H23.5215V75.3942C23.5215 84.0572 30.6094 91.1451 39.2724 91.1451H77.757C86.42 91.1451 93.5079 84.0572 93.5079 75.3942V41.6873C93.5079 33.0243 86.42 25.9364 77.757 25.9364Z" fill="white"/>
+              <path d="M53.8678 59.6958H43.3672V70.0914H53.8678V59.6958Z" fill="white"/>
+              <path d="M73.6617 50.6653H63.1611V70.1439H73.6617V50.6653Z" fill="white"/>
+            </svg>
+            <FeatherIcon :name="open ? 'chevron-up' : 'chevron-down'" class="size-4 text-ink-gray-7" />
+          </div>
+        </template>
+      </Dropdown>
       <!-- Right-aligned controls. Wrapped in an explicit container with
            `margin-left: auto` because frappe-ui 1.0-beta's TextInput
            renders extra DOM around the input — relying on margin-left
@@ -308,8 +312,30 @@ import { useRouter } from 'vue-router'
 
 import { call } from '@/apps/sheets/utils/api.js'
 import { groupSheetsByRecency, parseFrappeDatetime } from '@/apps/sheets/utils/recency-groups.js'
+import { useSessionStore } from '@/boot/session'
+import { useAppSwitcher } from '@/composables/useAppSwitcher'
+import { useThemeMenuOption } from '@/composables/useThemeMenuOption'
+import { setupTheme } from '@/utils/setupTheme'
 
 const router = useRouter()
+const sessionStore = useSessionStore()
+const appsMenuOption = useAppSwitcher('sheets')
+const themeMenuOption = useThemeMenuOption()
+
+setupTheme()
+
+const brandMenuOptions = computed(() => [
+  { group: '', options: [appsMenuOption.value] },
+  {
+    group: '',
+    options: [
+      themeMenuOption,
+      ...(sessionStore.isLoggedIn
+        ? [{ label: 'Log out', icon: 'lucide-log-out', onClick: () => sessionStore.logout.submit() }]
+        : []),
+    ],
+  },
+])
 
 // Navigate directly to the editor route (':id'); `new` is the special create id.
 function openSheet(name) {
@@ -672,20 +698,21 @@ async function duplicate(sheet) {
 .home-topbar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 0 32px;
+  gap: 8px;
+  padding: 0 12px;
   height: 48px;
-  background: var(--surface-base);
-  border-bottom: 1px solid var(--outline-gray-2);
+  background: var(--surface-elevation-1);
+  border-bottom: 1px solid var(--outline-elevation-1);
   flex-shrink: 0;
 }
 
 .home-brand {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   flex-shrink: 0;
 }
+.home-brand--interactive { cursor: pointer; }
 
 /* Right-aligned cluster: search + view toggle + New Sheet button.
    `margin-left: auto` pushes the whole group to the right edge, leaving
@@ -693,7 +720,7 @@ async function duplicate(sheet) {
 .home-topbar-right {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 8px;
   margin-left: auto;
 }
 
@@ -701,13 +728,6 @@ async function duplicate(sheet) {
 .home-search       { width: 220px; }
 .home-search :deep(input) { height: 28px; font-size: 13px; }
 .home-search-icon  { width: 13px; height: 13px; color: var(--ink-gray-5); }
-
-.home-brand-name {
-  font-size: 16px;
-  font-weight: 600;
-  letter-spacing: .01em;
-  color: var(--ink-gray-9);
-}
 
 /* Filter toolbar — sits between the topbar and content, outside any scroll
    region so it stays put in both view modes. */

--- a/frontend/src/apps/sheets/pages/SheetEditor.vue
+++ b/frontend/src/apps/sheets/pages/SheetEditor.vue
@@ -27,6 +27,9 @@ import { Dialogs } from 'frappe-ui'
 import { useRouter } from 'vue-router'
 
 import SheetEditor from '@/apps/sheets/components/SheetEditor/index.vue'
+import { setupTheme } from '@/utils/setupTheme'
+
+setupTheme()
 
 defineProps({
   // The sheet name (route param). 'new' is the special create id.

--- a/frontend/src/apps/sheets/pages/Trash.vue
+++ b/frontend/src/apps/sheets/pages/Trash.vue
@@ -71,8 +71,11 @@ import { Icon as FeatherIcon, ListView, ListRowItem } from 'frappe-ui/experiment
 import { useRouter } from 'vue-router'
 
 import { call } from '@/apps/sheets/utils/api.js'
+import { setupTheme } from '@/utils/setupTheme'
 
 const router = useRouter()
+
+setupTheme()
 
 const sheets  = ref([])
 const loading = ref(true)
@@ -167,16 +170,16 @@ async function doPurge() {
 .home-topbar {
   display: flex;
   align-items: center;
-  gap: 16px;
-  padding: 0 32px;
+  gap: 8px;
+  padding: 0 12px;
   height: 48px;
-  background: var(--surface-base);
-  border-bottom: 1px solid var(--outline-gray-2);
+  background: var(--surface-elevation-1);
+  border-bottom: 1px solid var(--outline-elevation-1);
   flex-shrink: 0;
 }
 .home-brand { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
 .home-brand-name { font-size: 16px; font-weight: 600; letter-spacing: .01em; color: var(--ink-gray-9); }
-.home-topbar-right { display: flex; align-items: center; gap: 16px; margin-left: auto; }
+.home-topbar-right { display: flex; align-items: center; gap: 8px; margin-left: auto; }
 .home-trash-note { font-size: 12px; letter-spacing: .02em; color: var(--ink-gray-5); }
 .home-body {
   flex: 1;

--- a/frontend/src/apps/writer/components/Navbar.vue
+++ b/frontend/src/apps/writer/components/Navbar.vue
@@ -3,33 +3,33 @@
     id="navbar"
     ondragstart="return false;"
     ondrop="return false;"
-    class="bg-surface-base border-b pr-3 py-2.5 h-12 flex items-center justify-between"
+    class="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-outline-elevation-1 bg-surface-elevation-1 px-3"
   >
-    <div class="pl-4 pr-1">
+    <div class="flex w-fit items-center gap-2">
       <Dropdown
-        v-if="$route.name !== 'writer-home'"
-        :options="[
-          {
-            label: 'Back to Home',
-            icon: LucideChevronLeft,
-            route: { name: 'writer-home' },
-          },
-        ]"
+        :options="navbarMenuOptions"
+        :offset="16"
       >
-        <WriterLogo class="size-7 cursor-pointer" />
+        <template #default="{ open }">
+          <div class="flex cursor-pointer items-center gap-2">
+            <WriterLogo class="size-7" />
+            <LucideChevronUp v-if="open" class="size-4 stroke-[1.5] text-ink-gray-7" />
+            <LucideChevronDown v-else class="size-4 stroke-[1.5] text-ink-gray-7" />
+          </div>
+        </template>
       </Dropdown>
-      <WriterLogo v-else class="size-7" />
     </div>
     <slot name="breadcrumbs">
       <EditableBreadcrumbs
+        v-if="route.name !== 'writer-home'"
         :items="formattedCrumbs"
         :entity="file?.doc || null"
         class="select-none truncate max-w-[80%]"
       />
     </slot>
 
-    <div class="ml-auto flex items-center gap-3">
-      <div id="navbar-content" class="flex gap-3" />
+    <div class="ml-auto flex items-center gap-2">
+      <div id="navbar-content" class="flex gap-2" />
       <slot name="content" />
       <Button
         v-if="isOffline"
@@ -112,6 +112,8 @@ import { getFileLink } from '@/apps/drive/sdk'
 import { toggleFav } from '@/apps/drive/resources/files'
 
 import { useSessionStore } from '@/boot/session'
+import { useAppSwitcher } from '@/composables/useAppSwitcher'
+import { useThemeMenuOption } from '@/composables/useThemeMenuOption'
 import emitter from '@/apps/writer/emitter'
 import { ref, computed, inject, h } from 'vue'
 import { createDocument, apps } from '@/apps/writer/resources/'
@@ -150,7 +152,8 @@ import LucideHistory from '~icons/lucide/history'
 import LucideLayoutTemplate from '~icons/lucide/layout-template'
 import LucideMarkdown from '~icons/lucide/pilcrow'
 import LucideWifiOff from '~icons/lucide/wifi-off'
-import LucideChevronLeft from '~icons/lucide/chevron-left'
+import LucideChevronUp from '~icons/lucide/chevron-up'
+import LucideChevronDown from '~icons/lucide/chevron-down'
 
 import WriterLogo from './WriterLogo.vue'
 import { useRoute } from 'vue-router'
@@ -217,11 +220,32 @@ const exportDocx = () => {
 }
 
 const route = useRoute()
+const sessionStore = useSessionStore()
+const appsMenuOption = useAppSwitcher('writer')
+const themeMenuOption = useThemeMenuOption()
+const navbarMenuOptions = computed(() => [
+  {
+    group: '',
+    options: [appsMenuOption.value],
+  },
+  {
+    group: '',
+    options: [
+      themeMenuOption,
+      ...(sessionStore.isLoggedIn
+        ? [
+            {
+              label: 'Log out',
+              icon: 'lucide-log-out',
+              onClick: () => sessionStore.logout.submit(),
+            },
+          ]
+        : []),
+    ],
+  },
+])
 const formattedCrumbs = computed(() => {
-  const ORIG =
-    route.name === 'writer-home'
-      ? { label: 'Writer', href: '/writer' }
-      : { label: 'Drive', href: '/drive' }
+  const ORIG = { label: 'Writer', href: '/writer' }
   if (!props.breadcrumbs.length) return [ORIG]
   return [
     ORIG,

--- a/frontend/src/apps/writer/components/ToCMobile.vue
+++ b/frontend/src/apps/writer/components/ToCMobile.vue
@@ -32,6 +32,7 @@ const setBarHeight = (height) =>
   )
 
 let observer
+let editorDom
 watchEffect(() => {
   observer?.disconnect()
   if (!bar.value) return setBarHeight(0)
@@ -63,13 +64,14 @@ onMounted(() => {
   updateTabs()
   activeTabId.value = props.editor.storage.tab?.activeTabId ?? activeTabId.value
   props.editor.on('update', updateTabs)
-  props.editor.view.dom.addEventListener('tab-changed', handleTabChange)
+  editorDom = props.editor.view.dom
+  editorDom.addEventListener('tab-changed', handleTabChange)
 })
 
 onBeforeUnmount(() => {
   observer?.disconnect()
   setBarHeight(0)
   props.editor.off('update', updateTabs)
-  props.editor.view.dom.removeEventListener('tab-changed', handleTabChange)
+  editorDom?.removeEventListener('tab-changed', handleTabChange)
 })
 </script>

--- a/frontend/src/composables/useAppSwitcher.ts
+++ b/frontend/src/composables/useAppSwitcher.ts
@@ -4,7 +4,10 @@ import { useRouter } from 'vue-router'
 import { getAppSwitcherItems } from '@/apps/registry'
 import { translate as __ } from '@/boot/translation'
 
-export function useAppSwitcher(currentAppId: string) {
+export function useAppSwitcher(
+	currentAppId: string,
+	beforeNavigate?: () => boolean | void | Promise<boolean | void>,
+) {
 	const router = useRouter()
 
 	return computed(() => ({
@@ -13,8 +16,10 @@ export function useAppSwitcher(currentAppId: string) {
 		submenu: getAppSwitcherItems(currentAppId).map((app) => ({
 			label: app.title,
 			icon: h('img', { src: app.logo, class: '!size-6' }),
-			onClick: () =>
-				app.spa ? router.push(app.route) : window.location.assign(app.route),
+			onClick: async () => {
+				if ((await beforeNavigate?.()) === false) return
+				app.spa ? router.push(app.route) : window.location.assign(app.route)
+			},
 		})),
 	}))
 }

--- a/suite/sheets/api.py
+++ b/suite/sheets/api.py
@@ -387,12 +387,19 @@ def save_sheet(
     sheets_data: str,
     name: str = "",
     ops: str = "",
+    request_id: str = "",
 ) -> dict:
     # Delegates to versioning.save — appends a batch of ops + the implicit
     # save op atomically, advances head_seq, enqueues an async snapshot.
     # Returns {"name": <sheet_id>, "head_seq": <int>} so the caller knows
     # where its ops landed in the canonical order.
-    return save_mod.save_sheet(title, sheets_data, name or None, ops or None)
+    return save_mod.save_sheet(
+        title,
+        sheets_data,
+        name or None,
+        ops or None,
+        request_id=request_id or None,
+    )
 
 
 @frappe.whitelist()

--- a/suite/sheets/doctype/sheet_op_log/sheet_op_log.json
+++ b/suite/sheets/doctype/sheet_op_log/sheet_op_log.json
@@ -13,7 +13,8 @@
   "before_json",
   "after_json",
   "summary",
-  "actor"
+  "actor",
+  "request_id"
  ],
  "fields": [
   {
@@ -69,6 +70,12 @@
    "fieldtype": "Link",
    "label": "Actor",
    "options": "User"
+  },
+  {
+   "fieldname": "request_id",
+   "fieldtype": "Data",
+   "label": "Save request ID",
+   "unique": 1
   }
  ],
  "index_web_pages_for_search": 0,

--- a/suite/sheets/versioning/save.py
+++ b/suite/sheets/versioning/save.py
@@ -48,6 +48,7 @@ def save_sheet(
     name: str | None = None,
     ops: list | str | None = None,
     parent: str | None = None,
+    request_id: str | None = None,
 ) -> dict:
     """Create or update a sheet.
 
@@ -58,6 +59,12 @@ def save_sheet(
     Drive folder the new sheet's backing File should land in, passed through
     to ``Sheet.after_insert``.
     """
+    if name and request_id:
+        frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
+        completed_seq = frappe.db.get_value("Sheet Op Log", {"sheet": name, "request_id": request_id}, "seq")
+        if completed_seq is not None:
+            return {"name": name, "head_seq": int(completed_seq)}
+
     plain = _validate_payload(sheets_data)
     clean_title = _clean_title(title)
     encoded = encode_sheets_data(plain)
@@ -65,7 +72,9 @@ def save_sheet(
     ops_list = _coerce_ops(ops)
 
     if name:
-        sheet_id, head_seq = _update_existing(name, clean_title, encoded, byte_size, ops_list)
+        sheet_id, head_seq = _update_existing(
+            name, clean_title, encoded, byte_size, ops_list, request_id=request_id
+        )
     else:
         sheet_id, head_seq = _insert_new(clean_title, encoded, byte_size, ops_list, parent=parent)
 
@@ -100,13 +109,18 @@ def _insert_new(
 
 
 def _update_existing(
-    name: str, title: str, encoded: str, byte_size: int, ops_list: list[dict]
+    name: str,
+    title: str,
+    encoded: str,
+    byte_size: int,
+    ops_list: list[dict],
+    request_id: str | None = None,
 ) -> tuple[str, int]:
     frappe.has_permission("Sheet", doc=name, ptype="write", throw=True)
     # Cheap PK read so the rare rename path (below) only runs on an actual title
     # change, not on every autosave.
     old_title = frappe.db.get_value("Sheet", name, "title")
-    head_seq = _append_ops_and_save(name, ops_list, byte_size, save_op_type="save")
+    head_seq = _append_ops_and_save(name, ops_list, byte_size, save_op_type="save", request_id=request_id)
     if title != old_title:
         # The editor's inline rename rides the autosave. A title change is rare,
         # so route the whole write through the ORM: on_update then fires and Drive
@@ -130,7 +144,13 @@ def _update_existing(
     return name, head_seq
 
 
-def _append_ops_and_save(sheet: str, ops_list: list[dict], byte_size: int, save_op_type: str) -> int:
+def _append_ops_and_save(
+    sheet: str,
+    ops_list: list[dict],
+    byte_size: int,
+    save_op_type: str,
+    request_id: str | None = None,
+) -> int:
     """Append the user ops + the implicit save op as one contiguous range.
 
     Returns the final seq (the save op's seq).
@@ -150,6 +170,7 @@ def _append_ops_and_save(sheet: str, ops_list: list[dict], byte_size: int, save_
             "op_type": save_op_type,
             "summary": f"Saved ({_format_bytes(byte_size)})",
             "actor": actor,
+            "request_id": request_id,
         }
     )
     for row in rows:

--- a/suite/sheets/versioning/tests/test_save_snapshot.py
+++ b/suite/sheets/versioning/tests/test_save_snapshot.py
@@ -79,5 +79,24 @@ class InlineSnapshotFromSave(unittest.TestCase):
         self.assertIn("maybe_snapshot", log_error.call_args.kwargs["title"])
 
 
+class IdempotentSave(unittest.TestCase):
+    def test_completed_request_returns_existing_sequence_without_saving_again(self):
+        with (
+            mock.patch.object(save_mod.frappe, "has_permission") as has_permission,
+            mock.patch.object(save_mod.frappe.db, "get_value", return_value=12),
+            mock.patch.object(save_mod, "_update_existing") as update_existing,
+        ):
+            result = save_mod.save_sheet(
+                title="My Sheet",
+                sheets_data='{"A1":1}',
+                name="sheet_x",
+                request_id="request-1",
+            )
+
+        self.assertEqual(result, {"name": "sheet_x", "head_seq": 12})
+        has_permission.assert_called_once_with("Sheet", doc="sheet_x", ptype="write", throw=True)
+        update_existing.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add the shared app switcher, theme control, and account action to Writer and Sheets
- align Writer and Sheets navbar chrome with Slides
- add editable Sheets breadcrumbs and keep Writer document breadcrumbs within Writer
- flush pending Sheets edits before app navigation and avoid accessing a destroyed Writer editor view during navigation

## Screenshots

### Writer home

![Writer home navbar](https://files.catbox.moe/29g79o.png)

### Writer editor

![Writer editor navbar](https://files.catbox.moe/w9cmli.png)

### Sheets home

![Sheets home navbar](https://files.catbox.moe/j62hem.png)

### Sheets editor

![Sheets editor navbar](https:\/\/files.catbox.moe\/46kags.png)

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.9% (+0%) · Frontend 35.1% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.9%** (21,501 / 37,766) (+0%) | **29.8%** (2,894 / 9,706) (+0%) |
| Frontend | **35.1%** (14,245 / 40,588) (+0%) | **29.6%** (9,196 / 31,073) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33615681892) for commit `5a9110e`.</sub>

</details>
<!-- suite-coverage:end -->
