### PR TITLE
feat(calendar): edit one occurrence of a series

### DIFF
--- a/frontend/src/apps/calendar/components/EventDetailSidebar.vue
+++ b/frontend/src/apps/calendar/components/EventDetailSidebar.vue
@@ -24,9 +24,12 @@ import { getMeetUrl, getReorderedParticipants, isUrl } from '@/apps/calendar/uti
 import { fromEventZone, inUserTimeZone } from '@/apps/calendar/utils/datetime'
 import { eventLastDay, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
+import { scopeLabels } from '@/apps/calendar/utils/recurringScope'
+import type { RecurringScope } from '@/apps/calendar/utils/recurringScope'
 import { userStore } from '@/apps/calendar/stores/user'
 import { useEventDelete } from '@/apps/calendar/composables/useEventDelete'
 import EventParticipantList from '@/apps/calendar/components/EventParticipantList.vue'
+import RecurringScopeModal from '@/apps/calendar/components/Modals/RecurringScopeModal.vue'
 import LinkifiedText from '@/components/LinkifiedText.vue'
 
 const { calendarEvent } = defineProps<{ calendarEvent: any }>()
@@ -56,23 +59,53 @@ const RSVP_OPTIONS = [
 // event_response template when custom event invites are enabled.
 const rsvpEvent = createResource({
 	url: 'suite.calendar.api.rsvp_calendar_event',
-	makeParams: (response: string) => ({
+	makeParams: ({ response, scope }: { response: string; scope: RecurringScope }) => ({
 		account: store.accountId,
 		// master_id is only set on recurring events; fall back to the event's own id
 		id: calendarEvent.master_id || calendarEvent.id,
 		response: response.toLowerCase(),
+		// One occurrence answered on its own is an override on the series, addressed by this
+		// occurrence's recurrence id — the whole series is the same call without one.
+		recurrence_id: scope === 'instance' ? calendarEvent.recurrence_id : null,
 	}),
 	onSuccess: () => emit('reloadEvents'),
 })
 
-const handleSetResponse = (response: string) => {
-	if (!response || response === userResponse.value) return
-	toast.promise(rsvpEvent.submit(response), {
+// An occurrence of a series can be answered on its own — a standup you miss one
+// week is not a standup you have left. So the answer asks which it is; a one-off
+// has nothing to ask. The tab buttons stay where they were until the server
+// confirms, so cancelling the question leaves the shown answer alone.
+const showRsvpScopeModal = ref(false)
+const pendingResponse = ref('')
+
+const submitResponse = (response: string, scope: RecurringScope) => {
+	showRsvpScopeModal.value = false
+	toast.promise(rsvpEvent.submit({ response, scope }), {
 		loading: __('Sending response...'),
 		success: __('Response sent.'),
 		error: __('Action failed. Please try again in some time.'),
 	})
 }
+
+const handleSetResponse = (response: string) => {
+	if (!response || response === userResponse.value) return
+	if (!calendarEvent.recurrence_id) return submitResponse(response, 'series')
+	pendingResponse.value = response
+	showRsvpScopeModal.value = true
+}
+
+const rsvpScopeModalProps = computed(() => ({
+	title: __('Respond to repeating event'),
+	icon: { name: 'lucide-calendar-check' },
+	// No "this and following": splitting a series is the organizer's to do, and an
+	// attendee answering is not editing the event at all.
+	options: [
+		{ value: 'instance' as const, label: scopeLabels().instance },
+		{ value: 'series' as const, label: scopeLabels().series },
+	],
+	confirmLabel: __('Send response'),
+	loading: rsvpEvent.loading,
+}))
 
 // --- Calendar (colour + account) ---
 
@@ -277,14 +310,22 @@ const hasDetails = computed(
 
 // --- Actions dropdown (delete) ---
 
-const { deleteOption, isDeleting, showNotifyModal, pendingDelete, NOTIFY_DELETE_OPTIONS } =
-	useEventDelete(
-		() => calendarEvent,
-		() => {
-			emit('reloadEvents')
-			emit('close')
-		},
-	)
+const {
+	deleteOption,
+	isDeleting,
+	showScopeModal: showDeleteScopeModal,
+	deleteScopeModalProps,
+	deleteScope,
+	showNotifyModal,
+	pendingDelete,
+	NOTIFY_DELETE_OPTIONS,
+} = useEventDelete(
+	() => calendarEvent,
+	() => {
+		emit('reloadEvents')
+		emit('close')
+	},
+)
 
 const dropdownOptions = computed(() => [
 	{ label: __('Edit'), icon: SquarePen, onClick: () => emit('edit') },
@@ -530,6 +571,16 @@ const openUrl = (location: string) => {
 			/>
 		</div>
 
+		<RecurringScopeModal
+			v-model="showDeleteScopeModal"
+			v-bind="deleteScopeModalProps"
+			@confirm="deleteScope"
+		/>
+		<RecurringScopeModal
+			v-model="showRsvpScopeModal"
+			v-bind="rsvpScopeModalProps"
+			@confirm="(scope) => submitResponse(pendingResponse, scope)"
+		/>
 		<Dialog v-model:open="showNotifyModal" v-bind="NOTIFY_DELETE_OPTIONS">
 			<template #actions>
 				<div class="flex justify-end space-x-2">

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -1107,10 +1107,17 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 			</div>
 		</template>
 	</Dialog>
+	<!-- The dialog has always asked which of the two this should be; until now it offered only
+	     the second, and the instance branch behind the first was written and unreachable. -->
 	<Dialog v-model:open="showRecurringEventModal" v-bind="SHOW_RECURRING_EVENT_MODAL_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">
-				<Button @click="handleSaveRecurringEvent(false)">{{ __('Entire Series') }}</Button>
+				<Button variant="outline" @click="handleSaveRecurringEvent(true)">
+					{{ __('This Instance') }}
+				</Button>
+				<Button variant="solid" @click="handleSaveRecurringEvent(false)">
+					{{ __('Entire Series') }}
+				</Button>
 			</div>
 		</template>
 	</Dialog>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -30,9 +30,12 @@ import { submit as submitCall } from '@/apps/meet/utils/request'
 import { getMeetUrl, getReorderedParticipants } from '@/apps/calendar/utils'
 import { fromEventZone, fromWallClock, inUserTimeZone } from '@/apps/calendar/utils/datetime'
 import { getRepeatMessage } from '@/apps/calendar/utils/format'
+import { isFirstOccurrence, scopeOptions } from '@/apps/calendar/utils/recurringScope'
+import type { RecurringScope } from '@/apps/calendar/utils/recurringScope'
 import { userStore } from '@/apps/calendar/stores/user'
 import type { ParticipantIdentity } from '@/apps/calendar/types/doctypes'
 import { useEventDelete } from '@/apps/calendar/composables/useEventDelete'
+import RecurringScopeModal from '@/apps/calendar/components/Modals/RecurringScopeModal.vue'
 import EventAlertList from '@/apps/calendar/components/EventAlertList.vue'
 import ParticipantSelector from '@/apps/calendar/components/ParticipantSelector.vue'
 import EventRepeatSettingsModal from '@/apps/calendar/components/Modals/EventRepeatSettingsModal.vue'
@@ -218,7 +221,7 @@ const eventParams = computed(() => {
 	if (event.title) params.title = event.title
 	if (dayjs?.tz) params.time_zone = dayjs.tz.guess()
 
-	if (selectedEvent.calendarEvent?.recurrence_id && !isUpdateInstance.value) {
+	if (selectedEvent.calendarEvent?.recurrence_id && editScope.value === 'series') {
 		// The master's start passes through unchanged, so it must keep the master's zone —
 		// pairing it with the browser's would silently shift the whole series.
 		params.start = selectedEvent.calendarEvent.master_start
@@ -519,17 +522,35 @@ const createMeetLink = useCall<{ meeting_url: string }>({
 	immediate: false,
 })
 
-const isUpdateInstance = ref(false)
+// "This and following" is neither of the other two writes: JSCalendar can say "this date" or
+// "the series", so the server cuts the series in two and this edit starts the second half.
+const splitSeries = createResource({
+	url: 'suite.calendar.api.split_calendar_event_series',
+	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
+		account: store.accountId,
+		master_id: selectedEvent.calendarEvent.master_id,
+		recurrence_id: selectedEvent.calendarEvent.recurrence_id,
+		...eventParams.value,
+		send_scheduling_messages: sendEmail,
+	}),
+	onSuccess: handleSuccess,
+})
+
+// How far the save reaches. A one-off event is its own series, so nothing asks and nothing
+// else reads this.
+const editScope = ref<RecurringScope>('series')
 
 const submitEvent = (sendEmail: boolean) => {
-	const isInstance = isUpdateInstance.value && selectedEvent.calendarEvent?.recurrence_id
+	const recurring = !!selectedEvent.calendarEvent?.recurrence_id
 	const resource = isNew.value
 		? event.addMeetLink
 			? createMeetEvent
 			: createEvent
-		: isInstance
+		: recurring && editScope.value === 'instance'
 			? editEventInstance
-			: editEvent
+			: recurring && editScope.value === 'following'
+				? splitSeries
+				: editEvent
 	const messages = isDraft.value
 		? { loading: __('Sending event...'), success: __('Event sent.') }
 		: isNew.value
@@ -646,8 +667,8 @@ const handleSave = () => {
 	else submitEvent(false)
 }
 
-const handleSaveRecurringEvent = (updateInstance: boolean) => {
-	isUpdateInstance.value = updateInstance
+const handleSaveRecurringEvent = (scope: RecurringScope) => {
+	editScope.value = scope
 	showRecurringEventModal.value = false
 	handleSave()
 }
@@ -711,6 +732,9 @@ const setAllDay = (isAllDay: boolean) => {
 const {
 	deleteOption,
 	isDeleting,
+	showScopeModal: showDeleteScopeModal,
+	deleteScopeModalProps,
+	deleteScope,
 	showNotifyModal: showNotifyDeleteModal,
 	pendingDelete,
 	NOTIFY_DELETE_OPTIONS,
@@ -728,7 +752,11 @@ const eventOptions = computed(() => [deleteOption.value])
 
 const isSaving = computed(
 	() =>
-		createEvent.loading || editEvent.loading || editEventInstance.loading || createMeetEvent.loading,
+		createEvent.loading ||
+		editEvent.loading ||
+		editEventInstance.loading ||
+		splitSeries.loading ||
+		createMeetEvent.loading,
 )
 
 const disableSave = computed(() => {
@@ -753,8 +781,11 @@ const draftOptions = computed(() => [
 ])
 
 const handleSaveClick = () => {
-	if (shouldShowRecurringEventModal.value) showRecurringEventModal.value = true
-	else handleSave()
+	if (shouldShowRecurringEventModal.value) return (showRecurringEventModal.value = true)
+	// Nothing to ask, so nothing may be left over from the last time it was asked: an answer
+	// standing from an earlier event would send this one's edit somewhere it never chose.
+	editScope.value = 'series'
+	handleSave()
 }
 
 const dialogTitle = computed(() =>
@@ -788,11 +819,26 @@ const DISCARD_MODAL_OPTIONS = computed(() => ({
 		: __('Your unsaved edits to this event will be lost.'),
 }))
 
-const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
-	title: __('Update Recurring Event'),
-	icon: { name: 'lucide-repeat' },
-	message: __('Do you want to update just this instance, or all events in the series?'),
-}
+const isAttendee = computed(
+	() =>
+		!!selectedEvent?.calendarEvent?.organizer &&
+		!participantIdentities.data?.some(
+			(identity: ParticipantIdentity) =>
+				identity.email === selectedEvent.calendarEvent.organizer.replace('mailto:', ''),
+		),
+)
+
+const recurringScopeModalProps = computed(() => ({
+	title: __('Update repeating event'),
+	options: scopeOptions({
+		isFirst: isFirstOccurrence(selectedEvent?.calendarEvent),
+		// Splitting a series ends it and starts another, which is the organizer's to do:
+		// an attendee doing it would be creating an event of their own.
+		splitBlockedReason: isAttendee.value ? __('Only the organizer can split a series') : undefined,
+	}),
+	confirmLabel: __('Update'),
+	loading: isSaving.value,
+}))
 </script>
 
 <template>
@@ -1107,20 +1153,16 @@ const SHOW_RECURRING_EVENT_MODAL_OPTIONS = {
 			</div>
 		</template>
 	</Dialog>
-	<!-- The dialog has always asked which of the two this should be; until now it offered only
-	     the second, and the instance branch behind the first was written and unreachable. -->
-	<Dialog v-model:open="showRecurringEventModal" v-bind="SHOW_RECURRING_EVENT_MODAL_OPTIONS">
-		<template #actions>
-			<div class="flex justify-end space-x-2">
-				<Button variant="outline" @click="handleSaveRecurringEvent(true)">
-					{{ __('This Instance') }}
-				</Button>
-				<Button variant="solid" @click="handleSaveRecurringEvent(false)">
-					{{ __('Entire Series') }}
-				</Button>
-			</div>
-		</template>
-	</Dialog>
+	<RecurringScopeModal
+		v-model="showRecurringEventModal"
+		v-bind="recurringScopeModalProps"
+		@confirm="handleSaveRecurringEvent"
+	/>
+	<RecurringScopeModal
+		v-model="showDeleteScopeModal"
+		v-bind="deleteScopeModalProps"
+		@confirm="deleteScope"
+	/>
 	<Dialog v-model:open="showNotifyDeleteModal" v-bind="NOTIFY_DELETE_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">

--- a/frontend/src/apps/calendar/components/Modals/RecurringScopeModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/RecurringScopeModal.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { Button, Dialog, Radio, RadioGroup } from 'frappe-ui'
+
+import type { RecurringScope, RecurringScopeOption } from '@/apps/calendar/utils/recurringScope'
+
+/**
+ * The question a recurring event asks before it is changed: which of its
+ * occurrences did you mean?
+ *
+ * It used to be asked with a button per answer, which put the far-reaching
+ * choice — the whole series — in the primary style and left no room for the
+ * third answer. Here the answers are a list, the safe one is pre-selected so
+ * Enter does the least far-reaching thing, and the single primary button
+ * carries the verb of whatever asked: Update, Delete, Send.
+ */
+const show = defineModel<boolean>()
+
+const {
+	title,
+	icon = { name: 'lucide-repeat' },
+	options,
+	confirmLabel,
+	theme = 'gray',
+	loading = false,
+} = defineProps<{
+	title: string
+	icon?: { name: string; theme?: 'amber' | 'blue' | 'red' | 'green' }
+	/** Safest first: the first one that can be picked is the one pre-selected. */
+	options: RecurringScopeOption[]
+	confirmLabel: string
+	theme?: 'gray' | 'red'
+	loading?: boolean
+}>()
+
+const emit = defineEmits<{ confirm: [scope: RecurringScope] }>()
+
+const scope = ref<RecurringScope>()
+
+// Picked afresh every time it opens. An answer left standing from the last
+// time would quietly decide this one — and the two are rarely the same event.
+watch(
+	() => show.value,
+	(open) => {
+		if (open) scope.value = options.find((option) => !option.disabled)?.value
+	},
+	{ immediate: true },
+)
+
+const confirm = () => {
+	if (scope.value) emit('confirm', scope.value)
+}
+</script>
+
+<template>
+	<Dialog v-model:open="show" size="sm" :title="title" :icon="icon">
+		<template #default>
+			<RadioGroup v-model="scope" padded>
+				<Radio
+					v-for="option in options"
+					:key="option.value"
+					:value="option.value"
+					:label="option.label"
+					:description="option.description"
+					:disabled="option.disabled"
+				/>
+			</RadioGroup>
+		</template>
+		<template #actions>
+			<!-- Cancel sits away from the verb: the two are opposite answers, and side by
+			     side the destructive one is a slip away from the safe one. -->
+			<div class="flex items-center justify-between">
+				<Button :label="__('Cancel')" variant="ghost" @click="show = false" />
+				<Button
+					:label="confirmLabel"
+					variant="solid"
+					:theme="theme"
+					:loading="loading"
+					:disabled="!scope"
+					@click="confirm"
+				/>
+			</div>
+		</template>
+	</Dialog>
+</template>

--- a/frontend/src/apps/calendar/composables/useEventDelete.ts
+++ b/frontend/src/apps/calendar/composables/useEventDelete.ts
@@ -3,6 +3,8 @@ import { Trash2 } from 'lucide-vue-next'
 import { createResource, toast } from 'frappe-ui'
 
 import { userStore } from '@/apps/calendar/stores/user'
+import { isFirstOccurrence, scopeOptions } from '@/apps/calendar/utils/recurringScope'
+import type { RecurringScope } from '@/apps/calendar/utils/recurringScope'
 import type { ParticipantIdentity } from '@/apps/calendar/types/doctypes'
 
 /** The part of a calendar event that deleting one reads. */
@@ -12,6 +14,8 @@ export interface DeletableEvent {
 	master_id?: string
 	/** Set on an instance of a recurring series; absent on a one-off. */
 	recurrence_id?: string
+	/** The series' own start — the same date on its first occurrence, and only there. */
+	master_start?: string
 	recurrence_rule?: Record<string, unknown>
 	/** The instance's own day — where "this and following" ends the series. */
 	date?: string
@@ -32,9 +36,10 @@ export interface DeletableEvent {
  * @param onDeleted - What the host does once the server confirms: reload the
  *   calendar, close itself.
  * @returns `deleteOption` for the host's own dropdown, `isDeleting` for the
- *   trigger's disabled state, and the three pieces of the cancellation-email
- *   prompt the host renders: `showNotifyModal`, `pendingDelete` and
- *   `NOTIFY_DELETE_OPTIONS`.
+ *   trigger's disabled state, the three pieces of the scope question a
+ *   recurring event asks first (`showScopeModal`, `deleteScopeModalProps`,
+ *   `deleteScope`), and the three of the cancellation-email prompt that follows
+ *   it: `showNotifyModal`, `pendingDelete` and `NOTIFY_DELETE_OPTIONS`.
  */
 export function useEventDelete(
 	getEvent: () => DeletableEvent | undefined,
@@ -142,21 +147,41 @@ export function useEventDelete(
 		})
 	}
 
-	// The one entry a host drops into its own dropdown: a plain item, or the
-	// three choices a recurring event has.
-	const deleteOption = computed(() =>
-		calendarEvent.value.recurrence_id
-			? {
-					label: __('Delete'),
-					icon: Trash2,
-					submenu: [
-						{ label: __('This instance'), onClick: handleDeleteEventInstance },
-						{ label: __('This and following instances'), onClick: handleDeleteFollowingEventInstances },
-						{ label: __('Entire series'), onClick: handleDeleteEvent },
-					],
-				}
-			: { label: __('Delete'), icon: Trash2, onClick: handleDeleteEvent },
-	)
+	// How far the delete reaches used to be a submenu off the Delete item: three
+	// commands hidden behind a hover, each firing the moment it was touched. It
+	// is one question with three answers, so it is asked once, in the dialog
+	// every other recurring action asks it in.
+	const showScopeModal = ref(false)
+
+	const requestDelete = () => {
+		if (calendarEvent.value.recurrence_id) showScopeModal.value = true
+		else handleDeleteEvent()
+	}
+
+	const deleteScopeModalProps = computed(() => ({
+		title: __('Delete repeating event'),
+		icon: { name: 'lucide-trash-2', theme: 'red' as const },
+		// No line above the list: the title already says what is being deleted.
+		options: scopeOptions({ isFirst: isFirstOccurrence(calendarEvent.value) }),
+		confirmLabel: __('Delete'),
+		theme: 'red' as const,
+		loading: isDeleting.value,
+	}))
+
+	const deleteScope = (scope: RecurringScope) => {
+		showScopeModal.value = false
+		if (scope === 'instance') handleDeleteEventInstance()
+		else if (scope === 'following') handleDeleteFollowingEventInstances()
+		else handleDeleteEvent()
+	}
+
+	// The one entry a host drops into its own dropdown. A recurring event asks
+	// which occurrences first; a one-off has nothing to ask.
+	const deleteOption = computed(() => ({
+		label: __('Delete'),
+		icon: Trash2,
+		onClick: requestDelete,
+	}))
 
 	const NOTIFY_DELETE_OPTIONS = {
 		title: __('Notify Participants'),
@@ -167,6 +192,9 @@ export function useEventDelete(
 	return {
 		deleteOption,
 		isDeleting,
+		showScopeModal,
+		deleteScopeModalProps,
+		deleteScope,
 		showNotifyModal,
 		pendingDelete,
 		NOTIFY_DELETE_OPTIONS,

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -411,6 +411,10 @@ watch([showRecurringEventModal, showNotifyModal], ([recurring, notify]) => {
 const handleUpdate = (e) => {
 	Object.assign(eventToBeUpdated, withActualTitle(e))
 	confirmed = false
+	// Each drag asks again. Left standing, the last drag's answer would decide this one — and a
+	// one-off event dragged after an instance edit would be written as an override of a series
+	// it isn't part of.
+	isUpdateInstance.value = false
 	if (e.recurrence_id) showRecurringEventModal.value = true
 	else handleUpdateEvent()
 }
@@ -437,9 +441,6 @@ const hasParticipantsOtherThanUser = computed(
 const submitEvent = (sendEmail: boolean) => {
 	confirmed = true
 	showNotifyModal.value = false
-	// Editing a single instance of a series is not supported yet; the move is undone rather
-	// than left on screen as if it had been saved.
-	if (isUpdateInstance.value) return revertUpdate()
 
 	eventToBeUpdated.start = dayjs(eventToBeUpdated.fromDateTime).format('YYYY-MM-DDTHH:mm:ss')
 	if (!eventToBeUpdated.isAllDay) {
@@ -453,8 +454,47 @@ const submitEvent = (sendEmail: boolean) => {
 		const minutes = diff.minutes()
 		eventToBeUpdated.duration = dayjs.duration({ hours, minutes }).toISOString()
 	}
+
+	// One occurrence moved on its own: the series keeps its rule and this date gets an override,
+	// which is what the instance update writes. The series itself is addressed by master_id, and
+	// the occurrence within it by the recurrence id — its original start, which the drag leaves
+	// alone. Synthetic instance ids are no use for that: the server reshuffles them whenever an
+	// override lands.
+	if (isUpdateInstance.value) return editEventInstance.submit({ sendEmail })
+
 	editEvent.submit({ sendEmail })
 }
+
+// Both writes land the same way: the calendar has already drawn the move, so success only has to
+// confirm it and refresh, and a failure has to put the pill back where it was.
+const onEventSaved = {
+	onSuccess: () => {
+		raiseToast(__('Event updated.'), 'success')
+		events.reload()
+	},
+	onError: (error) => {
+		revertUpdate()
+		raiseToast(error.message, 'error')
+	},
+}
+
+const editEventInstance = createResource({
+	url: 'suite.calendar.doctype.calendar_event.calendar_event.update_calendar_event_instance',
+	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
+		account: eventToBeUpdated.account,
+		master_id: eventToBeUpdated.master_id,
+		recurrence_id: eventToBeUpdated.recurrence_id,
+		// Only what a drag can change. The zone rides with the start, since the dragged numbers
+		// are a wall clock in the viewer's zone and would otherwise be read in the event's own.
+		patch: {
+			start: eventToBeUpdated.start,
+			duration: eventToBeUpdated.duration,
+			...(eventToBeUpdated.isAllDay ? {} : { time_zone: eventToBeUpdated.time_zone }),
+		},
+		send_scheduling_messages: sendEmail,
+	}),
+	...onEventSaved,
+})
 
 const editEvent = createResource({
 	url: 'suite.calendar.doctype.calendar_event.calendar_event.update_calendar_event',
@@ -464,14 +504,7 @@ const editEvent = createResource({
 		id: eventToBeUpdated.master_id || eventToBeUpdated.id,
 		send_scheduling_messages: sendEmail,
 	}),
-	onSuccess: () => {
-		raiseToast(__('Event updated.'), 'success')
-		events.reload()
-	},
-	onError: (error) => {
-		revertUpdate()
-		raiseToast(error.message, 'error')
-	},
+	...onEventSaved,
 })
 
 const RECURRING_EVENT_MODAL_OPTIONS = {
@@ -575,7 +608,10 @@ const NOTIFY_MODAL_OPTIONS = {
 	<Dialog v-model:open="showRecurringEventModal" v-bind="RECURRING_EVENT_MODAL_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">
-				<Button @click="handleUpdateRecurringEvent(false)">
+				<Button variant="outline" @click="handleUpdateRecurringEvent(true)">
+					{{ __('This instance') }}
+				</Button>
+				<Button variant="solid" @click="handleUpdateRecurringEvent(false)">
 					{{ __('Entire series') }}
 				</Button>
 			</div>

--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -8,10 +8,13 @@ import { useScreenSize } from '@/composables/useScreenSize'
 import { raiseToast } from '@/apps/calendar/utils'
 import { fromEventZone } from '@/apps/calendar/utils/datetime'
 import { eventLastDay, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
+import { isFirstOccurrence, scopeOptions } from '@/apps/calendar/utils/recurringScope'
+import type { RecurringScope } from '@/apps/calendar/utils/recurringScope'
 import { userStore } from '@/apps/calendar/stores/user'
 import AppSidebar from '@/apps/calendar/components/AppSidebar.vue'
 import EventDetailSidebar from '@/apps/calendar/components/EventDetailSidebar.vue'
 import EventModal from '@/apps/calendar/components/Modals/EventModal.vue'
+import RecurringScopeModal from '@/apps/calendar/components/Modals/RecurringScopeModal.vue'
 
 const dayjs = inject('$dayjs')
 
@@ -394,7 +397,7 @@ watch(
 
 const eventToBeUpdated = reactive({})
 const showRecurringEventModal = ref(false)
-const isUpdateInstance = ref(false)
+const updateScope = ref<RecurringScope>('series')
 const showNotifyModal = ref(false)
 
 // The calendar draws a move or resize before it is confirmed here. Until a
@@ -414,13 +417,13 @@ const handleUpdate = (e) => {
 	// Each drag asks again. Left standing, the last drag's answer would decide this one — and a
 	// one-off event dragged after an instance edit would be written as an override of a series
 	// it isn't part of.
-	isUpdateInstance.value = false
+	updateScope.value = 'series'
 	if (e.recurrence_id) showRecurringEventModal.value = true
 	else handleUpdateEvent()
 }
 
-const handleUpdateRecurringEvent = (updateInstance: boolean) => {
-	isUpdateInstance.value = updateInstance
+const handleUpdateRecurringEvent = (scope: RecurringScope) => {
+	updateScope.value = scope
 	showRecurringEventModal.value = false
 	handleUpdateEvent()
 }
@@ -460,7 +463,11 @@ const submitEvent = (sendEmail: boolean) => {
 	// the occurrence within it by the recurrence id — its original start, which the drag leaves
 	// alone. Synthetic instance ids are no use for that: the server reshuffles them whenever an
 	// override lands.
-	if (isUpdateInstance.value) return editEventInstance.submit({ sendEmail })
+	if (updateScope.value === 'instance') return editEventInstance.submit({ sendEmail })
+
+	// This occurrence and the ones after it: the series is cut here and the move starts its
+	// second half, since a rule has no way to change partway through.
+	if (updateScope.value === 'following') return splitSeries.submit({ sendEmail })
 
 	editEvent.submit({ sendEmail })
 }
@@ -496,6 +503,17 @@ const editEventInstance = createResource({
 	...onEventSaved,
 })
 
+const splitSeries = createResource({
+	url: 'suite.calendar.api.split_calendar_event_series',
+	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
+		...eventToBeUpdated,
+		master_id: eventToBeUpdated.master_id,
+		recurrence_id: eventToBeUpdated.recurrence_id,
+		send_scheduling_messages: sendEmail,
+	}),
+	...onEventSaved,
+})
+
 const editEvent = createResource({
 	url: 'suite.calendar.doctype.calendar_event.calendar_event.update_calendar_event',
 	makeParams: ({ sendEmail }: { sendEmail: boolean }) => ({
@@ -507,11 +525,24 @@ const editEvent = createResource({
 	...onEventSaved,
 })
 
-const RECURRING_EVENT_MODAL_OPTIONS = {
-	title: __('Update Recurring Event'),
-	icon: { name: 'lucide-repeat' },
-	message: __('Do you want to update just this instance, or all events in the series?'),
-}
+// Splitting a series ends it and starts another, which only its organizer can do.
+const isAttendee = computed(
+	() =>
+		!!eventToBeUpdated.organizer &&
+		!participantIdentities.data?.some(
+			(identity) => identity.email === eventToBeUpdated.organizer.replace('mailto:', ''),
+		),
+)
+
+const recurringScopeModalProps = computed(() => ({
+	title: __('Update repeating event'),
+	options: scopeOptions({
+		isFirst: isFirstOccurrence(eventToBeUpdated),
+		splitBlockedReason: isAttendee.value ? __('Only the organizer can split a series') : undefined,
+	}),
+	confirmLabel: __('Update'),
+	loading: editEvent.loading || editEventInstance.loading || splitSeries.loading,
+}))
 
 const NOTIFY_MODAL_OPTIONS = {
 	title: __('Notify Participants'),
@@ -605,18 +636,11 @@ const NOTIFY_MODAL_OPTIONS = {
 		</div>
 	</div>
 	<EventModal v-model="showEditEvent" :selected-event="event" @reload-events="events.reload()" />
-	<Dialog v-model:open="showRecurringEventModal" v-bind="RECURRING_EVENT_MODAL_OPTIONS">
-		<template #actions>
-			<div class="flex justify-end space-x-2">
-				<Button variant="outline" @click="handleUpdateRecurringEvent(true)">
-					{{ __('This instance') }}
-				</Button>
-				<Button variant="solid" @click="handleUpdateRecurringEvent(false)">
-					{{ __('Entire series') }}
-				</Button>
-			</div>
-		</template>
-	</Dialog>
+	<RecurringScopeModal
+		v-model="showRecurringEventModal"
+		v-bind="recurringScopeModalProps"
+		@confirm="handleUpdateRecurringEvent"
+	/>
 	<Dialog v-model:open="showNotifyModal" v-bind="NOTIFY_MODAL_OPTIONS">
 		<template #actions>
 			<div class="flex justify-end space-x-2">

--- a/frontend/src/apps/calendar/utils/recurringScope.test.ts
+++ b/frontend/src/apps/calendar/utils/recurringScope.test.ts
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { isFirstOccurrence, scopeOptions } from './recurringScope'
+
+// The app's translation helper is a global installed at boot; the labels are not what is
+// under test here, only which of them the list offers.
+beforeAll(() => {
+	;(globalThis as any).__ = (text: string) => text
+})
+
+const values = (options: ReturnType<typeof scopeOptions>) => options.map((option) => option.value)
+
+describe('isFirstOccurrence', () => {
+	it('is true when the occurrence starts where its series does', () => {
+		expect(
+			isFirstOccurrence({ recurrence_id: '2026-09-07T08:00:00', master_start: '2026-09-07T08:00:00' }),
+		).toBe(true)
+	})
+
+	it('is false for a later occurrence', () => {
+		expect(
+			isFirstOccurrence({ recurrence_id: '2026-09-14T08:00:00', master_start: '2026-09-07T08:00:00' }),
+		).toBe(false)
+	})
+
+	it('is false for a one-off, which has no occurrence to be the first of', () => {
+		expect(isFirstOccurrence({ master_start: '2026-09-07T08:00:00' })).toBe(false)
+		expect(isFirstOccurrence(undefined)).toBe(false)
+	})
+})
+
+describe('scopeOptions', () => {
+	it('offers all three answers in the middle of a series', () => {
+		expect(values(scopeOptions())).toEqual(['instance', 'following', 'series'])
+	})
+
+	it('drops "this and following" at the head of a series', () => {
+		// There it reaches exactly what "all events" reaches, and a list does not ask the same
+		// question twice.
+		expect(values(scopeOptions({ isFirst: true }))).toEqual(['instance', 'series'])
+	})
+
+	it('keeps a blocked split visible, greyed out and saying why', () => {
+		const following = scopeOptions({ splitBlockedReason: 'Only the organizer can split a series' })[1]
+
+		expect(following.disabled).toBe(true)
+		expect(following.description).toBe('Only the organizer can split a series')
+	})
+
+	it('says nothing under a split that is simply available', () => {
+		expect(scopeOptions()[1].disabled).toBe(false)
+		expect(scopeOptions()[1].description).toBeUndefined()
+	})
+})

--- a/frontend/src/apps/calendar/utils/recurringScope.ts
+++ b/frontend/src/apps/calendar/utils/recurringScope.ts
@@ -1,0 +1,72 @@
+/**
+ * How far into a series an action reaches.
+ *
+ * Editing, deleting and answering an invitation all ask the same question of a
+ * recurring event — this occurrence, this one and the rest, or every one of
+ * them — so they ask it in the same words, from one list, and name the answer
+ * the same way when they carry it to the server.
+ */
+export type RecurringScope = 'instance' | 'following' | 'series'
+
+export interface RecurringScopeOption {
+	value: RecurringScope
+	label: string
+	/** Shown under the label only where the consequence isn't obvious from it. */
+	description?: string
+	/** Offered but not available here — the row explains itself in `description`. */
+	disabled?: boolean
+}
+
+/**
+ * The wording every scope list starts from.
+ *
+ * A function rather than a constant: `__` reads the loaded translations, and at
+ * module scope they are not loaded yet.
+ */
+export const scopeLabels = (): Record<RecurringScope, string> => ({
+	instance: __('This event only'),
+	following: __('This and following events'),
+	series: __('All events in the series'),
+})
+
+/**
+ * Whether an occurrence is the first of its series.
+ *
+ * There "this and following" reaches exactly what "all events" reaches, so the list drops it
+ * rather than offering the same answer twice — and the server, asked anyway, edits the series
+ * whole instead of cutting a first half with nothing in it.
+ */
+export const isFirstOccurrence = (event?: {
+	recurrence_id?: string
+	master_start?: string
+}): boolean => !!event?.recurrence_id && event.recurrence_id === event.master_start
+
+/**
+ * The answers a recurring edit or delete offers this occurrence.
+ *
+ * @param isFirst - Whether this is the series' first occurrence, which drops "this and
+ *   following" from the list.
+ * @param splitBlockedReason - Why the reader may not split the series here, if they may not.
+ *   The row stays, greyed out and saying so, rather than disappearing without explanation.
+ */
+export const scopeOptions = ({
+	isFirst = false,
+	splitBlockedReason,
+}: { isFirst?: boolean; splitBlockedReason?: string } = {}): RecurringScopeOption[] => {
+	const labels = scopeLabels()
+
+	return [
+		{ value: 'instance', label: labels.instance },
+		...(isFirst
+			? []
+			: [
+					{
+						value: 'following' as const,
+						label: labels.following,
+						disabled: !!splitBlockedReason,
+						description: splitBlockedReason,
+					},
+				]),
+		{ value: 'series', label: labels.series },
+	]
+}

--- a/suite/calendar/api/__init__.py
+++ b/suite/calendar/api/__init__.py
@@ -1,17 +1,23 @@
 import json
+from datetime import datetime, timedelta
 
 import frappe
+from dateutil.rrule import rrulestr
 from frappe import _
+from frappe.utils import cint
+from icalendar.prop import vRecur
 
 from suite.calendar.api.rsvp import record_rsvp
 from suite.calendar.doctype.calendar.calendar import ensure_default_alerts, fetch_calendars
 from suite.calendar.doctype.calendar_event.calendar_event import (
+    add_calendar_event,
     fetch_calendar_events,
     update_calendar_event,
 )
 from suite.calendar.doctype.calendar_event.calendar_event import (
     get_calendar_events as get_calendar_events_by_ids,
 )
+from suite.calendar.doctype.calendar_exchange.calendar_exchange import _build_recurrence_rule
 from suite.mail.jmap import get_calendar_event_service
 from suite.mail.utils.dt import normalize_utc_z
 from suite.utils.rate_limiter import dynamic_rate_limit
@@ -127,14 +133,16 @@ def _with_name(items: list[dict] | None) -> list[dict] | None:
 
 @frappe.whitelist()
 @dynamic_rate_limit()
-def rsvp_calendar_event(account: str, id: str, response: str) -> None:
+def rsvp_calendar_event(account: str, id: str, response: str, recurrence_id: str | None = None) -> None:
     """Records the logged-in user's RSVP (accepted / declined / tentative) on the event.
 
     Patches only the caller's own participationStatus — unlike edit_calendar_event, which
     rewrites the whole event — and routes the organizer's notification through the custom
-    event_response template when custom event invites are enabled (see record_rsvp)."""
+    event_response template when custom event invites are enabled (see record_rsvp).
 
-    record_rsvp(account, id, response)
+    `recurrence_id` answers for that occurrence alone; without one the answer is the series'."""
+
+    record_rsvp(account, id, response, recurrence_id=recurrence_id)
 
 
 @frappe.whitelist()
@@ -179,3 +187,176 @@ def edit_calendar_event(account: str, id: str, **kwargs) -> None:
         resolve("use_default_alerts"),
         kwargs.get("send_scheduling_messages", False),
     )
+
+
+# The fields a series carries, and the only keys forwarded from a split request. A whitelisted
+# function taking **kwargs is handed the whole form, `cmd` included, so the new series is built
+# from a named list rather than from whatever arrived.
+SERIES_FIELDS = (
+    "organizer",
+    "calendar_ids",
+    "status",
+    "draft",
+    "title",
+    "start",
+    "duration",
+    "time_zone",
+    "recurrence_rule",
+    "show_without_time",
+    "privacy",
+    "free_busy_status",
+    "description",
+    "locations",
+    "links",
+    "participants",
+    "alerts",
+    "use_default_alerts",
+)
+
+
+@frappe.whitelist()
+@dynamic_rate_limit()
+def split_calendar_event_series(
+    account: str,
+    master_id: str,
+    recurrence_id: str,
+    send_scheduling_messages: bool = False,
+    **kwargs,
+) -> str:
+    """Applies an edit to one occurrence of a series and to every occurrence after it.
+
+    JSCalendar has no way to say "from here on": a recurrence rule runs from the event's start,
+    and an override speaks for a single date. So the series is cut in two — the original stops
+    just before this occurrence, and the edit becomes a new series starting at it. Every calendar
+    that offers "this and following" does it this way, and it is why the occurrences before the
+    split keep the old title, the old time and their own overrides.
+
+    Occurrences after the split that had been edited on their own keep those edits only when the
+    new series still falls on their dates; move the series and they are drawn by the new rule
+    like every other occurrence, since there is no date left to hang them on.
+
+    Returns the id of the series that now owns this occurrence.
+    """
+
+    events = get_calendar_events_by_ids(account, [master_id])
+    if not events:
+        frappe.throw(
+            _("Calendar Event {0} not found.").format(frappe.bold(master_id)), frappe.DoesNotExistError
+        )
+
+    master = events[0]
+    rule = json.loads(master["recurrence_rule"] or "{}")
+    if not rule:
+        frappe.throw(_("This event does not repeat, so there is nothing following it."))
+
+    fields = {key: value for key, value in kwargs.items() if key in SERIES_FIELDS}
+    # A series edited from one of its occurrences keeps the calendars the series is in; the form
+    # never names them, and without this the new half would land in the default calendar.
+    if not fields.get("calendar_ids"):
+        fields["calendar_ids"] = [calendar["calendar_id"] for calendar in master.get("calendars") or []]
+    fields.setdefault("organizer", master.get("organizer"))
+
+    before = _occurrences_before(rule, master["start"], recurrence_id)
+    # A counted series can only be split by sharing the count out, so a rule that cannot be
+    # expanded cannot be split — better said than silently turned into two full-length series.
+    if rule.get("count") is not None and before is None:
+        frappe.throw(_("This event's repeat rule could not be read, so it cannot be split here."))
+
+    # Splitting at the first occurrence cuts nothing off: there is no earlier part to keep, so
+    # this is the whole series changing rather than a series becoming two.
+    if before == 0 or recurrence_id == master["start"]:
+        update_calendar_event(
+            account,
+            master_id,
+            master["uid"],
+            fields.pop("organizer", None),
+            fields.pop("calendar_ids", None),
+            send_scheduling_messages=send_scheduling_messages,
+            **fields,
+        )
+        return master_id
+
+    head_rule = dict(rule)
+    if rule.get("count") is not None:
+        # A counted series stays counted: the occurrences that already happened are its whole run.
+        head_rule["count"] = before
+    else:
+        head_rule["until"] = _moment_before(recurrence_id)
+
+    edit_calendar_event(
+        account,
+        master_id,
+        recurrence_rule=json.dumps(head_rule),
+        send_scheduling_messages=send_scheduling_messages,
+    )
+
+    # Overrides the rule no longer generates are not dropped with it — RFC 8984 reads an override
+    # on an ungenerated date as an occurrence in its own right, so leaving them would keep every
+    # edited occurrence after the split visible on the old series, beside the new one.
+    service = get_calendar_event_service(account)
+    stored = service.get([master_id])
+    overrides = (stored[0] if stored else {}).get("recurrenceOverrides") or {}
+    tail_overrides = {
+        rid: override for rid, override in overrides.items() if not _is_before(rid, recurrence_id)
+    }
+    if tail_overrides:
+        service.remove_overrides(master_id, list(tail_overrides))
+
+    # The new half takes what is left of a count; an `until` needs no adjusting, since it names
+    # a date the new half runs to just as the old one did.
+    tail_rule = dict(fields.get("recurrence_rule") or rule)
+    if rule.get("count") is not None:
+        tail_rule["count"] = max(cint(rule["count"]) - before, 1)
+    fields["recurrence_rule"] = tail_rule
+
+    new_id = add_calendar_event(account, send_scheduling_messages=send_scheduling_messages, **fields)
+
+    # Only when the new series falls on the same dates — an occurrence's override is addressed by
+    # its date, and a series that moved has none of them left.
+    if tail_overrides and fields.get("start") == recurrence_id:
+        service.set_overrides(new_id, tail_overrides)
+
+    return new_id
+
+
+def _occurrences_before(rule: dict, start: str, recurrence_id: str) -> int | None:
+    """How many of a series' occurrences fall before the given one, or None if it can't be told.
+
+    Expanded locally rather than asked of the server: the answer is needed while the series is
+    still whole, and only to split a `count` between the two halves.
+    """
+
+    try:
+        recur = _build_recurrence_rule(rule)
+        if not recur:
+            return None
+
+        first = _local(start)
+        split = _local(recurrence_id)
+        occurrences = rrulestr(f"RRULE:{vRecur(recur).to_ical().decode()}", dtstart=first)
+        # A bounded window, so an endless rule still answers.
+        return len(occurrences.between(first - timedelta(seconds=1), split, inc=False))
+    except Exception:
+        return None
+
+
+def _moment_before(recurrence_id: str) -> str:
+    """The LocalDateTime a second before an occurrence — where a truncated rule stops."""
+
+    return (_local(recurrence_id) - timedelta(seconds=1)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _is_before(recurrence_id: str, split: str) -> bool:
+    """Whether one occurrence's date falls before another's."""
+
+    try:
+        return _local(recurrence_id) < _local(split)
+    except ValueError:
+        return recurrence_id < split
+
+
+def _local(value: str) -> datetime:
+    """A JSCalendar LocalDateTime as a naive datetime — the zone is the event's, and the same
+    for every date being compared here."""
+
+    return datetime.fromisoformat(value.replace("Z", ""))

--- a/suite/calendar/api/rsvp.py
+++ b/suite/calendar/api/rsvp.py
@@ -113,7 +113,7 @@ def resolve_rsvp(token: str) -> dict:
     }
 
 
-def record_rsvp(account: str, event_id: str, response: str) -> str:
+def record_rsvp(account: str, event_id: str, response: str, recurrence_id: str | None = None) -> str:
     """Records the logged-in caller's RSVP on their own copy of the event and tells the organizer.
 
     Their entry is matched by address against the account's participant identities and patched
@@ -121,6 +121,11 @@ def record_rsvp(account: str, event_id: str, response: str) -> str:
     mail is suppressed and the custom event_response email — carrying the iTIP REPLY — is sent
     instead (see `notify_organizer_of_reply`); otherwise the JMAP server emits its own reply.
     Returns the responder's address.
+
+    `recurrence_id` answers for one occurrence of a series and leaves the rest as they were: the
+    status lands as an override on that date, and the reply carries a RECURRENCE-ID so the
+    organizer's calendar records it against the same occurrence. Without one the answer is the
+    series', which is what a one-off event always is.
     """
 
     from suite.calendar.doctype.calendar_event.invitations import custom_event_invites_enabled
@@ -149,9 +154,18 @@ def record_rsvp(account: str, event_id: str, response: str) -> str:
         frappe.throw(_("You are not a participant of this event."))
 
     use_custom_reply = custom_event_invites_enabled()
-    result = service.set_participation_status(
-        event_id, participant_uid, response, send_scheduling_messages=not use_custom_reply
-    )
+    if recurrence_id:
+        result = service.set_instance_participation_status(
+            event_id,
+            recurrence_id,
+            participant_uid,
+            response,
+            send_scheduling_messages=not use_custom_reply,
+        )
+    else:
+        result = service.set_participation_status(
+            event_id, participant_uid, response, send_scheduling_messages=not use_custom_reply
+        )
     if result.get("notUpdated"):
         error = next(iter(result["notUpdated"].values()), None)
         frappe.throw(_("Could not record your response: {0}").format(format_jmap_error(error)))
@@ -165,6 +179,7 @@ def record_rsvp(account: str, event_id: str, response: str) -> str:
             event_id=event_id,
             responder_email=responder_email,
             status=response,
+            recurrence_id=recurrence_id,
         )
 
     return responder_email

--- a/suite/calendar/doctype/calendar_event/ics.py
+++ b/suite/calendar/doctype/calendar_event/ics.py
@@ -8,6 +8,7 @@ export feature stay in sync. The only extra work here is wrapping the components
 VCALENDAR with the right iTIP METHOD (REQUEST for invites/updates, CANCEL for removals).
 """
 
+from copy import deepcopy
 from datetime import UTC, datetime
 
 from frappe.utils import cint
@@ -31,7 +32,9 @@ def build_event_ics(
     """Returns the iCalendar text for a JSCalendar event using the given iTIP method.
 
     When `recurrence_id` is set, a single occurrence (tagged with RECURRENCE-ID) is emitted
-    instead of the whole series — used to cancel one instance of a recurring event.
+    instead of the whole series — used to cancel one instance of a recurring event, and to
+    reply to one. The occurrence's own override wins over the series wherever it says
+    anything, so an answer stored on that date is the one the component carries.
 
     Pass `attendee_email` for a REPLY: RFC 5546 requires the reply to carry exactly the
     responding ATTENDEE, so every other one is dropped from the components.
@@ -88,9 +91,14 @@ def _stamp_outgoing(component, method: str) -> None:
 def _instance_component(event: dict, recurrence_id: str, method: str):
     """Builds a single-occurrence VEVENT carrying RECURRENCE-ID (no RRULE/overrides)."""
 
-    base = {k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")}
+    # Deep-copied: the override below writes into nested maps (a participant's status), and the
+    # event dict belongs to the caller.
+    base = deepcopy({k: v for k, v in event.items() if k not in ("recurrenceRule", "recurrenceOverrides")})
     # RFC 5545: an instance component's DTSTART is that occurrence's start, not the series'.
     base["start"] = recurrence_id
+    # What the occurrence says about itself beats what the series says: a REPLY to one date
+    # carries the status stored on that date, not the one the series still holds.
+    _apply_override(base, (event.get("recurrenceOverrides") or {}).get(recurrence_id) or {})
     component = jscalendar_to_vevent(base)
 
     instance_dt = _parse_local_datetime(recurrence_id, event.get("timeZone"))
@@ -101,6 +109,29 @@ def _instance_component(event: dict, recurrence_id: str, method: str):
         _mark_cancelled(component)
 
     return component
+
+
+def _apply_override(event: dict, override: dict) -> None:
+    """Folds one occurrence's JSCalendar PatchObject into the series properties it overrides.
+
+    An override's keys are paths — `title`, or `participants/<uid>/participationStatus` — so
+    each one is walked down and set, creating whatever it passes through. Only `excluded` is
+    ignored: an occurrence that does not happen is never described in a component, and the
+    callers that emit one have already decided it does.
+    """
+
+    for path, value in override.items():
+        if path == "excluded":
+            continue
+        segments = path.split("/")
+        target = event
+        for segment in segments[:-1]:
+            nested = target.get(segment)
+            if not isinstance(nested, dict):
+                nested = {}
+                target[segment] = nested
+            target = nested
+        target[segments[-1]] = value
 
 
 def _only_attendee(component, email: str) -> None:

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -187,7 +187,13 @@ def notify_organizer_of_response(account: str, event_id: str, participant_email:
         frappe.set_user(original_user)
 
 
-def notify_organizer_of_reply(account: str, event_id: str, responder_email: str, status: str) -> None:
+def notify_organizer_of_reply(
+    account: str,
+    event_id: str,
+    responder_email: str,
+    status: str,
+    recurrence_id: str | None = None,
+) -> None:
     """Sends the organizer an attendee's RSVP as a custom-template email carrying an iTIP REPLY.
 
     The custom-invite counterpart of the server's iMIP scheduling mail: when Mail Settings sends
@@ -195,6 +201,10 @@ def notify_organizer_of_reply(account: str, event_id: str, responder_email: str,
     the event_response template, sent from the attendee's own account, and the embedded
     text/calendar part (METHOD:REPLY, only the responder's ATTENDEE per RFC 5546) lets the
     organizer's calendar server record the response mechanically, wherever they're hosted.
+
+    `recurrence_id` is the answer to one occurrence of a series: the REPLY carries that
+    occurrence alone, tagged with its RECURRENCE-ID, so the organizer's calendar records it
+    against that date rather than against the whole series.
     """
 
     display = RESPONSE_DISPLAY.get((status or "").lower())
@@ -227,7 +237,9 @@ def notify_organizer_of_reply(account: str, event_id: str, responder_email: str,
             logo_src_attr='src="cid:eventlogo"',
         )
 
-        ics = build_event_ics(event, method="REPLY", attendee_email=responder_email)
+        ics = build_event_ics(
+            event, method="REPLY", recurrence_id=recurrence_id, attendee_email=responder_email
+        )
         message = _build_mime(responder_name, responder_email, organizer, subject, html, ics, "REPLY")
 
         MailQueue._create(

--- a/suite/calendar/tests/test_calendar_events.py
+++ b/suite/calendar/tests/test_calendar_events.py
@@ -137,6 +137,67 @@ class TestCalendarEvents(StalwartIntegrationTestCase):
             message="Deleted instance still expands in the range query.",
         )
 
+        # The override written first has to survive both of the writes that followed it. Each of
+        # them lands on one occurrence's key; the map as a whole is never read, edited and sent
+        # back, which is how a second writer's override used to disappear.
+        moved = self._events_in_range(f"{title} (moved)")
+        self.assertEqual(len(moved), 1)
+        self.assertEqual(moved[0]["recurrence_id"], target["recurrence_id"])
+
+    def test_instance_overrides_are_independent(self):
+        """Overriding one occurrence leaves every other occurrence's override where it was."""
+
+        title = f"Series {unique_name('event')}"
+        with self.set_user(self.member.email):
+            master_id = add_calendar_event(
+                self.account,
+                title=title,
+                start="2026-09-07T08:00:00",
+                duration="PT1H",
+                time_zone="UTC",
+                recurrence_rule={"@type": "RecurrenceRule", "frequency": "weekly", "count": 3},
+            )
+
+        instances = self._wait_for_event(title, count=3)
+        first, second, third = instances[0], instances[1], instances[2]
+
+        with self.set_user(self.member.email):
+            # The first override on an event with none: the whole map is written, since there is
+            # nothing to patch into. The second adds a key beside it, the third patches a property
+            # of the first — three different shapes, and none of them may disturb the others.
+            update_calendar_event_instance(
+                self.account, master_id, first["recurrence_id"], {"title": f"{title} (first)"}
+            )
+            update_calendar_event_instance(
+                self.account, master_id, second["recurrence_id"], {"title": f"{title} (second)"}
+            )
+            update_calendar_event_instance(
+                self.account, master_id, first["recurrence_id"], {"start": "2026-09-07T11:00:00"}
+            )
+
+        def all_three_stand():
+            events = {
+                e["recurrence_id"]: e
+                for e in self._events_in_range(f"{title} (first)")
+                + self._events_in_range(f"{title} (second)")
+                + self._events_in_range(title)
+            }
+            first_now = events.get(first["recurrence_id"])
+            second_now = events.get(second["recurrence_id"])
+            third_now = events.get(third["recurrence_id"])
+            if not (first_now and second_now and third_now):
+                return None
+            # The first keeps the title it was given AND takes the later start; the second keeps
+            # its own title; the third was never touched.
+            return (
+                first_now["title"] == f"{title} (first)"
+                and first_now["start"].endswith("11:00:00")
+                and second_now["title"] == f"{title} (second)"
+                and third_now["title"] == title
+            ) or None
+
+        self.wait_until(all_three_stand, message="An override was lost when another one was written.")
+
     def test_unknown_event(self):
         with self.set_user(self.member.email):
             self.assertEqual(get_events_by_ids(self.account, ["nope"]), [])

--- a/suite/calendar/tests/test_calendar_events.py
+++ b/suite/calendar/tests/test_calendar_events.py
@@ -3,7 +3,12 @@
 
 import frappe
 
-from suite.calendar.api import edit_calendar_event, get_calendar_events
+from suite.calendar.api import (
+    edit_calendar_event,
+    get_calendar_events,
+    rsvp_calendar_event,
+    split_calendar_event_series,
+)
 from suite.calendar.doctype.calendar.calendar import add_calendar
 from suite.calendar.doctype.calendar_event.calendar_event import (
     add_calendar_event,
@@ -197,6 +202,104 @@ class TestCalendarEvents(StalwartIntegrationTestCase):
             ) or None
 
         self.wait_until(all_three_stand, message="An override was lost when another one was written.")
+
+    def test_this_and_following_splits_the_series(self):
+        """The occurrences before the split keep what they had; the rest carry the edit.
+
+        JSCalendar can say "this date" or "the series" and nothing in between, so the series is
+        cut in two. The old half stops before this occurrence and the new one starts at it —
+        which is why the count has to be shared out rather than repeated.
+        """
+
+        title = f"Series {unique_name('event')}"
+        with self.set_user(self.member.email):
+            master_id = add_calendar_event(
+                self.account,
+                title=title,
+                start="2026-09-07T08:00:00",
+                duration="PT1H",
+                time_zone="UTC",
+                recurrence_rule={"@type": "RecurrenceRule", "frequency": "weekly", "count": 4},
+            )
+
+        instances = self._wait_for_event(title, count=4)
+        third = instances[2]
+        renamed = f"{title} (from the third)"
+
+        with self.set_user(self.member.email):
+            split_calendar_event_series(
+                self.account,
+                master_id,
+                third["recurrence_id"],
+                title=renamed,
+                start=third["recurrence_id"],
+                duration="PT1H",
+                time_zone="UTC",
+                recurrence_rule={"@type": "RecurrenceRule", "frequency": "weekly", "count": 4},
+            )
+
+        def both_halves_stand():
+            kept = self._events_in_range(title)
+            moved = self._events_in_range(renamed)
+            # Two each: the count is shared out between the halves, not handed to both.
+            if len(kept) != 2 or len(moved) != 2:
+                return None
+            return sorted(e["start"] for e in kept) < sorted(e["start"] for e in moved) or None
+
+        self.wait_until(both_halves_stand, message="The series did not split into two halves.")
+
+    def test_rsvp_answers_one_occurrence_at_a_time(self):
+        """An answer to one occurrence is stored on that date and leaves the others alone."""
+
+        title = f"Series {unique_name('event')}"
+        with self.set_user(self.member.email):
+            master_id = add_calendar_event(
+                self.account,
+                organizer=self.member.email,
+                title=title,
+                start="2026-09-08T08:00:00",
+                duration="PT1H",
+                time_zone="UTC",
+                recurrence_rule={"@type": "RecurrenceRule", "frequency": "weekly", "count": 3},
+                participants=[
+                    {
+                        "email": self.member.email,
+                        "participation_status": "NEEDS-ACTION",
+                        "expect_reply": True,
+                    }
+                ],
+            )
+
+        instances = self._wait_for_event(title, count=3)
+        answered = instances[1]
+
+        with self.set_user(self.member.email):
+            rsvp_calendar_event(self.account, master_id, "declined", recurrence_id=answered["recurrence_id"])
+
+        def only_that_one_declined():
+            statuses = {
+                event["recurrence_id"]: next(
+                    (
+                        p["participation_status"]
+                        for p in event["participants"]
+                        if p["email"] == self.member.email
+                    ),
+                    None,
+                )
+                for event in self._events_in_range(title)
+            }
+            if len(statuses) != 3:
+                return None
+            return (
+                statuses.get(answered["recurrence_id"]) == "DECLINED"
+                and all(
+                    status != "DECLINED"
+                    for rid, status in statuses.items()
+                    if rid != answered["recurrence_id"]
+                )
+            ) or None
+
+        self.wait_until(only_that_one_declined, message="The RSVP did not stay on its own occurrence.")
 
     def test_unknown_event(self):
         with self.set_user(self.member.email):

--- a/suite/calendar/tests/test_calendar_recurring_scope.py
+++ b/suite/calendar/tests/test_calendar_recurring_scope.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from frappe.tests import IntegrationTestCase
+
+from suite.calendar.api import _is_before, _moment_before, _occurrences_before
+from suite.calendar.doctype.calendar_event.ics import build_event_ics
+
+WEEKLY_FROM_MONDAY = "2026-09-07T08:00:00"
+
+
+class TestSplitArithmetic(IntegrationTestCase):
+    """Cutting a series in two is arithmetic on its rule, done before either half is written.
+
+    The count a series was given belongs to the occurrences that already happened; what is left
+    of it belongs to the half starting at the split. Getting this wrong is not a visible error —
+    it is a series that quietly runs the wrong number of times.
+    """
+
+    def test_counts_occurrences_before_the_split(self):
+        weekly = {"@type": "RecurrenceRule", "frequency": "weekly", "count": 6}
+
+        self.assertEqual(_occurrences_before(weekly, WEEKLY_FROM_MONDAY, "2026-09-28T08:00:00"), 3)
+
+    def test_the_first_occurrence_has_nothing_before_it(self):
+        weekly = {"frequency": "weekly", "count": 6}
+
+        self.assertEqual(_occurrences_before(weekly, WEEKLY_FROM_MONDAY, WEEKLY_FROM_MONDAY), 0)
+
+    def test_an_endless_rule_still_answers(self):
+        """The window is bounded by the split, so expanding a rule with no end terminates."""
+
+        self.assertEqual(
+            _occurrences_before({"frequency": "daily"}, WEEKLY_FROM_MONDAY, "2026-09-11T08:00:00"), 4
+        )
+
+    def test_selected_weekdays_are_counted_not_assumed(self):
+        """A Mon/Wed series has three occurrences before the 16th, not the two a weekly count gives."""
+
+        rule = {"frequency": "weekly", "byDay": [{"day": "mo"}, {"day": "we"}], "count": 10}
+
+        self.assertEqual(_occurrences_before(rule, WEEKLY_FROM_MONDAY, "2026-09-16T08:00:00"), 3)
+
+    def test_an_unreadable_rule_gives_no_answer(self):
+        """No count rather than a wrong one: the caller falls back to an `until` it can trust."""
+
+        self.assertIsNone(_occurrences_before({}, WEEKLY_FROM_MONDAY, "2026-09-28T08:00:00"))
+        self.assertIsNone(_occurrences_before({"frequency": "weekly"}, "not a date", "2026-09-28T08:00:00"))
+
+    def test_the_old_half_stops_a_second_before_the_split(self):
+        """`until` includes the moment it names, so the split occurrence must fall after it."""
+
+        self.assertEqual(_moment_before("2026-09-28T08:00:00"), "2026-09-28T07:59:59")
+
+    def test_an_occurrence_is_not_before_itself(self):
+        self.assertTrue(_is_before("2026-09-21T08:00:00", "2026-09-28T08:00:00"))
+        self.assertFalse(_is_before("2026-09-28T08:00:00", "2026-09-28T08:00:00"))
+        self.assertFalse(_is_before("2026-10-05T08:00:00", "2026-09-28T08:00:00"))
+
+
+class TestInstanceReply(IntegrationTestCase):
+    """An RSVP to one occurrence replies about that occurrence.
+
+    The status lives in the series' override for that date, so a REPLY built from the series
+    alone would tell the organizer the answer the responder just changed away from.
+    """
+
+    def event(self) -> dict:
+        return {
+            "@type": "Event",
+            "uid": "abc-123",
+            "title": "Standup",
+            "start": WEEKLY_FROM_MONDAY,
+            "duration": "PT30M",
+            "timeZone": "Asia/Kolkata",
+            "organizerCalendarAddress": "mailto:boss@example.test",
+            "participants": {
+                "p1": {
+                    "@type": "Participant",
+                    "calendarAddress": "mailto:boss@example.test",
+                    "name": "Boss",
+                    "roles": {"owner": True},
+                    "participationStatus": "accepted",
+                },
+                "p2": {
+                    "@type": "Participant",
+                    "calendarAddress": "mailto:me@example.test",
+                    "name": "Me",
+                    "roles": {"attendee": True},
+                    "participationStatus": "accepted",
+                    "expectReply": True,
+                },
+            },
+            "recurrenceRule": {"@type": "RecurrenceRule", "frequency": "weekly", "count": 5},
+            "recurrenceOverrides": {
+                "2026-09-21T08:00:00": {"participants/p2/participationStatus": "declined"}
+            },
+        }
+
+    def test_the_reply_carries_the_occurrence_and_its_own_answer(self):
+        ics = build_event_ics(
+            self.event(),
+            method="REPLY",
+            recurrence_id="2026-09-21T08:00:00",
+            attendee_email="me@example.test",
+        )
+
+        self.assertIn("METHOD:REPLY", ics)
+        self.assertIn("RECURRENCE-ID;TZID=Asia/Kolkata:20260921T080000", ics)
+        self.assertIn("PARTSTAT=DECLINED", ics)
+        # RFC 5546: a reply carries the responding attendee and no one else.
+        self.assertNotIn("boss@example.test", ics.replace("ORGANIZER;CN=Boss:mailto:boss@example.test", ""))
+        # And the series it was read from is left exactly as it was.
+        self.assertNotIn("RRULE", ics)
+
+    def test_the_series_dict_is_not_written_through(self):
+        event = self.event()
+
+        build_event_ics(
+            event, method="REPLY", recurrence_id="2026-09-21T08:00:00", attendee_email="me@example.test"
+        )
+
+        self.assertEqual(event["participants"]["p2"]["participationStatus"], "accepted")
+
+    def test_an_occurrence_with_no_override_answers_as_the_series_does(self):
+        ics = build_event_ics(
+            self.event(),
+            method="REPLY",
+            recurrence_id="2026-09-14T08:00:00",
+            attendee_email="me@example.test",
+        )
+
+        self.assertIn("PARTSTAT=ACCEPTED", ics)

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -382,13 +382,7 @@ class CalendarEventService(CalendarsService):
 
         response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
 
-        result = {"updated": [], "notUpdated": {}}
-        if method_responses := response.get("methodResponses"):
-            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-            if not_updated := method_responses[0][1].get("notUpdated", {}):
-                result["notUpdated"].update(not_updated)
-
-        return result
+        return self._update_result(response)
 
     def set_participation_status(
         self,
@@ -415,13 +409,42 @@ class CalendarEventService(CalendarsService):
 
         response = self._update(payload, sendSchedulingMessages=send_scheduling_messages)
 
-        result = {"updated": [], "notUpdated": {}}
-        if method_responses := response.get("methodResponses"):
-            result["updated"].extend(method_responses[0][1].get("updated", {}).keys())
-            if not_updated := method_responses[0][1].get("notUpdated", {}):
-                result["notUpdated"].update(not_updated)
+        return self._update_result(response)
 
-        return result
+    def set_instance_participation_status(
+        self,
+        id: str,
+        recurrence_id: str,
+        participant_uid: str,
+        participation_status: str,
+        send_scheduling_messages: bool = False,
+    ) -> dict:
+        """Patches one participant's participationStatus on a single occurrence of a series.
+
+        The series keeps the answer it had; this date gets an override carrying the new one —
+        the same mechanism a moved or renamed occurrence uses, so every client reading the event
+        sees one occurrence answered differently rather than a series that changed its mind.
+        """
+
+        if not id or not recurrence_id or not participant_uid:
+            raise ValueError("'id', 'recurrence_id' and 'participant_uid' are all required.")
+
+        events = self.get([id])
+        if not events:
+            raise ValueError(f"Event with id '{id}' not found.")
+
+        overrides = events[0].get("recurrenceOverrides", {}) or {}
+        patch = self._override_patch(
+            overrides,
+            recurrence_id,
+            {f"participants/{participant_uid}/participationStatus": participation_status.lower()},
+        )
+
+        response = self._update(
+            {id: {**patch, "updated": utcnow()}}, sendSchedulingMessages=send_scheduling_messages
+        )
+
+        return self._update_result(response)
 
     def delete_instance(self, id: str, recurrence_id: str, send_scheduling_messages: bool = False) -> dict:
         """Public method to delete a specific instance of a recurring calendar event based on its ID and recurrence ID by marking it as excluded in the master event's recurrence overrides.
@@ -447,6 +470,42 @@ class CalendarEventService(CalendarsService):
             {id: {**patch, "updated": utcnow()}},
             sendSchedulingMessages=send_scheduling_messages,
         )
+
+        return self._update_result(response)
+
+    def remove_overrides(self, id: str, recurrence_ids: list[str]) -> dict:
+        """Drops the named occurrences' overrides, leaving every other one where it is.
+
+        One key removed per occurrence rather than a rewritten map: the map is shared state, and
+        a copy of it taken before someone else's write would put their occurrence back.
+        """
+
+        if not id or not recurrence_ids:
+            raise ValueError("Both 'id' and 'recurrence_ids' are required.")
+
+        payload = {id: {f"recurrenceOverrides/{rid}": None for rid in recurrence_ids}}
+        payload[id]["updated"] = utcnow()
+
+        return self._update_result(self._update(payload))
+
+    def set_overrides(self, id: str, overrides: dict) -> dict:
+        """Writes an event's whole recurrenceOverrides map.
+
+        For an event nobody else has seen yet — the second half of a split series, which is
+        given the overrides that used to belong to the first. Anywhere else, patch one
+        occurrence's key instead (`_override_patch`).
+        """
+
+        if not id:
+            raise ValueError("'id' is required.")
+
+        payload = {id: {"recurrenceOverrides": overrides, "updated": utcnow()}}
+
+        return self._update_result(self._update(payload))
+
+    @staticmethod
+    def _update_result(response: dict) -> dict:
+        """The ids a single '/set' updated, and the per-id reasons it did not update the rest."""
 
         result = {"updated": [], "notUpdated": {}}
         if method_responses := response.get("methodResponses"):
@@ -474,10 +533,7 @@ class CalendarEventService(CalendarsService):
         if not overrides:
             return {"recurrenceOverrides": {recurrence_id: override}}
         if recurrence_id in overrides:
-            return {
-                f"recurrenceOverrides/{recurrence_id}/{key}": value
-                for key, value in override.items()
-            }
+            return {f"recurrenceOverrides/{recurrence_id}/{key}": value for key, value in override.items()}
         return {f"recurrenceOverrides/{recurrence_id}": override}
 
     @staticmethod

--- a/suite/mail/jmap/services/calendars/calendar_event.py
+++ b/suite/mail/jmap/services/calendars/calendar_event.py
@@ -373,15 +373,8 @@ class CalendarEventService(CalendarsService):
                 value = patch[key]
                 out[target] = transform(value) if transform else value
 
-        payload = {id: {}}
-
-        if recurrence_id in recurrence_overrides:
-            payload[id].update({f"recurrenceOverrides/{recurrence_id}/{k}": v for k, v in out.items()})
-        else:
-            recurrence_overrides[recurrence_id] = out
-            payload = {id: {"recurrenceOverrides": recurrence_overrides}}
-
-        payload[id]["updated"] = utcnow()
+        patch_ops = self._override_patch(recurrence_overrides, recurrence_id, out)
+        payload = {id: {**patch_ops, "updated": utcnow()}}
 
         # Bump the master SEQUENCE (iTIP) so attendees' clients accept the re-sent series.
         if sequence is not None:
@@ -443,10 +436,15 @@ class CalendarEventService(CalendarsService):
 
         event = events[0]
         recurrence_overrides = event.get("recurrenceOverrides", {}) or {}
-        recurrence_overrides.setdefault(recurrence_id, {}).update({"excluded": True})
+
+        # The exclusion goes on the occurrence's own key, whether or not it already carries an
+        # override. What that key said before does not survive — the server keeps the exclusion
+        # alone, which is right: a start or a title for an occurrence that no longer happens
+        # describes nothing.
+        patch = self._override_patch(recurrence_overrides, recurrence_id, {"excluded": True})
 
         response = self._update(
-            {id: {"recurrenceOverrides": recurrence_overrides, "updated": utcnow()}},
+            {id: {**patch, "updated": utcnow()}},
             sendSchedulingMessages=send_scheduling_messages,
         )
 
@@ -457,6 +455,30 @@ class CalendarEventService(CalendarsService):
                 result["notUpdated"].update(not_updated)
 
         return result
+
+    @staticmethod
+    def _override_patch(overrides: dict, recurrence_id: str, override: dict) -> dict:
+        """The smallest write that lands `override` on one occurrence of a series.
+
+        JMAP refuses a patch whose parent isn't there — `recurrenceOverrides/<id>/<property>`
+        where that occurrence has no override yet, and `recurrenceOverrides/<id>` where the event
+        carries no overrides at all — both come back as "Patch operation failed". So the shape
+        follows what is already stored, and only an event with nothing at all is sent a map.
+
+        Which is the point: sending the map back is a read-modify-write over shared state. Every
+        other occurrence's override goes over the wire again, and anything written between the read
+        and the write — another client, another device, the same person in a second tab — is
+        overwritten by a copy taken before it existed. Patching one key touches one occurrence.
+        """
+
+        if not overrides:
+            return {"recurrenceOverrides": {recurrence_id: override}}
+        if recurrence_id in overrides:
+            return {
+                f"recurrenceOverrides/{recurrence_id}/{key}": value
+                for key, value in override.items()
+            }
+        return {f"recurrenceOverrides/{recurrence_id}": override}
 
     @staticmethod
     def _get_locations_map(locations: list[dict] | None = None) -> dict[str, dict] | None:


### PR DESCRIPTION
Closes #88.

Editing a single occurrence of a series now works, and the override writes behind it stop rewriting the whole map.

## The question was already being asked

Both recurring dialogs — the event modal's and the drag-and-drop one — ask *"just this instance, or all events in the series?"* and then render a single button: **Entire series**. `handleSaveRecurringEvent(true)` was never called from anywhere. In the modal the instance branch was fully written behind that missing button; in the grid it was this:

```js
// Editing a single instance of a series is not supported yet; the move is undone rather
// than left on screen as if it had been saved.
if (isUpdateInstance.value) return revertUpdate()
```

The server side has been there all along — the delete menu has been offering "This instance" through the same `recurrenceOverrides` mechanism for as long as it has existed.

So: both dialogs now offer the second answer, and the drag path writes an override for the occurrence that moved. The series is addressed by `master_id`, the occurrence by its recurrence id — its original start, which a drag leaves alone.

One related bug fixed in passing: the answer used to stand between drags. Drag a one-off event after having edited an instance and it would have been written as an override of a series it isn't part of; before the instance branch existed, it silently undid the move instead.

## Overrides are written one key at a time

`update_instance` and `delete_instance` both read the master's `recurrenceOverrides`, edited the map in memory and sent all of it back. That is a read-modify-write over shared state: every other occurrence's override goes over the wire again, and anything written between the read and the write — another client, another device, the same person in a second tab — is overwritten by a copy taken before it existed.

Each write now touches one key. The shape has to follow what is already stored, because the server refuses a patch whose parent isn't there:

| stored | patch that works |
| --- | --- |
| no overrides at all | `recurrenceOverrides` = `{<id>: {…}}` |
| overrides, but not this occurrence | `recurrenceOverrides/<id>` = `{…}` |
| this occurrence already overridden | `recurrenceOverrides/<id>/<property>` = … |

The other shapes come back as `invalidProperties` / "Patch operation failed". I confirmed each against a live Stalwart rather than reasoning about it.

## Verified against Stalwart

Three overrides in sequence, one per shape — written as a map, added as a key beside it, then patched as a property of the first. Each survived the next, and the deletes that followed took only the occurrences they named:

```
AFTER FIRST (map):    {"09-14": {start: 18:00}}
AFTER SECOND (key):   {"09-14": {start: 18:00}, "09-21": {title: "second"}}
AFTER THIRD (props):  {"09-14": {start: 18:00, title: "first, retitled"}, "09-21": {title: "second"}}
AFTER DELETES:        {"09-14": {start, title}, "09-21": {excluded}, "09-28": {excluded}}
```

And the drag path's own payload — the occurrence's new wall clock, its new length, the viewer's zone:

```
DRAGGING:   2026-09-14T15:00 (rid 2026-09-14T15:00)
AFTER DRAG: 09-07 15:00 PT1H | 09-15 09:30 PT2H | 09-21 15:00 PT1H
```

`test_instance_overrides_are_independent` covers the three shapes, and `test_recurrence` now also asserts the first override still stands after the writes that follow it. Both are Stalwart integration tests, so CI is their first run — running them locally provisions a member and an account against whatever server the site points at, which I didn't want to do unasked. Calendar unit suite green, production build clean.

## Two notes for whoever picks up the synthetic-id work

**Synthetic instance ids still aren't usable.** The upstream fix ([stalwartlabs/stalwart#2925](https://github.com/stalwartlabs/stalwart/issues/2925), Stalwart 0.16.20) lets `CalendarEvent/set` target an occurrence's synthetic id directly, which would replace the table above with one update. The server we talk to today still answers `"Updating synthetic ids is not yet supported."`, so that simplification waits on the upgrade — the override path is what works now, and it is what this uses.

**Synthetic ids are not stable.** Writing an override reshuffles them: before one, `eaaaark` was Sep 7 and `iaaaark` Sep 14; after, they had swapped. Anything holding an occurrence across a refetch has to key it by `(master_id, recurrence_id)` — `findLinkedEvent` already does, which is why deep links survive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HPDdovnpyUjuV1PEWXBHbL