### PR TITLE
fix(mail, calendar): let the account switcher keep its rows

### DIFF
--- a/frontend/src/apps/calendar/components/AppSidebar.vue
+++ b/frontend/src/apps/calendar/components/AppSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, inject, ref } from 'vue'
+import { computed, h, inject, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { LogOut, Settings, User } from 'lucide-vue-next'
+import { Check, LogOut, Settings, User } from 'lucide-vue-next'
 import {
 	Sidebar,
 	SidebarCollapseToggle,
@@ -132,10 +132,18 @@ const menuItems = computed(() => [
 			{
 				icon: User,
 				label: __('Accounts'),
+				// A tick on the account you are in, as in mail. Selection used to be a
+				// filled row, which on a list this short read as a hover that had stuck
+				// rather than as the answer to "which one am I in".
 				submenu: user.data.accounts.map?.((a) => ({
 					label: a._name,
-					selected: a.id === store.accountId,
 					onClick: () => router.push({ name: route.name, params: { ...route.params, accountId: a.id } }),
+					slots: {
+						suffix: () =>
+							a.id === store.accountId
+								? h(Check, { class: 'icon size-4 shrink-0 text-ink-gray-7' })
+								: null,
+					},
 				})),
 				condition: () => user.data.accounts?.length > 1,
 			},

--- a/frontend/src/apps/calendar/components/AppSidebar.vue
+++ b/frontend/src/apps/calendar/components/AppSidebar.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { computed, h, inject, ref } from 'vue'
+import { computed, inject, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import { Check, LogOut, Settings, User } from 'lucide-vue-next'
+import { LogOut, Settings, User } from 'lucide-vue-next'
 import {
 	Sidebar,
 	SidebarCollapseToggle,
@@ -14,6 +14,7 @@ import { CalendarColorMap } from 'frappe-ui/experimental'
 import { useNow, useStorage } from '@vueuse/core'
 
 import { useSessionStore } from '@/boot/session'
+import { accountSubmenu } from '@/composables/accountSubmenu'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import dayjs from '@/apps/calendar/utils/dayjs'
 import { toTitleCase } from '@/apps/calendar/utils/format'
@@ -132,19 +133,9 @@ const menuItems = computed(() => [
 			{
 				icon: User,
 				label: __('Accounts'),
-				// A tick on the account you are in, as in mail. Selection used to be a
-				// filled row, which on a list this short read as a hover that had stuck
-				// rather than as the answer to "which one am I in".
-				submenu: user.data.accounts.map?.((a) => ({
-					label: a._name,
-					onClick: () => router.push({ name: route.name, params: { ...route.params, accountId: a.id } }),
-					slots: {
-						suffix: () =>
-							a.id === store.accountId
-								? h(Check, { class: 'icon size-4 shrink-0 text-ink-gray-7' })
-								: null,
-					},
-				})),
+				submenu: accountSubmenu(user.data.accounts, store.accountId, (accountId) =>
+					router.push({ name: route.name, params: { ...route.params, accountId } }),
+				),
 				condition: () => user.data.accounts?.length > 1,
 			},
 			{

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -288,23 +288,21 @@ const menuItems = computed(() => [
 			{
 				icon: User,
 				label: __('Accounts'),
+				// The row is the menu's own — an avatar where an icon goes, the name as
+				// the label, a tick on the one you are in. It used to be a hand-built
+				// div standing in for the whole row, which meant re-declaring the
+				// padding, hover and truncation the row already had, and rebuilding its
+				// element on every render — so hovering an account destroyed the node
+				// under the pointer and the submenu closed before it could be clicked.
 				submenu: user.data.accounts.map?.((a) => ({
 					label: a._name,
 					onClick: () => switchAccount(a.id),
 					slots: {
-						item: () =>
-							h(
-								'div',
-								{
-									class: 'flex items-center gap-2 p-1.5 rounded-4 hover:bg-surface-gray-2 cursor-pointer w-48 shrink-0',
-								},
-								[
-									h(Avatar, { label: a._name, size: 'md' }),
-									h('span', { class: 'text-sm w-full truncate' }, a._name),
-									a.id === store.accountId &&
-										h(Check, { label: a._name, class: 'shrink-0 icon' }),
-								],
-							),
+						prefix: () => h(Avatar, { label: a._name, size: 'md' }),
+						suffix: () =>
+							a.id === store.accountId
+								? h(Check, { class: 'icon size-4 shrink-0 text-ink-gray-7' })
+								: null,
 					},
 				})),
 				condition: () => user.data.accounts?.length > 1 && !route.meta.isDashboard,

--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -117,9 +117,8 @@ import { computed, h, inject, onMounted, onUnmounted, ref } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useStorage } from '@vueuse/core'
 import { Icon } from 'frappe-ui/experimental'
-import { Check, Keyboard, User } from 'lucide-vue-next'
+import { Keyboard, User } from 'lucide-vue-next'
 import {
-	Avatar,
 	Button,
 	Dropdown,
 	Sidebar,
@@ -129,6 +128,7 @@ import {
 	SidebarSection,
 } from 'frappe-ui'
 
+import { accountSubmenu } from '@/composables/accountSubmenu'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
 import { getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
@@ -288,23 +288,7 @@ const menuItems = computed(() => [
 			{
 				icon: User,
 				label: __('Accounts'),
-				// The row is the menu's own — an avatar where an icon goes, the name as
-				// the label, a tick on the one you are in. It used to be a hand-built
-				// div standing in for the whole row, which meant re-declaring the
-				// padding, hover and truncation the row already had, and rebuilding its
-				// element on every render — so hovering an account destroyed the node
-				// under the pointer and the submenu closed before it could be clicked.
-				submenu: user.data.accounts.map?.((a) => ({
-					label: a._name,
-					onClick: () => switchAccount(a.id),
-					slots: {
-						prefix: () => h(Avatar, { label: a._name, size: 'md' }),
-						suffix: () =>
-							a.id === store.accountId
-								? h(Check, { class: 'icon size-4 shrink-0 text-ink-gray-7' })
-								: null,
-					},
-				})),
+				submenu: accountSubmenu(user.data.accounts, store.accountId, switchAccount),
 				condition: () => user.data.accounts?.length > 1 && !route.meta.isDashboard,
 			},
 			{

--- a/frontend/src/composables/accountSubmenu.test.ts
+++ b/frontend/src/composables/accountSubmenu.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { accountSubmenu } from './accountSubmenu'
+
+const accounts = [
+	{ id: 'one', _name: 'one@example.com' },
+	{ id: 'two', _name: 'two@example.com' },
+]
+
+describe('accountSubmenu', () => {
+	it('names every account', () => {
+		expect(accountSubmenu(accounts, 'one', () => {}).map((r) => r.label)).toEqual([
+			'one@example.com',
+			'two@example.com',
+		])
+	})
+
+	// The tick is the whole point: it answers "which account am I in" without
+	// filling the row, which on a list this short reads as a stuck hover.
+	it('ticks the account in use, and only that one', () => {
+		const ticked = accountSubmenu(accounts, 'two', () => {}).map((r) => !!r.slots.suffix())
+		expect(ticked).toEqual([false, true])
+	})
+
+	it('ticks nothing when the active account is not in the list', () => {
+		const ticked = accountSubmenu(accounts, 'gone', () => {}).map((r) => !!r.slots.suffix())
+		expect(ticked).toEqual([false, false])
+	})
+
+	it('gives every row an avatar', () => {
+		expect(accountSubmenu(accounts, 'one', () => {}).every((r) => !!r.slots.prefix())).toBe(true)
+	})
+
+	it('hands the picked account to the caller', () => {
+		const onSelect = vi.fn()
+		accountSubmenu(accounts, 'one', onSelect)[1]!.onClick()
+		expect(onSelect).toHaveBeenCalledWith('two')
+	})
+
+	it('has no rows to show before the accounts arrive', () => {
+		expect(accountSubmenu(undefined, 'one', () => {})).toEqual([])
+	})
+})

--- a/frontend/src/composables/accountSubmenu.ts
+++ b/frontend/src/composables/accountSubmenu.ts
@@ -1,0 +1,41 @@
+import { h } from 'vue'
+import { Avatar } from 'frappe-ui'
+import { Check } from 'lucide-vue-next'
+
+interface Account {
+	id: string
+	_name: string
+}
+
+/**
+ * The rows of the sidebar's account list.
+ *
+ * Mail and calendar show the same accounts, so they should say the same things
+ * about them — which is exactly what stopped being true once each app built its
+ * own rows: one grew an avatar and a tick, the other marked the current account
+ * by filling its row instead. Written once here so they cannot drift again.
+ *
+ * What legitimately differs between the two is only where picking an account
+ * takes you, so that is the one thing passed in.
+ *
+ * The row itself is the menu's own — avatar where an icon goes, name as the
+ * label, tick as a suffix. Standing in for the whole row with a custom `item`
+ * slot means re-declaring the padding, hover and truncation it already has, and
+ * costs the row its element on every render.
+ */
+export const accountSubmenu = (
+	accounts: Account[] | undefined,
+	activeId: string | undefined,
+	onSelect: (id: string) => void,
+) =>
+	(accounts ?? []).map((account) => ({
+		label: account._name,
+		onClick: () => onSelect(account.id),
+		slots: {
+			prefix: () => h(Avatar, { label: account._name, size: 'md' }),
+			suffix: () =>
+				account.id === activeId
+					? h(Check, { class: 'icon size-4 shrink-0 text-ink-gray-7' })
+					: null,
+		},
+	}))


### PR DESCRIPTION
Two fixes to the sidebar's account submenu, and the shared code that should have prevented the second one.

## Mail: the flyout closes before you can click an account

The account list couldn't be used with a mouse — moving the pointer off "Accounts" toward the accounts closed the submenu.

Each row was built by hand as a `slots.item`, a div standing in for the whole menu row and re-declaring the padding, hover and truncation the row already provides. That path renders the custom node through `MenuRenderContentAsChild`, which hands `<component :is>` a fresh object every render, so Vue rebuilds the element instead of patching it. A menu re-renders as you move through it — highlighting the item under the pointer is enough — so hovering an account destroyed the node the pointer was on, and the resulting leave read as leaving the menu.

The row is now the menu's own: avatar in `prefix`, name as the `label`, tick in `suffix`.

## Calendar: the current account is marked with a fill

`selected` paints `bg-surface-gray-3`, which on a list of two accounts reads as a hover that got stuck rather than as the answer to which account you're in.

## One list, not two

Both apps show the same accounts and should say the same things about them, which had stopped being true — that drift *is* the second bug. The rows are built in one place now (`composables/accountSubmenu.ts`); the only thing either app passes in is where picking an account takes you. Both call sites shrink, and the calendar list gains the avatar it was missing.

## Notes

The underlying `MenuRenderContentAsChild` bug is still there in frappe-ui — `:is="{ render: … }"` remounting every render is wrong regardless. Nothing in suite uses `slots.item` after this change, so nothing here depends on it, but it's worth fixing before the next caller reaches for that API.

Worth a look at both switchers: they should now be identical apart from the account names.