### PR TITLE
fix(mail): delete the site's push subscriptions when a user is disabled

### DIFF
--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -253,12 +253,10 @@ doc_events = {
             "suite.drive.utils.users.create_drive_settings",
             "suite.mail.events.create_user_settings",
         ],
-        # Before save, not on update: the mail server is still reachable for the user while
-        # the record reads as enabled (see delete_push_subscriptions_on_disable).
-        "before_save": [
-            "suite.mail.events.delete_push_subscriptions_on_disable",
-        ],
         "on_update": [
+            # First: the disabled account role applied below may cut the JMAP access the
+            # deletion needs.
+            "suite.mail.events.delete_push_subscriptions_on_disable",
             "suite.mail.events.update_account_password",
             "suite.mail.events.clear_sessions_on_disable",
             "suite.mail.events.apply_disabled_account_role",

--- a/suite/hooks.py
+++ b/suite/hooks.py
@@ -253,6 +253,11 @@ doc_events = {
             "suite.drive.utils.users.create_drive_settings",
             "suite.mail.events.create_user_settings",
         ],
+        # Before save, not on update: the mail server is still reachable for the user while
+        # the record reads as enabled (see delete_push_subscriptions_on_disable).
+        "before_save": [
+            "suite.mail.events.delete_push_subscriptions_on_disable",
+        ],
         "on_update": [
             "suite.mail.events.update_account_password",
             "suite.mail.events.clear_sessions_on_disable",

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -530,16 +530,41 @@ def delete_push_subscriptions(user: str, ids: list[str]) -> None:
     has_permission_for_user(user, raise_exception=True)
 
     service = get_push_subscription_service(user)
-    response = service.delete(ids)
+    _raise_for_not_destroyed(service.delete(ids))
 
-    if response.get("notDestroyed"):
-        error_messages = []
-        for id, error in response["notDestroyed"].items():
-            error_messages.append(f"{id}: {error['description']}")
-        frappe.throw(
-            _("Push Subscription Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
-            title=_("Push Subscription Deletion Error"),
-        )
+
+def delete_site_push_subscriptions(user: str) -> None:
+    """Deletes every subscription on the mail server that wears this site's device client id.
+
+    Used when the user is disabled: the subscriptions would otherwise keep webhooks flowing
+    for an account the site no longer serves, and the server only purges them at expiry.
+    Custom subscriptions carry their own device client id and are left alone. Login healing
+    recreates the site's subscription once the user is enabled again.
+    """
+
+    device_client_id = get_site_device_client_id(user)
+    service = get_push_subscription_service(user, ignore_permissions=True)
+
+    ids = [
+        subscription["id"]
+        for subscription in service.get()
+        if subscription.get("deviceClientId") == device_client_id
+    ]
+    if ids:
+        _raise_for_not_destroyed(service.delete(ids))
+
+
+def _raise_for_not_destroyed(response: dict) -> None:
+    """Surfaces the server's per-id errors from a delete response, if any."""
+
+    if not (not_destroyed := response.get("notDestroyed")):
+        return
+
+    error_messages = [f"{id}: {error['description']}" for id, error in not_destroyed.items()]
+    frappe.throw(
+        _("Push Subscription Deletion Error(s):<br>{0}").format("<br>".join(error_messages)),
+        title=_("Push Subscription Deletion Error"),
+    )
 
 
 @frappe.whitelist()

--- a/suite/mail/doctype/push_subscription/push_subscription.py
+++ b/suite/mail/doctype/push_subscription/push_subscription.py
@@ -539,11 +539,12 @@ def delete_site_push_subscriptions(user: str) -> None:
     Used when the user is disabled: the subscriptions would otherwise keep webhooks flowing
     for an account the site no longer serves, and the server only purges them at expiry.
     Custom subscriptions carry their own device client id and are left alone. Login healing
-    recreates the site's subscription once the user is enabled again.
+    recreates the site's subscription once the user is enabled again. The user is already
+    disabled when this runs, so the connection is opened with that allowed explicitly.
     """
 
     device_client_id = get_site_device_client_id(user)
-    service = get_push_subscription_service(user, ignore_permissions=True)
+    service = get_push_subscription_service(user, ignore_permissions=True, allow_disabled=True)
 
     ids = [
         subscription["id"]

--- a/suite/mail/events.py
+++ b/suite/mail/events.py
@@ -98,6 +98,30 @@ def update_account_password(doc: Document, method: str | None = None) -> None:
     )
 
 
+def delete_push_subscriptions_on_disable(doc: Document, method: str | None = None) -> None:
+    """Delete this site's push subscriptions on the mail server when the user is disabled.
+
+    Only the subscriptions wearing the site's device client id go; the user's custom ones stay.
+    Runs before save rather than on update: the JMAP connection refuses disabled users, and once
+    the flag is written the User record (cached or not) may already read as disabled.
+    """
+
+    if doc.flags.in_insert or doc.enabled or not doc.has_value_changed("enabled"):
+        return
+    if not is_jmap_configured(doc.name):
+        return
+
+    from suite.mail.doctype.push_subscription.push_subscription import delete_site_push_subscriptions
+
+    user = doc.name
+    execute_with_logging(
+        lambda: delete_site_push_subscriptions(user),
+        title="Failed to delete push subscriptions on mail server",
+        with_context=False,
+        module="Mail",
+    )
+
+
 def clear_sessions_on_disable(doc: Document, method: str | None = None) -> None:
     """Log the user out everywhere when they are disabled.
 

--- a/suite/mail/events.py
+++ b/suite/mail/events.py
@@ -102,8 +102,8 @@ def delete_push_subscriptions_on_disable(doc: Document, method: str | None = Non
     """Delete this site's push subscriptions on the mail server when the user is disabled.
 
     Only the subscriptions wearing the site's device client id go; the user's custom ones stay.
-    Runs before save rather than on update: the JMAP connection refuses disabled users, and once
-    the flag is written the User record (cached or not) may already read as disabled.
+    Ordered ahead of apply_disabled_account_role: that role may revoke the account's access on
+    Stalwart, after which the JMAP delete would be refused.
     """
 
     if doc.flags.in_insert or doc.enabled or not doc.has_value_changed("enabled"):

--- a/suite/mail/jmap/__init__.py
+++ b/suite/mail/jmap/__init__.py
@@ -33,12 +33,17 @@ from suite.utils.user import is_system_manager
 
 @request_cache
 def get_jmap_connection(
-    user: str, ignore_permissions: bool = False, timeout: tuple[float, float] = (30.0, 60.0)
+    user: str,
+    ignore_permissions: bool = False,
+    timeout: tuple[float, float] = (30.0, 60.0),
+    allow_disabled: bool = False,
 ) -> JMAPConnection:
     """Returns a JMAPConnection instance for the specified user, using the user's settings for connection details.
 
     Cached per request so the many service factories that resolve a connection for the same
     user reuse one instance (and skip the repeated password decryption / session lookup).
+    ``allow_disabled`` is for server-side cleanup that must still reach the mail server on
+    behalf of a user who has just been disabled; requests never pass it.
     """
 
     if not ignore_permissions:
@@ -50,7 +55,8 @@ def get_jmap_connection(
                 frappe.PermissionError,
             )
 
-    if not frappe.get_cached_value("User", user, "enabled"):
+    enabled = frappe.get_cached_value("User", user, "enabled")
+    if enabled is None or (not enabled and not allow_disabled):
         frappe.throw(_("User {0} does not exist or is disabled.").format(frappe.bold(user)))
 
     settings = frappe.db.exists("User Settings", {"user": user, "username": ["!=", None]})
@@ -229,10 +235,13 @@ def get_principal_service(
 def get_push_subscription_service(
     user: str,
     ignore_permissions: bool = False,
+    allow_disabled: bool = False,
 ) -> PushSubscriptionService:
     """Returns an instance of PushSubscriptionService for handling push subscription-related operations for the specified user."""
 
-    connection = get_jmap_connection(user, ignore_permissions=ignore_permissions)
+    connection = get_jmap_connection(
+        user, ignore_permissions=ignore_permissions, allow_disabled=allow_disabled
+    )
     return PushSubscriptionService(connection)
 
 

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -363,7 +363,7 @@ class DeleteSitePushSubscriptions(unittest.TestCase):
             ]
         )
 
-        service.assert_called_once_with(USER, ignore_permissions=True)
+        service.assert_called_once_with(USER, ignore_permissions=True, allow_disabled=True)
         service.return_value.delete.assert_called_once_with(["site-1", "site-2"])
 
     def test_nothing_to_delete_skips_the_delete_call(self):
@@ -431,3 +431,29 @@ class DeletePushSubscriptionsOnDisable(unittest.TestCase):
             events.delete_push_subscriptions_on_disable(doc)
 
         log_error.assert_called_once()
+
+
+class GetJMAPConnectionForDisabledUser(unittest.TestCase):
+    """The factory refuses disabled users unless the caller says the disabled state is expected."""
+
+    def _run(self, enabled: int | None, allow_disabled: bool = False) -> None:
+        from suite.mail import jmap
+
+        with (
+            mock.patch.object(jmap.frappe, "get_cached_value", return_value=enabled),
+            # No User Settings: a call that gets past the enabled check fails here instead.
+            mock.patch.object(jmap.frappe.db, "exists", return_value=None),
+            self.assertRaises(frappe.ValidationError) as raised,
+        ):
+            jmap.get_jmap_connection(USER, ignore_permissions=True, allow_disabled=allow_disabled)
+
+        return str(raised.exception)
+
+    def test_disabled_user_is_refused_by_default(self):
+        self.assertIn("disabled", self._run(enabled=0))
+
+    def test_allow_disabled_lets_the_call_through(self):
+        self.assertIn("JMAP settings", self._run(enabled=0, allow_disabled=True))
+
+    def test_allow_disabled_still_refuses_a_missing_user(self):
+        self.assertIn("does not exist", self._run(enabled=None, allow_disabled=True))

--- a/suite/mail/tests/test_push_subscription_healing.py
+++ b/suite/mail/tests/test_push_subscription_healing.py
@@ -9,6 +9,7 @@ import unittest
 from datetime import timedelta
 from unittest import mock
 
+import frappe
 from frappe.utils.file_lock import LockTimeoutError
 
 from suite.mail.doctype.push_subscription import push_subscription
@@ -339,3 +340,94 @@ class OnLogin(unittest.TestCase):
 
     def test_skips_users_without_jmap(self):
         self._run(USER, jmap_configured=False).assert_not_called()
+
+
+class DeleteSitePushSubscriptions(unittest.TestCase):
+    def _run(self, subscriptions: list[dict], not_destroyed: dict | None = None) -> mock.Mock:
+        with (
+            mock.patch.object(push_subscription, "get_site_device_client_id", return_value="site-device"),
+            mock.patch.object(push_subscription, "get_push_subscription_service") as service,
+        ):
+            service.return_value.get.return_value = subscriptions
+            service.return_value.delete.return_value = {"destroyed": [], "notDestroyed": not_destroyed or {}}
+            push_subscription.delete_site_push_subscriptions(USER)
+
+        return service
+
+    def test_deletes_only_the_site_subscriptions(self):
+        service = self._run(
+            [
+                {"id": "site-1", "deviceClientId": "site-device"},
+                {"id": "custom", "deviceClientId": "other-device"},
+                {"id": "site-2", "deviceClientId": "site-device"},
+            ]
+        )
+
+        service.assert_called_once_with(USER, ignore_permissions=True)
+        service.return_value.delete.assert_called_once_with(["site-1", "site-2"])
+
+    def test_nothing_to_delete_skips_the_delete_call(self):
+        service = self._run([{"id": "custom", "deviceClientId": "other-device"}])
+
+        service.return_value.delete.assert_not_called()
+
+    def test_server_side_delete_errors_surface(self):
+        with self.assertRaises(push_subscription.frappe.ValidationError):
+            self._run(
+                [{"id": "site-1", "deviceClientId": "site-device"}],
+                not_destroyed={"site-1": {"type": "notFound", "description": "gone"}},
+            )
+
+
+class DeletePushSubscriptionsOnDisable(unittest.TestCase):
+    def _run(
+        self,
+        enabled: int = 0,
+        changed: bool = True,
+        in_insert: bool = False,
+        jmap_configured: bool = True,
+    ) -> mock.Mock:
+        from suite.mail import events
+
+        doc = mock.Mock()
+        doc.name = USER
+        doc.enabled = enabled
+        doc.flags = frappe._dict(in_insert=in_insert)
+        doc.has_value_changed.return_value = changed
+
+        with (
+            mock.patch.object(events, "is_jmap_configured", return_value=jmap_configured),
+            mock.patch.object(push_subscription, "delete_site_push_subscriptions") as delete,
+        ):
+            events.delete_push_subscriptions_on_disable(doc)
+
+        return delete
+
+    def test_disabling_deletes_the_site_subscriptions(self):
+        self._run().assert_called_once_with(USER)
+
+    def test_enabled_user_or_unchanged_flag_is_ignored(self):
+        self._run(enabled=1).assert_not_called()
+        self._run(changed=False).assert_not_called()
+        self._run(in_insert=True).assert_not_called()
+
+    def test_users_without_jmap_are_skipped(self):
+        self._run(jmap_configured=False).assert_not_called()
+
+    def test_server_failure_is_logged_not_raised(self):
+        from suite.mail import events
+
+        doc = mock.Mock()
+        doc.name = USER
+        doc.enabled = 0
+        doc.flags = frappe._dict()
+        doc.has_value_changed.return_value = True
+
+        with (
+            mock.patch.object(events, "is_jmap_configured", return_value=True),
+            mock.patch.object(push_subscription, "delete_site_push_subscriptions", side_effect=RuntimeError),
+            mock.patch("suite.utils.log_error") as log_error,
+        ):
+            events.delete_push_subscriptions_on_disable(doc)
+
+        log_error.assert_called_once()


### PR DESCRIPTION
## Summary
- Disabling a user now deletes this site's push subscriptions on the mail server. Only subscriptions carrying the site's deterministic device client id are removed; the user's custom subscriptions stay.
- New `delete_site_push_subscriptions` helper in the Push Subscription module, sharing the per-id error reporting with the existing delete path.
- New `delete_push_subscriptions_on_disable` User handler, first in the `on_update` list so it runs ahead of `apply_disabled_account_role`, whose Stalwart role may cut the JMAP access the deletion needs.
- The JMAP connection factory gains an explicit `allow_disabled` keyword, passed only by this cleanup, so it can reach the mail server for a user whose record already reads as disabled. Requests never pass it.
- Re-enable needs no counterpart: login healing recreates the site subscription on the user's next sign-in.

## Test plan
- 10 new unit tests in `suite/mail/tests/test_push_subscription_healing.py` cover filtering by device client id, skipping the delete when nothing matches, surfacing server-side errors, the handler's guards, log-not-raise on failure, and the connection factory refusing disabled users unless `allow_disabled` is passed while still refusing missing users. Module passes (37 tests).
- Verified live on a dev site by disabling a JMAP-configured user inside a rolled-back transaction with the User document cache cleared: the handler ran before the disabled-role handler, the connection opened with the record reading disabled, the delete succeeded, and no Error Log entry was written.