### PR TITLE
fix: standardize app page metadata

### DIFF
--- a/frontend/src/apps/calendar/pages/CalendarView.vue
+++ b/frontend/src/apps/calendar/pages/CalendarView.vue
@@ -5,6 +5,7 @@ import { Button, Dialog, TabButtons, createResource, usePageMeta } from 'frappe-
 import { Calendar } from 'frappe-ui/experimental'
 
 import { useScreenSize } from '@/composables/useScreenSize'
+import { appPageMeta } from '@/utils/documentTitle'
 import { raiseToast } from '@/apps/calendar/utils'
 import { fromEventZone } from '@/apps/calendar/utils/datetime'
 import { eventLastDay, isAllDayEvent } from '@/apps/calendar/utils/eventTime'
@@ -31,7 +32,7 @@ const ROUTE_TO_VIEW = { 'calendar-month': 'Month', 'calendar-week': 'Week', 'cal
 const routeNameForView = (view) => VIEW_TO_ROUTE[view as keyof typeof VIEW_TO_ROUTE]
 const viewForRouteName = (name) => ROUTE_TO_VIEW[name as keyof typeof ROUTE_TO_VIEW]
 
-usePageMeta(() => ({ title: calendarRef.value?.currentMonthYear || __('Frappe Calendar') }))
+usePageMeta(() => appPageMeta(calendarRef.value?.currentMonthYear || __('Frappe Calendar'), 'Calendar'))
 
 watch(
 	() => [

--- a/frontend/src/apps/drive/components/EditableBreadcrumbs.vue
+++ b/frontend/src/apps/drive/components/EditableBreadcrumbs.vue
@@ -7,7 +7,7 @@
     </div>
     <template v-else-if="isEditing">
       <template v-if="parentItems.length">
-        <Breadcrumbs :items="parentItems" />
+        <Breadcrumbs class="parent-breadcrumbs" :items="parentItems" />
         <span class="mx-0.5 text-base text-ink-gray-4" aria-hidden="true">/</span>
       </template>
       <InlineRenameInput :entity="entity" appearance="breadcrumb" />
@@ -50,3 +50,9 @@ const displayItems = computed(() => {
   return items
 })
 </script>
+
+<style scoped>
+.parent-breadcrumbs :deep(a) {
+  color: var(--ink-gray-5);
+}
+</style>

--- a/frontend/src/apps/drive/pages/File.vue
+++ b/frontend/src/apps/drive/pages/File.vue
@@ -48,6 +48,7 @@ import { Button } from 'frappe-ui'
 import FileRender from '@/apps/drive/components/FileRender.vue'
 import FilePreviewSkeleton from '@/apps/drive/components/FileTypePreview/FilePreviewSkeleton.vue'
 import { createResource } from 'frappe-ui'
+import { appDocumentTitle } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import LucideScan from '~icons/lucide/scan'
 import { onKeyStroke } from '@vueuse/core'
@@ -110,7 +111,7 @@ const onSuccess = async (entity) => {
     await router.push({ name: 'writer-document', params: { id: entity.name } })
     return
   }
-  document.title = entity.file_name
+  document.title = appDocumentTitle(entity.file_name, 'Drive')
   setCrumbEntity(entity)
   updateURLSlug(entity.file_name)
   trackVisit.submit({ entity_name: entity.name })

--- a/frontend/src/apps/drive/pages/Folder.vue
+++ b/frontend/src/apps/drive/pages/Folder.vue
@@ -14,6 +14,7 @@
 import GenericPage from '@/apps/drive/components/GenericPage.vue'
 import { watch, computed, onUnmounted } from 'vue'
 import { createResource } from 'frappe-ui'
+import { appDocumentTitle } from '@/utils/documentTitle'
 import { COMMON_OPTIONS } from '@/apps/drive/resources/files'
 import { prettyData, setCache, updateURLSlug } from '@/apps/drive/utils/files'
 import { setCrumbEntity, clearCrumbEntity } from '@/apps/drive/data/breadcrumbs'
@@ -45,7 +46,7 @@ setCache(getFolderContents, ['folder', props.entityName])
 
 const onSuccess = (entity) => {
   if (router.currentRoute.value.params.entityName !== entity.name) return
-  document.title = 'Folder - ' + entity.file_name
+  document.title = appDocumentTitle(entity.file_name, 'Drive')
   setCrumbEntity(entity)
   updateURLSlug(entity.file_name)
 }

--- a/frontend/src/apps/drive/routes.ts
+++ b/frontend/src/apps/drive/routes.ts
@@ -2,6 +2,7 @@ import type { RouteRecordRaw } from 'vue-router'
 import { createResource } from 'frappe-ui'
 
 import { useSessionStore } from '@/boot/session'
+import { appDocumentTitle } from '@/utils/documentTitle'
 
 /**
  * Drive route module — mounted by the suite router under the '/drive' prefix.
@@ -22,7 +23,7 @@ import { useSessionStore } from '@/boot/session'
 
 const setPageTitle = (to: any) => {
   if (useSessionStore().isLoggedIn) {
-    document.title = __(String(to.name).replace(/^drive-/, ''))
+    document.title = appDocumentTitle(__(String(to.name).replace(/^drive-/, '')), 'Drive')
   }
 }
 

--- a/frontend/src/apps/drive/utils/files.js
+++ b/frontend/src/apps/drive/utils/files.js
@@ -17,6 +17,7 @@ import { set } from 'idb-keyval'
 import { toast } from '@/apps/drive/utils/toasts.js'
 import { useFileUpload, toast as nToast } from 'frappe-ui'
 import emitter from '@/apps/drive/emitter'
+import { appDocumentTitle } from '@/utils/documentTitle'
 
 import folderIcon from '../../../../../suite/public/drive/images/icons/folder.svg'
 import imageIcon from '../../../../../suite/public/drive/images/icons/image.svg'
@@ -540,10 +541,7 @@ export function dynamicList(k) {
   return k.filter((a) => typeof a !== 'object' || !('cond' in a) || a.cond)
 }
 
-export const setTitle = (file_name) =>
-  (document.title =
-    (router.currentRoute.value.name === 'drive-Folder' ? 'Folder - ' : '') +
-    file_name)
+export const setTitle = (file_name) => (document.title = appDocumentTitle(file_name, 'Drive'))
 
 async function uploadImage(file, params) {
   const uploader = useFileUpload()

--- a/frontend/src/apps/mail/pages/AddressBookView.vue
+++ b/frontend/src/apps/mail/pages/AddressBookView.vue
@@ -91,6 +91,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useTemplateRef } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { useDebounceFn, watchDebounced } from '@vueuse/core'
 import { Pin, Trash2 } from 'lucide-vue-next'
@@ -183,7 +184,7 @@ const loadMoreContacts = useDebounceFn((e) => {
 
 const addressBookDisplay = computed(() => addressBook.doc?._name || addressBookName)
 
-usePageMeta(() => ({ title: addressBookDisplay.value }))
+usePageMeta(() => appPageMeta(addressBookDisplay.value, 'Mail'))
 
 const breadcrumbs = computed(() => [
 	{ label: __('Address Books'), route: '/mail/address-books' },

--- a/frontend/src/apps/mail/pages/AddressBooksView.vue
+++ b/frontend/src/apps/mail/pages/AddressBooksView.vue
@@ -46,6 +46,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import {
 	Badge, FormControl, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon, ListEmptyState, ListHeader, ListRow, ListRows, ListView } from 'frappe-ui/experimental'
@@ -54,7 +55,7 @@ import { userStore } from '@/apps/mail/stores/user'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import AddAddressBookModal from '@/apps/mail/components/Modals/AddAddressBookModal.vue'
 
-usePageMeta(() => ({ title: __('Address Books') }))
+usePageMeta(() => appPageMeta(__('Address Books'), 'Mail'))
 
 const { addressBooks } = userStore()
 

--- a/frontend/src/apps/mail/pages/AllInboxesView.vue
+++ b/frontend/src/apps/mail/pages/AllInboxesView.vue
@@ -171,6 +171,7 @@
 
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRoute, useRouter } from 'vue-router'
 import { LoaderCircle, RefreshCw } from 'lucide-vue-next'
 import { Breadcrumbs, Button, call, createResource, usePageMeta } from 'frappe-ui'
@@ -1019,7 +1020,7 @@ const unreadPrefix = computed(() =>
 	store.allInboxesUnread.data ? `(${store.allInboxesUnread.data})` : '',
 )
 
-usePageMeta(() => ({ title: `${unreadPrefix.value} ${__('All Inboxes')}` }))
+usePageMeta(() => appPageMeta(`${unreadPrefix.value} ${__('All Inboxes')}`, 'Mail'))
 
 // Keep the merged list fresh: poll periodically and react to new-mail push events (which can arrive
 // for any account). Both merge the newest window at the top, preserving scroll.

--- a/frontend/src/apps/mail/pages/ContactView.vue
+++ b/frontend/src/apps/mail/pages/ContactView.vue
@@ -210,6 +210,7 @@
 
 <script setup lang="ts">
 import { capitalize, computed, inject, ref, useTemplateRef } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Trash2 } from 'lucide-vue-next'
 import {
@@ -369,7 +370,7 @@ const contactDisplay = computed(
 	() => contact.doc?.full_name || contact.doc?.emails[0]?.address || contactName,
 )
 
-usePageMeta(() => ({ title: contactDisplay.value }))
+usePageMeta(() => appPageMeta(contactDisplay.value, 'Mail'))
 
 const breadcrumbs = computed(() => [
 	{ label: __('Contacts'), route: '/mail/contacts' },

--- a/frontend/src/apps/mail/pages/ContactsView.vue
+++ b/frontend/src/apps/mail/pages/ContactsView.vue
@@ -40,6 +40,7 @@
 
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useDebounceFn, watchDebounced } from '@vueuse/core'
 import {
 	Button, Dialog, FormControl, createResource, usePageMeta } from 'frappe-ui'
@@ -52,7 +53,7 @@ import AddContactModal from '@/apps/mail/components/Modals/AddContactModal.vue'
 
 const { accountId } = defineProps<{ accountId: string }>()
 
-usePageMeta(() => ({ title: __('Contacts') }))
+usePageMeta(() => appPageMeta(__('Contacts'), 'Mail'))
 
 const store = userStore()
 

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -455,6 +455,7 @@
 </template>
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRoute, useRouter } from 'vue-router'
 import {
 	Archive,
@@ -1599,8 +1600,8 @@ const currentThread = computed(() =>
 )
 
 usePageMeta(() => {
-	if (threadID) return { title: currentThread.value?.subject || __('[No Subject]') }
-	return { title: `${unreadThreadsPrefix.value} ${mailboxName.value}` }
+	if (threadID) return appPageMeta(currentThread.value?.subject || __('[No Subject]'), 'Mail')
+	return appPageMeta(`${unreadThreadsPrefix.value} ${mailboxName.value}`, 'Mail')
 })
 
 const title = computed(() => {

--- a/frontend/src/apps/mail/pages/OutboxView.vue
+++ b/frontend/src/apps/mail/pages/OutboxView.vue
@@ -107,6 +107,7 @@
 
 <script setup lang="ts">
 import { computed, inject, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { useDebounceFn, watchDebounced } from '@vueuse/core'
 import { EllipsisVertical, Mail } from 'lucide-vue-next'
@@ -144,7 +145,7 @@ import MobileTitleHeader from '@/apps/mail/components/mobile/MobileTitleHeader.v
 import OutboxFilters from '@/apps/mail/components/OutboxFilters.vue'
 import ScheduleSendModal from '@/apps/mail/components/Modals/ScheduleSendModal.vue'
 
-usePageMeta(() => ({ title: __('Outbox') }))
+usePageMeta(() => appPageMeta(__('Outbox'), 'Mail'))
 
 const store = userStore()
 const router = useRouter()

--- a/frontend/src/apps/mail/pages/ScreenerView.vue
+++ b/frontend/src/apps/mail/pages/ScreenerView.vue
@@ -423,6 +423,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import {
 	Archive,
@@ -764,10 +765,11 @@ usePageMeta(() => {
 	// Name the open sender, the way the mailbox view names the open thread. The queue's own title is
 	// the right one for the list, but it made every sender's page — each its own URL, each shareable
 	// and restorable — read as the same tab, and the count kept moving under it as you triaged.
-	if (openSender.value) return { title: openSender.value.from_name || openSender.value.from_email }
+	if (openSender.value)
+		return appPageMeta(openSender.value.from_name || openSender.value.from_email, 'Mail')
 
 	const n = senders.data?.length ?? 0
-	return { title: n ? `(${n}) ${__('Screener')}` : __('Screener') }
+	return appPageMeta(n ? `(${n}) ${__('Screener')}` : __('Screener'), 'Mail')
 })
 
 const waitingLabel = computed(() => {

--- a/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
+++ b/frontend/src/apps/mail/pages/SubmissionDetailsView.vue
@@ -144,6 +144,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { ArrowUpRight } from 'lucide-vue-next'
 import { Breadcrumbs, Button, Dialog, Skeleton, createResource, usePageMeta } from 'frappe-ui'
@@ -218,7 +219,7 @@ const data = computed<SubmissionDetails | null>(() =>
 // and be replaced.
 const title = computed(() => (data.value ? subjectLabel(data.value) : ''))
 
-usePageMeta(() => ({ title: title.value || __('Outbox') }))
+usePageMeta(() => appPageMeta(title.value || __('Outbox'), 'Mail'))
 
 const summary = computed(() => (data.value ? statusSummary(data.value) : ''))
 const activity = computed(() => (data.value ? activityEntries(data.value) : []))

--- a/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ActionsView.vue
@@ -40,6 +40,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { Button, Dialog, Tooltip, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
 
@@ -68,7 +69,7 @@ type ActionField = {
 	options?: ActionOption[]
 }
 
-usePageMeta(() => ({ title: __('Actions') }))
+usePageMeta(() => appPageMeta(__('Actions'), 'Mail'))
 
 // Input fields for the parameterized actions (parameterless actions run directly).
 const ACTION_FIELDS: Record<string, ActionField[]> = {

--- a/frontend/src/apps/mail/pages/dashboard/DeliveryTestView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DeliveryTestView.vue
@@ -50,6 +50,7 @@
 </template>
 <script setup lang="ts">
 import { onUnmounted, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { Button, FormControl, LoadingIndicator, usePageMeta } from 'frappe-ui'
 
 import { raiseToast } from '@/apps/mail/utils'
@@ -58,7 +59,7 @@ import DashboardCard from '@/apps/mail/components/DashboardCard.vue'
 
 type TraceEvent = { type: string; [key: string]: unknown }
 
-usePageMeta(() => ({ title: __('Delivery Test') }))
+usePageMeta(() => appPageMeta(__('Delivery Test'), 'Mail'))
 
 const target = ref('')
 const running = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DkimSignatureView.vue
@@ -67,6 +67,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Dialog, Dropdown, Tooltip, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -101,7 +102,7 @@ const router = useRouter()
 
 const showDelete = ref(false)
 
-usePageMeta(() => ({ title: (signature.data as DkimData | undefined)?.selector || signatureId }))
+usePageMeta(() => appPageMeta((signature.data as DkimData | undefined)?.selector || signatureId, 'Mail'))
 
 const signature = createResource({
 	url: 'suite.mail.api.admin.get_dkim_signature',

--- a/frontend/src/apps/mail/pages/dashboard/DkimSignaturesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DkimSignaturesView.vue
@@ -30,6 +30,7 @@
 	</DashboardLayout>
 </template>
 <script setup lang="ts">
+import { appPageMeta } from '@/utils/documentTitle'
 import { createResource, usePageMeta } from 'frappe-ui'
 import { ListEmptyState, ListHeader, ListRow, ListRowItem, ListRows, ListView } from 'frappe-ui/experimental'
 
@@ -37,7 +38,7 @@ import { fromNow } from '@/apps/mail/utils/datetime'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 
-usePageMeta(() => ({ title: __('DKIM Signatures') }))
+usePageMeta(() => appPageMeta(__('DKIM Signatures'), 'Mail'))
 
 const signatures = createResource({
 	url: 'suite.mail.api.admin.get_dkim_signatures',

--- a/frontend/src/apps/mail/pages/dashboard/DomainView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainView.vue
@@ -80,6 +80,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
@@ -113,7 +114,7 @@ const getErrorMessage = (error: ResourceError) =>
 
 const { domainId } = defineProps<{ domainId: string }>()
 
-usePageMeta(() => ({ title: domain.data?.name || domainId }))
+usePageMeta(() => appPageMeta(domain.data?.name || domainId, 'Mail'))
 
 const router = useRouter()
 

--- a/frontend/src/apps/mail/pages/dashboard/DomainsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/DomainsView.vue
@@ -59,6 +59,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import {
 	Badge, FormControl, createResource, usePageMeta } from 'frappe-ui'
@@ -69,7 +70,7 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddDomainModal from '@/apps/mail/components/Modals/AddDomainModal.vue'
 
-usePageMeta(() => ({ title: __('Domains') }))
+usePageMeta(() => appPageMeta(__('Domains'), 'Mail'))
 
 const showAddDomain = ref(false)
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/GroupView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/GroupView.vue
@@ -126,6 +126,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import {
 	Button, Dialog, Dropdown, FormControl, Switch, Tooltip, createResource, usePageMeta } from 'frappe-ui'
@@ -165,7 +166,7 @@ const { groupId } = defineProps<{ groupId: string }>()
 const router = useRouter()
 const { localeLabel } = useAccountOptions()
 
-usePageMeta(() => ({ title: (member.data as GroupData | undefined)?.email || groupId }))
+usePageMeta(() => appPageMeta((member.data as GroupData | undefined)?.email || groupId, 'Mail'))
 
 const showEdit = ref(false)
 const showEditQuota = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/GroupsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/GroupsView.vue
@@ -43,6 +43,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import { FormControl, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -53,7 +54,7 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddGroupModal from '@/apps/mail/components/Modals/AddGroupModal.vue'
 
-usePageMeta(() => ({ title: __('Groups') }))
+usePageMeta(() => appPageMeta(__('Groups'), 'Mail'))
 
 const showAddGroup = ref(false)
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/LogView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/LogView.vue
@@ -30,6 +30,7 @@
 </template>
 <script setup lang="ts">
 import { computed } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Button, createResource, usePageMeta } from 'frappe-ui'
 
@@ -55,7 +56,7 @@ type LogData = {
 const { logId } = defineProps<{ logId: string }>()
 const router = useRouter()
 
-usePageMeta(() => ({ title: __('Log Entry') }))
+usePageMeta(() => appPageMeta(__('Log Entry'), 'Mail'))
 
 const log = createResource({
 	url: 'suite.mail.api.admin.get_log',

--- a/frontend/src/apps/mail/pages/dashboard/LogsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/LogsView.vue
@@ -58,6 +58,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import {
 	Badge, Button, FormControl, createResource, usePageMeta } from 'frappe-ui'
@@ -78,7 +79,7 @@ type LogRow = {
 	details?: string
 }
 
-usePageMeta(() => ({ title: __('Logs') }))
+usePageMeta(() => appPageMeta(__('Logs'), 'Mail'))
 
 const PAGE_LENGTH = 100
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MailingListView.vue
@@ -108,6 +108,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import {
 	Button, Dialog, Dropdown, FormControl, Switch, Tooltip, createResource, usePageMeta } from 'frappe-ui'
@@ -136,7 +137,7 @@ const { listId } = defineProps<{ listId: string }>()
 
 const router = useRouter()
 
-usePageMeta(() => ({ title: (list.data as ListData | undefined)?.email || listId }))
+usePageMeta(() => appPageMeta((list.data as ListData | undefined)?.email || listId, 'Mail'))
 
 const showEdit = ref(false)
 const showAddEmail = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/MailingListsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MailingListsView.vue
@@ -41,6 +41,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import { FormControl, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -50,7 +51,7 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddMailingListModal from '@/apps/mail/components/Modals/AddMailingListModal.vue'
 
-usePageMeta(() => ({ title: __('Mailing Lists') }))
+usePageMeta(() => appPageMeta(__('Mailing Lists'), 'Mail'))
 
 const showAdd = ref(false)
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/MemberView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MemberView.vue
@@ -173,6 +173,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import {
 	Button, Dialog, Dropdown, Switch, Tooltip, createResource, usePageMeta } from 'frappe-ui'
@@ -214,7 +215,7 @@ const { memberId } = defineProps<{ memberId: string }>()
 const router = useRouter()
 const { localeLabel } = useAccountOptions()
 
-usePageMeta(() => ({ title: memberId }))
+usePageMeta(() => appPageMeta(memberId, 'Mail'))
 
 const showDeleteMember = ref(false)
 const showResetPassword = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/MembersView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/MembersView.vue
@@ -28,6 +28,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, useTemplateRef } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRoute, useRouter } from 'vue-router'
 import { Mails, Users } from 'lucide-vue-next'
 import { Tabs, usePageMeta } from 'frappe-ui'
@@ -37,7 +38,7 @@ import UsersView from '@/apps/mail/pages/dashboard/UsersView.vue'
 import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import AddMemberModal from '@/apps/mail/components/Modals/AddMemberModal.vue'
 
-usePageMeta(() => ({ title: __('Members') }))
+usePageMeta(() => appPageMeta(__('Members'), 'Mail'))
 
 const route = useRoute()
 const router = useRouter()

--- a/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OAuthClientView.vue
@@ -84,6 +84,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Button, Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -103,7 +104,7 @@ import AddOAuthRedirectUrisModal from '@/apps/mail/components/Modals/AddOAuthRed
 const { clientId } = defineProps<{ clientId: string }>()
 const router = useRouter()
 
-usePageMeta(() => ({ title: client.data?.client_id || clientId }))
+usePageMeta(() => appPageMeta(client.data?.client_id || clientId, 'Mail'))
 
 const showEdit = ref(false)
 const showAddContacts = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/OAuthClientsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OAuthClientsView.vue
@@ -43,6 +43,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import { FormControl, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -53,7 +54,7 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddOAuthClientModal from '@/apps/mail/components/Modals/AddOAuthClientModal.vue'
 
-usePageMeta(() => ({ title: __('OAuth Clients') }))
+usePageMeta(() => appPageMeta(__('OAuth Clients'), 'Mail'))
 
 const showAdd = ref(false)
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/OverviewView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/OverviewView.vue
@@ -82,6 +82,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Badge, Button, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -120,7 +121,7 @@ type OverviewData = {
 	recent_logs: LogEntry[]
 }
 
-usePageMeta(() => ({ title: __('Overview') }))
+usePageMeta(() => appPageMeta(__('Overview'), 'Mail'))
 
 const router = useRouter()
 

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessageView.vue
@@ -88,6 +88,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import {
 	Badge, Button, Dialog, Dropdown, LoadingIndicator, createResource, usePageMeta } from 'frappe-ui'
@@ -130,7 +131,7 @@ type MessageData = {
 const { messageId } = defineProps<{ messageId: string }>()
 const router = useRouter()
 
-usePageMeta(() => ({ title: __('Queued Message') }))
+usePageMeta(() => appPageMeta(__('Queued Message'), 'Mail'))
 
 const showEditMessage = ref(false)
 const showEditRecipient = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/QueuedMessagesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/QueuedMessagesView.vue
@@ -60,6 +60,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import {
 	Button, Dialog, FormControl, createResource, usePageMeta } from 'frappe-ui'
@@ -81,7 +82,7 @@ type QueueRow = {
 	created_at?: string
 }
 
-usePageMeta(() => ({ title: __('Queued') }))
+usePageMeta(() => appPageMeta(__('Queued'), 'Mail'))
 
 const PAGE_LENGTH = 50
 const search = ref('')

--- a/frontend/src/apps/mail/pages/dashboard/ReportView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ReportView.vue
@@ -44,6 +44,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Button, Dialog, Dropdown, createResource, usePageMeta } from 'frappe-ui'
 
@@ -85,7 +86,7 @@ const detailTitle = computed(() => {
 	return `${dir} ${KIND_LABELS[kind] || kind} ${__('Report')}`
 })
 
-usePageMeta(() => ({ title: listTitle.value }))
+usePageMeta(() => appPageMeta(listTitle.value, 'Mail'))
 
 const showDelete = ref(false)
 

--- a/frontend/src/apps/mail/pages/dashboard/ReportsView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/ReportsView.vue
@@ -46,6 +46,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import {
 	Button, Dialog, FormControl, createResource, usePageMeta } from 'frappe-ui'
@@ -75,7 +76,7 @@ const title = computed(() => {
 	return `${dir} ${KIND_LABELS[kind] || kind} ${__('Reports')}`
 })
 
-usePageMeta(() => ({ title: title.value }))
+usePageMeta(() => appPageMeta(title.value, 'Mail'))
 
 const reports = createResource({
 	url: 'suite.mail.api.admin.get_reports',

--- a/frontend/src/apps/mail/pages/dashboard/RoleView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/RoleView.vue
@@ -56,6 +56,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { useRouter } from 'vue-router'
 import { Button, Dialog, Dropdown, MultiSelect, createResource, usePageMeta } from 'frappe-ui'
 
@@ -78,7 +79,7 @@ type RoleData = {
 const { roleId } = defineProps<{ roleId: string }>()
 const router = useRouter()
 
-usePageMeta(() => ({ title: (role.data as RoleData | undefined)?.description || roleId }))
+usePageMeta(() => appPageMeta((role.data as RoleData | undefined)?.description || roleId, 'Mail'))
 
 const showEdit = ref(false)
 const showDelete = ref(false)

--- a/frontend/src/apps/mail/pages/dashboard/RolesView.vue
+++ b/frontend/src/apps/mail/pages/dashboard/RolesView.vue
@@ -41,6 +41,7 @@
 </template>
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { appPageMeta } from '@/utils/documentTitle'
 import { watchDebounced } from '@vueuse/core'
 import { FormControl, createResource, usePageMeta } from 'frappe-ui'
 import { Icon as FeatherIcon } from 'frappe-ui/experimental'
@@ -50,7 +51,7 @@ import DashboardLayout from '@/apps/mail/components/DashboardLayout.vue'
 import DashboardListSkeleton from '@/apps/mail/components/DashboardListSkeleton.vue'
 import AddRoleModal from '@/apps/mail/components/Modals/AddRoleModal.vue'
 
-usePageMeta(() => ({ title: __('Roles') }))
+usePageMeta(() => appPageMeta(__('Roles'), 'Mail'))
 
 const showAdd = ref(false)
 const search = ref('')

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -282,7 +282,7 @@
 </template>
 
 <script setup lang="ts">
-import { Badge, Button, toast, useCall, useDoc } from "frappe-ui";
+import { Badge, Button, toast, useCall, useDoc, usePageMeta } from "frappe-ui";
 import { computed, h, onMounted, onUnmounted, provide, ref, toRef, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { submit } from "../utils/request";
@@ -347,6 +347,7 @@ import {
 	showStatsForNerds,
 } from "../data/statsPreferences";
 import { session, userResource } from "@/boot/session";
+import { appPageMeta } from "@/utils/documentTitle";
 import { useSocket } from "../socket";
 import { deviceManager } from "../utils/media/DeviceManager";
 import type { Participant } from "../utils/media/ParticipantManager";
@@ -479,6 +480,7 @@ const checkMeetingAccess = useCall<AccessData, { meeting_id: string }>({
 const previewTitle = computed(
 	() => meetingDoc.doc?.title || previewDetails.data?.title || meetingId.value,
 );
+usePageMeta(() => appPageMeta(previewTitle.value, "Meet"));
 
 watch(
 	() => meetingDoc.error,

--- a/frontend/src/apps/sheets/components/SheetEditor/index.vue
+++ b/frontend/src/apps/sheets/components/SheetEditor/index.vue
@@ -1273,6 +1273,7 @@ import { call } from '../../utils/api.js'
 import { useCurrentUser, useSessionStore } from '@/boot/session'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { useThemeMenuOption } from '@/composables/useThemeMenuOption'
+import { appPageMeta } from '@/utils/documentTitle'
 import { userInitials } from '../../utils/session.js'
 import { parseNumberFmt, buildNumberFmt, applyNumberFmt } from '../../utils/format-number.js'
 import { getTextWrap } from '../../utils/text-wrap.js'
@@ -1335,7 +1336,7 @@ import NamedRangesDialog       from './NamedRangesDialog.vue'
 import { useSmartFill }        from './useSmartFill.js'
 import * as versionsApi        from '../../services/versions.js'
 import {
-   Avatar, Badge, Breadcrumbs, Button, Checkbox, Dialog, Dropdown, FormControl, KeyboardShortcut, KeyboardShortcutsDialog, Spinner, TextInput, Tooltip } from 'frappe-ui'
+   Avatar, Badge, Breadcrumbs, Button, Checkbox, Dialog, Dropdown, FormControl, KeyboardShortcut, KeyboardShortcutsDialog, Spinner, TextInput, Tooltip, usePageMeta } from 'frappe-ui'
 import {
   CommandPalette,
   CommandPaletteEmpty,
@@ -1695,6 +1696,7 @@ const formulaValue      = ref('')
 const canUndo           = ref(false)
 const canRedo           = ref(false)
 const currentTitle      = ref('Untitled Sheet')
+usePageMeta(() => appPageMeta(currentTitle.value, 'Sheets'))
 const activeNumberFormat = ref('')
 
 // Cross-sheet picker: when the user starts a `=…` edit in the top formula
@@ -6094,7 +6096,7 @@ function toggleShowFormulas() {
    (gap:12) so the title reads as the focal point, not crowded by badges. */
 .sn-topbar-left  { display:flex; align-items:center; gap:8px; min-width:0; }
 .sn-topbar-right { display:flex; align-items:center; gap:6px; flex-shrink:0; }
-.sn-identity { display:flex; min-width:0; align-items:center; }
+.sn-identity { display:flex; min-width:0; align-items:center; gap:8px; }
 
 .sn-app-icon { width:28px; height:28px; flex-shrink:0; display:block; }
 .sn-app-menu-trigger { display:flex; width:fit-content; align-items:center; gap:8px; cursor:pointer; }

--- a/frontend/src/apps/slides/pages/PresentationEditor.vue
+++ b/frontend/src/apps/slides/pages/PresentationEditor.vue
@@ -64,6 +64,7 @@ import {
 import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 
 import { call, toast, usePageMeta, KeyboardShortcutsDialog } from 'frappe-ui'
+import { appPageMeta } from '@/utils/documentTitle'
 
 import ExportView from '@/apps/slides/pages/ExportView.vue'
 import EditorNavbar from '@/apps/slides/components/EditorNavbar.vue'
@@ -158,9 +159,7 @@ setCommandHistory(commandHistoryInstance)
 useShortcuts(inReadonlyMode, inSlideShowMode)
 
 usePageMeta(() => {
-	return {
-		title: pageTitle(),
-	}
+	return appPageMeta(pageTitle(), 'Slides')
 })
 
 onActivated(() => (document.title = pageTitle()))

--- a/frontend/src/apps/slides/pages/Slideshow.vue
+++ b/frontend/src/apps/slides/pages/Slideshow.vue
@@ -66,6 +66,7 @@
 <script setup>
 import { computed, onActivated, onDeactivated, ref, watch, provide } from 'vue'
 import { toast, useKeyboardShortcut, usePageMeta } from 'frappe-ui'
+import { appPageMeta } from '@/utils/documentTitle'
 
 import SlideElement from '@/apps/slides/components/SlideElement.vue'
 import SlideshowEndScreen from '@/apps/slides/components/SlideshowEndScreen.vue'
@@ -326,7 +327,7 @@ const updateWindowSize = () => {
 	windowHeight.value = window.innerHeight
 }
 
-usePageMeta(() => ({ title: pageTitle() }))
+usePageMeta(() => appPageMeta(pageTitle(), 'Slides'))
 
 onActivated(() => {
 	document.title = pageTitle()

--- a/frontend/src/apps/slides/stores/presentation.js
+++ b/frontend/src/apps/slides/stores/presentation.js
@@ -8,6 +8,7 @@ import { slides } from './slide'
 import { markClean, markDirty, getPresentationFromLocalDB } from './saving'
 import { normalizeZIndices } from '@/apps/slides/stores/element'
 import { normalizeColor } from '@/apps/slides/utils/color'
+import { appDocumentTitle } from '@/utils/documentTitle'
 import { v4 as uuid4 } from 'uuid'
 import { commandHistory } from './historyMeta'
 
@@ -383,9 +384,8 @@ const duplicatePresentation = async (presentation) => {
 }
 
 const pageTitle = () => {
-	const appTitle = router.currentRoute.value.meta.title || 'Frappe Slides'
 	const title = presentationDoc.value?.title
-	return title ? `${title} - ${appTitle}` : appTitle
+	return appDocumentTitle(title, 'Slides')
 }
 
 const resetEditorState = () => {

--- a/frontend/src/apps/writer/components/Navbar.vue
+++ b/frontend/src/apps/writer/components/Navbar.vue
@@ -5,7 +5,7 @@
     ondrop="return false;"
     class="relative z-10 flex h-12 shrink-0 items-center justify-between border-b border-outline-elevation-1 bg-surface-elevation-1 px-3"
   >
-    <div class="flex w-fit items-center gap-2">
+    <div class="flex min-w-0 items-center gap-2">
       <Dropdown
         :options="navbarMenuOptions"
         :offset="16"
@@ -18,15 +18,15 @@
           </div>
         </template>
       </Dropdown>
+      <slot name="breadcrumbs">
+        <EditableBreadcrumbs
+          v-if="route.name !== 'writer-home'"
+          :items="formattedCrumbs"
+          :entity="file?.doc || null"
+          class="select-none truncate max-w-[80%]"
+        />
+      </slot>
     </div>
-    <slot name="breadcrumbs">
-      <EditableBreadcrumbs
-        v-if="route.name !== 'writer-home'"
-        :items="formattedCrumbs"
-        :entity="file?.doc || null"
-        class="select-none truncate max-w-[80%]"
-      />
-    </slot>
 
     <div class="ml-auto flex items-center gap-2">
       <div id="navbar-content" class="flex gap-2" />

--- a/frontend/src/apps/writer/pages/Document.vue
+++ b/frontend/src/apps/writer/pages/Document.vue
@@ -81,6 +81,7 @@ import { useSessionStore } from '@/boot/session'
 const currentUserId = computed(() => useSessionStore().user)
 const isLoggedIn = computed(() => useSessionStore().isLoggedIn)
 import { Button, Skeleton, useDoc, usePageMeta } from 'frappe-ui'
+import { appPageMeta } from '@/utils/documentTitle'
 
 import VersionsSidebar from '@/apps/writer/components/VersionsSidebar.vue'
 import WriterSettings from '@/apps/writer/components/WriterSettings.vue'
@@ -142,9 +143,7 @@ const editable = computed(() => {
 watch(showVersions, (v) => {
   if (!v) versionPreview.value = null
 })
-usePageMeta(() => ({
-  title: file.doc ? file.doc.file_name : 'Loading...',
-}))
+usePageMeta(() => appPageMeta(file.doc ? file.doc.file_name : 'Loading...', 'Writer'))
 
 // fix: bad pattern
 const globalSettings = !isLoggedIn.value

--- a/frontend/src/apps/writer/pages/Documents.vue
+++ b/frontend/src/apps/writer/pages/Documents.vue
@@ -13,15 +13,14 @@ import { getDocuments } from '@/apps/writer/resources/'
 import RoundedListView from '@/apps/writer/components/RoundedListView.vue'
 import Navbar from '@/apps/writer/components/Navbar.vue'
 import { usePageMeta } from 'frappe-ui'
+import { appPageMeta } from '@/utils/documentTitle'
 import ErrorPage from '@/apps/writer/components/ErrorPage.vue'
 import WriterDocumentsSkeleton from '@/apps/writer/components/WriterDocumentsSkeleton.vue'
 
 const groupedDocuments = computed(() => getDocuments.data && groupByTime(getDocuments.data))
 getDocuments.fetch()
 
-usePageMeta(() => ({
-  title: 'Writer',
-}))
+usePageMeta(() => appPageMeta('Writer', 'Writer'))
 
 function groupByTime(entities) {
   const today = new Date()

--- a/frontend/src/apps/writer/utils/index.js
+++ b/frontend/src/apps/writer/utils/index.js
@@ -10,6 +10,7 @@ import globalStyle from '@/apps/writer/styles/index.css?inline'
 import slugify from 'slugify'
 import { useFileUpload, toast as nToast, createResource } from 'frappe-ui'
 import { rootInfo } from '@/apps/drive/sdk'
+import { appDocumentTitle } from '@/utils/documentTitle'
 
 rootInfo.fetch()
 import emitter from '@/apps/writer/emitter'
@@ -435,9 +436,7 @@ export function dynamicList(k) {
   return k.filter((a) => typeof a !== 'object' || !('cond' in a) || a.cond)
 }
 
-export const setTitle = (title) =>
-  (document.title =
-    (router.currentRoute.value.name === 'Folder' ? 'Folder - ' : '') + title)
+export const setTitle = (title) => (document.title = appDocumentTitle(title, 'Writer'))
 
 async function uploadImage(file, params) {
   const uploader = useFileUpload()

--- a/frontend/src/utils/documentTitle.ts
+++ b/frontend/src/utils/documentTitle.ts
@@ -1,4 +1,20 @@
-import { SUITE_APPS } from '@/apps/registry'
+import calendarLogo from '@/assets/app-logos/calendar.svg'
+import driveLogo from '@/assets/app-logos/drive.svg'
+import mailLogo from '@/assets/app-logos/mail.svg'
+import meetLogo from '@/assets/app-logos/meet.png'
+import sheetsLogo from '@/assets/app-logos/sheets.svg'
+import slidesLogo from '@/assets/app-logos/slides.svg'
+import writerLogo from '@/assets/app-logos/writer.png'
+
+const APP_LOGOS: Record<string, string> = {
+  Calendar: calendarLogo,
+  Drive: driveLogo,
+  Mail: mailLogo,
+  Meet: meetLogo,
+  Sheets: sheetsLogo,
+  Slides: slidesLogo,
+  Writer: writerLogo,
+}
 
 export function appDocumentTitle(pageTitle: string | undefined, appName: string) {
   const title = pageTitle?.trim()
@@ -10,6 +26,6 @@ export function appDocumentTitle(pageTitle: string | undefined, appName: string)
 export function appPageMeta(pageTitle: string | undefined, appName: string) {
   return {
     title: appDocumentTitle(pageTitle, appName),
-    icon: SUITE_APPS.find((app) => app.name === appName)?.logo,
+    icon: APP_LOGOS[appName],
   }
 }

--- a/frontend/src/utils/documentTitle.ts
+++ b/frontend/src/utils/documentTitle.ts
@@ -1,0 +1,15 @@
+import { SUITE_APPS } from '@/apps/registry'
+
+export function appDocumentTitle(pageTitle: string | undefined, appName: string) {
+  const title = pageTitle?.trim()
+  if (!title || title === appName || title === `Frappe ${appName}`) return appName
+  if (title.endsWith(` | ${appName}`)) return title
+  return `${title} | ${appName}`
+}
+
+export function appPageMeta(pageTitle: string | undefined, appName: string) {
+  return {
+    title: appDocumentTitle(pageTitle, appName),
+    icon: SUITE_APPS.find((app) => app.name === appName)?.logo,
+  }
+}


### PR DESCRIPTION
## Summary
- standardize dynamic document titles and app favicons across Suite apps
- add workbook and document-aware metadata where titles were previously static
- correct breadcrumb spacing and editable parent breadcrumb emphasis

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 57.1% (+0%) · Frontend 35.1% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **57.1%** (21,595 / 37,842) (+0%) | **29.9%** (2,907 / 9,710) (+0%) |
| Frontend | **35.1%** (14,252 / 40,599) (+0%) | **29.6%** (9,200 / 31,076) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33715867228) for commit `8bee4f5`.</sub>

</details>
<!-- suite-coverage:end -->
