### PR TITLE
ci: checkout Frappe before bench init

### DIFF
--- a/.github/workflows/drive-backed-apps-e2e.yml
+++ b/.github/workflows/drive-backed-apps-e2e.yml
@@ -161,7 +161,7 @@ jobs:
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Clone Frappe
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: frappe/frappe
           path: .frappe-source

--- a/.github/workflows/drive-backed-apps-e2e.yml
+++ b/.github/workflows/drive-backed-apps-e2e.yml
@@ -160,6 +160,13 @@ jobs:
           persist-credentials: false
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
+      - name: Clone Frappe
+        uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe
+          path: .frappe-source
+          persist-credentials: false
+
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -189,7 +196,7 @@ jobs:
           if [ "$(bench --version 2>/dev/null || true)" != "5.31.0" ]; then
             python -m pip install "frappe-bench==5.31.0"
           fi
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" "$RUNNER_TEMP/frappe-bench"
+          bench init --frappe-path "$GITHUB_WORKSPACE/.frappe-source" --skip-redis-config-generation --skip-assets --python "$(which python)" "$RUNNER_TEMP/frappe-bench"
 
       - name: Install Suite
         working-directory: ${{ runner.temp }}/frappe-bench

--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -161,7 +161,7 @@ jobs:
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
       - name: Clone Frappe
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: frappe/frappe
           path: .frappe-source

--- a/.github/workflows/meet-e2e.yml
+++ b/.github/workflows/meet-e2e.yml
@@ -160,6 +160,13 @@ jobs:
           persist-credentials: false
           allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository }}
 
+      - name: Clone Frappe
+        uses: actions/checkout@v4
+        with:
+          repository: frappe/frappe
+          path: .frappe-source
+          persist-credentials: false
+
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
@@ -189,7 +196,7 @@ jobs:
           if [ "$(bench --version 2>/dev/null || true)" != "5.31.0" ]; then
             python -m pip install "frappe-bench==5.31.0"
           fi
-          bench init --skip-redis-config-generation --skip-assets --python "$(which python)" "$RUNNER_TEMP/frappe-bench"
+          bench init --frappe-path "$GITHUB_WORKSPACE/.frappe-source" --skip-redis-config-generation --skip-assets --python "$(which python)" "$RUNNER_TEMP/frappe-bench"
 
       - name: Install Suite
         working-directory: ${{ runner.temp }}/frappe-bench


### PR DESCRIPTION
## Summary
- Check out the public Frappe repository explicitly without persisting credentials.
- Initialize Bench from the local checkout to avoid anonymous clone failures on shared ARC runners.
- Reuse the existing immutable checkout action pin for self-hosted runner safety.