### PR TITLE
fix(slides): let native copy work in text fields

### DIFF
--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -53,6 +53,10 @@ const copyElements = (e) => {
 const handleCopy = (e) => {
 	if (isCopyTriggeredByButton.value) return
 
+	// let native copy work in text fields (e.g. hex input in color picker,
+	// text editing) instead of hijacking it with element/slide JSON
+	if (isInputElement(e.target)) return
+
 	e.preventDefault()
 	const isCopyingElements = activeElementIds.value.length > 0
 	if (isCopyingElements) {
@@ -146,13 +150,15 @@ const handlePastedSlideJSON = async (slideJSON) => {
 	insertSlide(slideJSON, index)
 }
 
-const isInputElement = (el) => {
-	const activeElement = document.activeElement
+const isEditableTarget = (el) => {
 	return (
-		activeElement?.tagName == 'INPUT' ||
-		activeElement?.tagName == 'TEXTAREA' ||
-		activeElement?.isContentEditable
+		el?.tagName == 'INPUT' || el?.tagName == 'TEXTAREA' || el?.isContentEditable
 	)
+}
+
+const isInputElement = (target) => {
+	if (isEditableTarget(target)) return true
+	return isEditableTarget(document.activeElement)
 }
 
 const handleClipboardText = (clipboardText) => {

--- a/frontend/src/apps/slides/stores/copyPaste.test.ts
+++ b/frontend/src/apps/slides/stores/copyPaste.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { ref } from 'vue'
+
+const activeElementIds = ref<string[]>([])
+const activeElements = ref<any[]>([])
+
+vi.mock('frappe-ui', () => ({
+	toast: { success: vi.fn() },
+	call: vi.fn(),
+}))
+vi.mock('@/apps/slides/stores/presentation', () => ({ presentationId: ref('p1') }))
+vi.mock('@/apps/slides/stores/slide', () => ({
+	slideIndex: ref(0),
+	insertSlide: vi.fn(),
+	getNewSlide: vi.fn(() => ({ elements: [] })),
+}))
+vi.mock('@/apps/slides/stores/element', () => ({
+	activeElements,
+	activeElementIds,
+	focusElementId: ref(null),
+	addTextElement: vi.fn(),
+	duplicateElements: vi.fn(),
+	resetFocus: vi.fn(),
+}))
+vi.mock('@/apps/slides/stores/imageCrop', () => ({ inCropMode: ref(false) }))
+vi.mock('@/apps/slides/composables/useTextEditor', () => ({
+	useTextEditor: () => ({ activeEditor: ref(null) }),
+}))
+vi.mock('@/apps/slides/utils/helpers', () => ({
+	getDocFromHTML: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+}))
+vi.mock('@/apps/slides/utils/connectors', () => ({
+	remapElementIds: (els: any) => els,
+}))
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({
+	handleUploadedMedia: vi.fn(),
+}))
+
+const { handleCopy } = await import('./copyPaste')
+const { toast } = await import('frappe-ui')
+
+const makeCopyEvent = (target: EventTarget | null) => ({
+	target,
+	preventDefault: vi.fn(),
+	clipboardData: { setData: vi.fn(), getData: vi.fn(() => '') },
+})
+
+beforeEach(() => {
+	activeElementIds.value = ['e1']
+	activeElements.value = [{ id: 'e1' }]
+	document.body.innerHTML = ''
+	;(document.activeElement as HTMLElement | null)?.blur?.()
+})
+
+afterEach(() => {
+	vi.restoreAllMocks()
+})
+
+describe('handleCopy from editable targets', () => {
+	it('lets native copy through from an input (e.g. the color picker hex field)', () => {
+		const input = document.createElement('input')
+		input.value = '#FF0000'
+		document.body.appendChild(input)
+		input.focus()
+		input.select()
+
+		const e = makeCopyEvent(input)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(e.clipboardData.setData).not.toHaveBeenCalled()
+	})
+
+	it('lets native copy through from a textarea', () => {
+		const textarea = document.createElement('textarea')
+		document.body.appendChild(textarea)
+		textarea.focus()
+
+		const e = makeCopyEvent(textarea)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(e.clipboardData.setData).not.toHaveBeenCalled()
+	})
+
+	it('lets native copy through from a contenteditable element', () => {
+		const editor = document.createElement('div')
+		// jsdom does not implement contenteditable focus semantics, so declare
+		// the property the guard reads directly
+		Object.defineProperty(editor, 'isContentEditable', { value: true })
+		document.body.appendChild(editor)
+		vi.spyOn(document, 'activeElement', 'get').mockReturnValue(editor)
+
+		const e = makeCopyEvent(editor)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(e.clipboardData.setData).not.toHaveBeenCalled()
+	})
+
+	it('falls back to the focused element when the event target is not editable', () => {
+		const input = document.createElement('input')
+		document.body.appendChild(input)
+		vi.spyOn(document, 'activeElement', 'get').mockReturnValue(input)
+
+		const e = makeCopyEvent(document.body)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).not.toHaveBeenCalled()
+		expect(e.clipboardData.setData).not.toHaveBeenCalled()
+	})
+})
+
+describe('handleCopy from the canvas', () => {
+	it('still hijacks copy for selected elements', () => {
+		const e = makeCopyEvent(document.body)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).toHaveBeenCalled()
+		expect(e.clipboardData.setData).toHaveBeenCalledWith(
+			'application/json',
+			expect.stringContaining('e1'),
+		)
+	})
+
+	it('still copies the slide when nothing is selected', () => {
+		activeElementIds.value = []
+		activeElements.value = []
+
+		const e = makeCopyEvent(document.body)
+		handleCopy(e as any)
+
+		expect(e.preventDefault).toHaveBeenCalled()
+		expect(e.clipboardData.setData).toHaveBeenCalledWith('application/json', expect.any(String))
+		expect(toast.success).toHaveBeenCalledWith('Slide copied to clipboard')
+	})
+})


### PR DESCRIPTION
Slides registers a global `copy` listener that replaces the clipboard with element/slide JSON. It had no guard for text fields (unlike the paste handler), so pressing Cmd+C with the color picker's hex input selected cleared the clipboard instead of copying the hex code.

Let the native copy event through when it originates from an input, textarea, or contenteditable, checked via both the event target and the focused element.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 57.1% (+0%) · Frontend 35.2% (+0.1%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **57.1%** (21,594 / 37,842) (+0%) | **29.9%** (2,907 / 9,710) (+0%) |
| Frontend | **35.2%** (14,290 / 40,602) (+0.1%) | **29.6%** (9,210 / 31,080) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33718045767) for commit `fe4384a`.</sub>

</details>
<!-- suite-coverage:end -->
