### PR TITLE
fix(slides): retain html formatting when pasting text content

### DIFF
--- a/frontend/src/apps/slides/stores/bulletPaste.test.ts
+++ b/frontend/src/apps/slides/stores/bulletPaste.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { Editor } from '@tiptap/vue-3'
+
+vi.mock('@/apps/slides/utils/mediaUploads', () => ({ getAttachmentUrl: () => '' }))
+
+const { extensions } = await import('./tiptapSetup')
+
+let editor: Editor | null = null
+
+const mountEditor = (content: string) => {
+	const element = document.createElement('div')
+	document.body.appendChild(element)
+	editor = new Editor({ element, extensions, content })
+	return editor
+}
+
+// drives the editor's real handlePaste chain the way a browser paste does
+const pasteAs = (target: Editor, plain: string, html: string) => {
+	const event = {
+		clipboardData: {
+			getData: (type: string) => (type === 'text/plain' ? plain : type === 'text/html' ? html : ''),
+		},
+		preventDefault: () => {},
+	} as any
+	let handled = false
+	target.view.someProp('handlePaste', (f: any) => {
+		if (handled) return
+		if (f(target.view, event)) handled = true
+	})
+	// unclaimed pastes fall through to prosemirror's default rich paste
+	if (!handled) target.view.pasteHTML(html, {} as any)
+	return handled
+}
+
+const nodeNames = (target: Editor) => {
+	const names: string[] = []
+	target.state.doc.descendants((node) => {
+		names.push(node.type.name)
+	})
+	return names
+}
+
+afterEach(() => {
+	editor?.destroy()
+	editor = null
+})
+
+describe('pasting copied bullet content', () => {
+	const bullets =
+		'<ul><li><p><span style="font-size: 28px; color: rgb(255, 0, 0)">first</span></p></li>' +
+		'<li><p><span style="font-size: 28px; color: rgb(255, 0, 0)">second</span></p></li></ul>'
+
+	it('keeps the bullet list structure', () => {
+		const dest = mountEditor('<p>dest</p>')
+		dest.commands.setTextSelection(dest.state.doc.content.size - 1)
+
+		pasteAs(dest, 'first\nsecond', bullets)
+
+		expect(nodeNames(dest)).toContain('bulletList')
+		expect(nodeNames(dest)).toContain('listItem')
+	})
+
+	it('keeps the bullet text formatting', () => {
+		const dest = mountEditor('<p>dest</p>')
+		dest.commands.setTextSelection(dest.state.doc.content.size - 1)
+
+		pasteAs(dest, 'first\nsecond', bullets)
+
+		const html = dest.getHTML()
+		expect(html).toContain('first')
+		expect(html).toContain('font-size: 28px')
+	})
+
+	it('keeps ordered lists too', () => {
+		const dest = mountEditor('<p></p>')
+		dest.commands.setTextSelection(1)
+
+		pasteAs(dest, '1. first', '<ol><li><p>first</p></li></ol>')
+
+		expect(nodeNames(dest)).toContain('orderedList')
+	})
+
+	it('still pastes plain paragraphs as plain text with inherited styles', () => {
+		const dest = mountEditor('<p>dest</p>')
+		dest.commands.setTextSelection(dest.state.doc.content.size - 1)
+
+		const handled = pasteAs(dest, 'plain words', '<p>plain words</p>')
+
+		expect(handled).toBe(true)
+		expect(nodeNames(dest)).not.toContain('bulletList')
+		expect(dest.state.doc.textContent).toContain('plain words')
+	})
+})

--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -15,7 +15,7 @@ import {
 import { inCropMode } from '@/apps/slides/stores/imageCrop'
 import { useTextEditor } from '@/apps/slides/composables/useTextEditor'
 
-import { getDocFromHTML, hasListMarkup } from '@/apps/slides/utils/helpers'
+import { getDocFromHTML, hasListMarkup, sanitizeSlideHTML } from '@/apps/slides/utils/helpers'
 import { remapElementIds } from '@/apps/slides/utils/connectors'
 import { v4 as uuid4 } from 'uuid'
 import { handleUploadedMedia } from '@/apps/slides/utils/mediaUploads'
@@ -89,8 +89,10 @@ const copyToClipboard = async (text) => {
 const handlePastedText = async (clipboardText, clipboardHTML = '') => {
 	await resetFocus()
 	// a copied bullet block pasted onto the canvas has to arrive as a list,
-	// not as the plain lines its text/plain fallback holds
-	addTextElement(clipboardText, undefined, hasListMarkup(clipboardHTML) ? clipboardHTML : null)
+	// not as the plain lines its text/plain fallback holds. Clipboard markup
+	// is untrusted, so it is sanitized before measurement and persistence
+	const listHTML = hasListMarkup(clipboardHTML) ? sanitizeSlideHTML(clipboardHTML) : null
+	addTextElement(clipboardText, undefined, listHTML)
 }
 
 const handlePastedJSON = async ({ srcPresentation, srcSlide, elements }) => {

--- a/frontend/src/apps/slides/stores/copyPaste.js
+++ b/frontend/src/apps/slides/stores/copyPaste.js
@@ -15,7 +15,7 @@ import {
 import { inCropMode } from '@/apps/slides/stores/imageCrop'
 import { useTextEditor } from '@/apps/slides/composables/useTextEditor'
 
-import { getDocFromHTML } from '@/apps/slides/utils/helpers'
+import { getDocFromHTML, hasListMarkup } from '@/apps/slides/utils/helpers'
 import { remapElementIds } from '@/apps/slides/utils/connectors'
 import { v4 as uuid4 } from 'uuid'
 import { handleUploadedMedia } from '@/apps/slides/utils/mediaUploads'
@@ -86,9 +86,11 @@ const copyToClipboard = async (text) => {
 
 // Paste Handlers
 
-const handlePastedText = async (clipboardText) => {
+const handlePastedText = async (clipboardText, clipboardHTML = '') => {
 	await resetFocus()
-	addTextElement(clipboardText)
+	// a copied bullet block pasted onto the canvas has to arrive as a list,
+	// not as the plain lines its text/plain fallback holds
+	addTextElement(clipboardText, undefined, hasListMarkup(clipboardHTML) ? clipboardHTML : null)
 }
 
 const handlePastedJSON = async ({ srcPresentation, srcSlide, elements }) => {
@@ -161,11 +163,11 @@ const isInputElement = (target) => {
 	return isEditableTarget(document.activeElement)
 }
 
-const handleClipboardText = (clipboardText) => {
+const handleClipboardText = (clipboardText, clipboardHTML = '') => {
 	if (clipboardText?.trim().startsWith('<svg') && clipboardText?.trim().endsWith('</svg>')) {
 		handleSvgText(clipboardText)
 	} else if (clipboardText && !focusElementId.value) {
-		handlePastedText(clipboardText)
+		handlePastedText(clipboardText, clipboardHTML)
 	}
 }
 
@@ -225,7 +227,7 @@ const handlePaste = (e) => {
 	if (clipboardJSON) return handleClipboardJSON(clipboardJSON)
 
 	const clipboardText = e.clipboardData.getData('text/plain')
-	if (clipboardText) return handleClipboardText(clipboardText)
+	if (clipboardText) return handleClipboardText(clipboardText, clipboardTextHTML)
 
 	const clipboardItems = e.clipboardData.items
 	if (clipboardItems) return handleUploadedMedia(clipboardItems)

--- a/frontend/src/apps/slides/stores/copyPaste.test.ts
+++ b/frontend/src/apps/slides/stores/copyPaste.test.ts
@@ -29,6 +29,7 @@ vi.mock('@/apps/slides/composables/useTextEditor', () => ({
 vi.mock('@/apps/slides/utils/helpers', () => ({
 	getDocFromHTML: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
 	hasListMarkup: (html: string) => !!html && /<(ul|ol|li)[\s>]/i.test(html),
+	sanitizeSlideHTML: (html: string) => html,
 }))
 vi.mock('@/apps/slides/utils/connectors', () => ({
 	remapElementIds: (els: any) => els,

--- a/frontend/src/apps/slides/stores/copyPaste.test.ts
+++ b/frontend/src/apps/slides/stores/copyPaste.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/apps/slides/composables/useTextEditor', () => ({
 }))
 vi.mock('@/apps/slides/utils/helpers', () => ({
 	getDocFromHTML: (html: string) => new DOMParser().parseFromString(html, 'text/html'),
+	hasListMarkup: (html: string) => !!html && /<(ul|ol|li)[\s>]/i.test(html),
 }))
 vi.mock('@/apps/slides/utils/connectors', () => ({
 	remapElementIds: (els: any) => els,

--- a/frontend/src/apps/slides/stores/element.js
+++ b/frontend/src/apps/slides/stores/element.js
@@ -342,7 +342,7 @@ const addShapeElement = async (shapeType, bounds = null, overrides = {}) => {
 	)
 }
 
-const getTextElementDimensions = (presets) => {
+const measureHTML = (html) => {
 	const tempTextElement = document.createElement('div')
 
 	// the element's own markup and CSS, or the measurement drifts by sub-pixels
@@ -351,7 +351,7 @@ const getTextElementDimensions = (presets) => {
 		position: 'absolute',
 		visibility: 'hidden',
 	})
-	tempTextElement.innerHTML = getElementContent(presets)
+	tempTextElement.innerHTML = html
 
 	document.body.appendChild(tempTextElement)
 
@@ -363,7 +363,9 @@ const getTextElementDimensions = (presets) => {
 	return { elementWidth, elementHeight }
 }
 
-const addTextElement = async (text, position) => {
+const getTextElementDimensions = (presets) => measureHTML(getElementContent(presets))
+
+const addTextElement = async (text, position, contentHTML = null) => {
 	const elementPresets = {
 		textAlign: 'center',
 		fontSize: 28,
@@ -375,7 +377,9 @@ const addTextElement = async (text, position) => {
 	}
 
 	if (!position) {
-		const { elementWidth, elementHeight } = getTextElementDimensions(elementPresets)
+		const { elementWidth, elementHeight } = contentHTML
+			? measureHTML(contentHTML)
+			: getTextElementDimensions(elementPresets)
 		position = getLeftTopForCenteredElement(elementWidth, elementHeight)
 	}
 
@@ -387,7 +391,7 @@ const addTextElement = async (text, position) => {
 		left: position.left,
 		top: position.top,
 		type: 'text',
-		content: getElementContent(elementPresets),
+		content: contentHTML ?? getElementContent(elementPresets),
 		lineHeight: elementPresets.lineHeight,
 	}
 

--- a/frontend/src/apps/slides/stores/tiptapSetup.js
+++ b/frontend/src/apps/slides/stores/tiptapSetup.js
@@ -19,7 +19,7 @@ import { Decoration, DecorationSet } from 'prosemirror-view'
 import { joinBackward } from 'prosemirror-commands'
 import { liftListItem } from 'prosemirror-schema-list'
 
-import { getDocFromHTML } from '@/apps/slides/utils/helpers'
+import { getDocFromHTML, hasListMarkup } from '@/apps/slides/utils/helpers'
 import { scaleAwareColumnResizing } from '@/apps/slides/utils/columnResizing'
 
 const parseElementStyle = (attribute, value) => {
@@ -150,6 +150,10 @@ const PastePlainText = Extension.create({
 
 	addProseMirrorPlugins() {
 		const pasteWithInheritedStyles = (view, event) => {
+			// list markup forced through plain text comes out unbulleted,
+			// so it falls through to the default rich paste instead
+			if (hasListMarkup(event.clipboardData?.getData('text/html'))) return false
+
 			const plainText = event.clipboardData?.getData('text/plain')
 			if (!plainText) return false
 

--- a/frontend/src/apps/slides/utils/helpers.ts
+++ b/frontend/src/apps/slides/utils/helpers.ts
@@ -83,6 +83,8 @@ const getDocFromHTML = (html: string) => {
 	return parser.parseFromString(html, 'text/html')
 }
 
+const hasListMarkup = (html: string) => !!html && /<(ul|ol|li)[\s>]/i.test(html)
+
 const sanitizeSlideHTML = (html: string) => {
 	return DOMPurify.sanitize(html, {
 		ALLOWED_TAGS: [
@@ -126,6 +128,7 @@ export {
 	cloneObj,
 	getThumbnailCardStyles,
 	getDocFromHTML,
+	hasListMarkup,
 	sanitizeSlideHTML,
 	isCmdOrCtrl,
 	normalizeRotation,


### PR DESCRIPTION
Pasting rich text content (e.g. bullet lists copied from one slide to another) was forced through plain text, dropping list structure and inline styling.

- In-editor paste now falls through to the default rich paste when clipboard HTML contains list markup, via a shared hasListMarkup helper.
- Canvas paste builds the new text element from the clipboard HTML in that case instead of the text/plain fallback.
- Plain paragraph pastes keep the existing inherit-destination-styles behavior.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 57.1% (+0%) · Frontend 35.2% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **57.1%** (21,594 / 37,842) (+0%) | **29.9%** (2,907 / 9,710) (+0%) |
| Frontend | **35.2%** (14,301 / 40,606) (+0%) | **29.6%** (9,219 / 31,093) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33720461414) for commit `24c3cf7`.</sub>

</details>
<!-- suite-coverage:end -->
