### PR TITLE
fix(writer): wrap a word instead of cutting it at the line end

### DIFF
--- a/e2e/drive-backed-apps/specs/writer/wrapping.spec.ts
+++ b/e2e/drive-backed-apps/specs/writer/wrapping.spec.ts
@@ -1,0 +1,88 @@
+import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "../../fixtures/test";
+import {
+	createWriterDocument,
+	openWriterDocument,
+	uniqueWriterTitle,
+	writerEditor,
+} from "../../helpers/writer";
+
+const PARAGRAPH =
+	"We do not deduct pay for taking leave. 45 annual leave will be provided " +
+	"to you apart from the Public Holiday list that Frappe observes.";
+
+const LINK =
+	"https://example.com/a/very/long/path/that/has/no/place/to/break/" +
+	"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+// Widths that put the wrap point in a different word each time.
+const VIEWPORTS = [960, 1120, 1280, 1440];
+
+function computed(locator: Locator, property: string) {
+	return locator.evaluate(
+		(node, prop) => getComputedStyle(node).getPropertyValue(prop),
+		property,
+	);
+}
+
+// A word the browser drew on two lines has one client rect per line.
+function splitWords(paragraph: Locator): Promise<string[]> {
+	return paragraph.evaluate((node) => {
+		const split: string[] = [];
+		const walker = document.createTreeWalker(node, NodeFilter.SHOW_TEXT);
+		let text = walker.nextNode();
+		while (text) {
+			for (const match of (text.textContent ?? "").matchAll(/\S+/g)) {
+				const range = document.createRange();
+				range.setStart(text, match.index);
+				range.setEnd(text, match.index + match[0].length);
+				if (range.getClientRects().length > 1) split.push(match[0]);
+			}
+			text = walker.nextNode();
+		}
+		return split;
+	});
+}
+
+async function typeParagraphs(page: Page, editor: Locator): Promise<void> {
+	await editor.click();
+	await page.keyboard.type(PARAGRAPH);
+	await page.keyboard.press("Enter");
+	await page.keyboard.type(LINK);
+}
+
+// frappe-ui's editor stylesheet sets `word-break: break-word` on .ProseMirror.
+// That keyword is deprecated, it means `overflow-wrap: anywhere`, and it lets
+// an engine cut a word at the end of a line although the whole word fits on
+// the next one. The writer pins the standard pair instead.
+test("the editor keeps a word whole and still wraps a long link", async ({
+	owner,
+	run,
+}) => {
+	const { page } = owner;
+	const file = await createWriterDocument(
+		page.request,
+		uniqueWriterTitle(run.run_id, "wrapping"),
+	);
+	await openWriterDocument(page, file.name);
+
+	const editor = writerEditor(page);
+	await typeParagraphs(page, editor);
+
+	await expect.poll(() => computed(editor, "word-break")).toBe("normal");
+	await expect.poll(() => computed(editor, "overflow-wrap")).toBe("break-word");
+
+	const paragraph = editor.locator("p").first();
+	const link = editor.locator("p").nth(1);
+	for (const width of VIEWPORTS) {
+		await page.setViewportSize({ width, height: 900 });
+		await expect.poll(() => splitWords(paragraph)).toEqual([]);
+		// The link has no place to break, so it may be cut — but it must stay
+		// inside the page rather than push the column wider.
+		await expect
+			.poll(() =>
+				link.evaluate((node) => node.scrollWidth - node.clientWidth),
+			)
+			.toBeLessThanOrEqual(0);
+	}
+});

--- a/e2e/drive-backed-apps/specs/writer/wrapping.spec.ts
+++ b/e2e/drive-backed-apps/specs/writer/wrapping.spec.ts
@@ -15,8 +15,10 @@ const LINK =
 	"https://example.com/a/very/long/path/that/has/no/place/to/break/" +
 	"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
-// Widths that put the wrap point in a different word each time.
-const VIEWPORTS = [960, 1120, 1280, 1440];
+// Widths that put the wrap point in a different word each time. The editor
+// column is capped at 48rem, so a viewport sweep leaves it unchanged on a wide
+// screen. The width goes on the editor element instead.
+const WIDTHS = [320, 400, 480, 560, 640];
 
 function computed(locator: Locator, property: string) {
 	return locator.evaluate(
@@ -42,6 +44,12 @@ function splitWords(paragraph: Locator): Promise<string[]> {
 		}
 		return split;
 	});
+}
+
+function setEditorWidth(editor: Locator, width: number): Promise<void> {
+	return editor.evaluate((node, value) => {
+		(node as HTMLElement).style.width = `${value}px`;
+	}, width);
 }
 
 async function typeParagraphs(page: Page, editor: Locator): Promise<void> {
@@ -74,8 +82,8 @@ test("the editor keeps a word whole and still wraps a long link", async ({
 
 	const paragraph = editor.locator("p").first();
 	const link = editor.locator("p").nth(1);
-	for (const width of VIEWPORTS) {
-		await page.setViewportSize({ width, height: 900 });
+	for (const width of WIDTHS) {
+		await setEditorWidth(editor, width);
 		await expect.poll(() => splitWords(paragraph)).toEqual([]);
 		// The link has no place to break, so it may be cut — but it must stay
 		// inside the page rather than push the column wider.

--- a/frontend/src/apps/writer/styles/editor.css
+++ b/frontend/src/apps/writer/styles/editor.css
@@ -7,6 +7,17 @@
   line-height: var(--editor-line-height, 1.5);
 }
 
+/* frappe-ui's editor stylesheet puts `word-break: break-word` on .ProseMirror.
+   CSS Text 3 keeps that keyword only for legacy content, and engines disagree
+   on it: a word can be cut at the end of a line even though the whole word
+   fits on the next one. A document must move the word down instead. The class
+   is repeated to outrank the frappe-ui rule without !important. overflow-wrap
+   still keeps a long unbreakable string, such as a URL, inside the page. */
+.ProseMirror.ProseMirror {
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+
 .prose-v3 p + p {
   margin-top: var(--paragraph-spacing-before, 0);
 }


### PR DESCRIPTION
From a bug report in the Raven Frappe-writer channel: the Writer editor cut a word in half at the end of a line. A screenshot showed a word split across two lines although the whole word fitted on the next one.

## Root cause

frappe-ui's editor stylesheet sets `word-break: break-word` on `.ProseMirror`, and Writer inherits it.

CSS Text 3 keeps that keyword for legacy content only. It means `word-break: normal` plus `overflow-wrap: anywhere` — the most permissive wrapping mode — no matter what `overflow-wrap` says. It is the only rule on the editor surface that lets a word break at an arbitrary point, and engines do not agree on when they apply it. A document editor must move the word to the next line instead.

## Change

`frontend/src/apps/writer/styles/editor.css` pins the standard pair on the editor surface:

```css
.ProseMirror.ProseMirror {
  word-break: normal;
  overflow-wrap: break-word;
}
```

The class is repeated to outrank the frappe-ui rule without `!important`. `overflow-wrap: break-word` stays, so a long unbreakable string such as a URL still wraps inside the page instead of pushing the column wider.

## Verification

New spec `e2e/drive-backed-apps/specs/writer/wrapping.spec.ts` types a paragraph plus an unbreakable link, then checks the computed values, that no word is drawn on two lines across a sweep of editor widths, and that the link does not overflow its paragraph.

The sweep sets the width on the editor element. A viewport sweep would not work: `CoreEditor` lays the document out as `minmax(0, 1fr) minmax(0, 48rem) minmax(0, 1fr)`, so every wide viewport gives the same 768 px column and the same wrap point. Probe run printing the first word of each line per width:

```
320 ["45","you","that"]
400 ["leave","Public"]
480 ["be","Frappe"]
560 ["to"]
640 ["apart"]
```

With the fix (Playwright, Chromium, local bench):

```
✓  1 [chromium] › specs/writer/wrapping.spec.ts › the editor keeps a word whole and still wraps a long link
  1 passed (7.0s)
```

With the stylesheet reverted to `develop`, the same spec fails:

```
✘  1 [chromium] › specs/writer/wrapping.spec.ts › the editor keeps a word whole and still wraps a long link
    Expected: "normal"
    Received: "break-word"
  1 failed
```

The geometry assertion has teeth as well: forcing `word-break: break-all` on the editor makes `splitWords` report two cut words and the test fails there too.

Frontend unit tests: `Test Files 172 passed | 1 skipped (173)`, `Tests 2425 passed | 1 skipped (2426)`.

Also checked in the running editor: the computed value moves from `word-break: break-word` to `word-break: normal` with `overflow-wrap: break-word`, and a 160-character link still wraps with zero pixels of overflow.

Not verified: the mid-word split itself does not reproduce in Chromium, which never applies `word-break: break-word` that way. The reporter's engine does. The deprecated keyword is the only rule that permits the break, and it is now gone from the editor surface.

Local Playwright runs used the Chromium build, not the `chrome` channel the config pins; CI is unaffected.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.9% (+0%) · Frontend 35.3% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.9%** (21,682 / 38,096) (+0%) | **29.8%** (2,926 / 9,818) (+0%) |
| Frontend | **35.3%** (14,364 / 40,690) (+0%) | **29.7%** (9,268 / 31,183) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33841718384) for commit `b86d441`.</sub>

</details>
<!-- suite-coverage:end -->
