### PR TITLE
fix(meet): send visible=false for tiles hidden from creation

### DIFF
--- a/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
+++ b/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
@@ -29,7 +29,6 @@ interface TileController {
 	forceNext: boolean;
 	lastSent: TileMetrics | null;
 	debouncedUpdate: (() => void) | null;
-	initialPending: boolean;
 	stopListeningForConsumer: (() => void) | null;
 }
 
@@ -58,6 +57,21 @@ export function useTileAdaptiveStreaming() {
 		return injectedManager.value;
 	}
 
+	// A tile with no visible dimensions counts as hidden. Fail closed:
+	// a wrongly-hidden tile self-corrects on the next resize, while a
+	// wrongly-visible one would leak forwarding forever.
+	function measureTile(
+		element: HTMLVideoElement,
+		target: Pick<TileController, "width" | "height" | "visible">,
+	) {
+		const width = Math.max(element.clientWidth || 0, 0);
+		const height = Math.max(element.clientHeight || 0, 0);
+		target.width = width;
+		target.height = height;
+		target.visible =
+			width > 0 && height > 0 && isElementInViewport(element);
+	}
+
 	async function updateConsumerPreferences(controller: TileController) {
 		if (!controller.active) return;
 		const manager = getManager();
@@ -71,21 +85,14 @@ export function useTileAdaptiveStreaming() {
 		const width = visible ? Math.round(controller.width) : 0;
 		const height = visible ? Math.round(controller.height) : 0;
 
-		// Don't send initial update without valid dimensions
-		// else we'll get a paused stream
-		if (
-			controller.initialPending &&
-			(!visible || width === 0 || height === 0)
-		) {
-			return;
-		}
-
 		const last = controller.lastSent;
 		const widthChanged =
 			!last || Math.abs(last.width - width) >= SIZE_DELTA_THRESHOLD;
 		const visibilityChanged = !last || last.visible !== visible;
 
-		// Skip if no meaningful change
+		// Skip if no meaningful change. forceNext is set for the first
+		// send (lastSent == null), so the initial state — visible or
+		// hidden — is always reported exactly once.
 		if (!controller.forceNext) {
 			if (!visibilityChanged && visible && !widthChanged) return;
 			if (!visibilityChanged && !visible) return;
@@ -101,9 +108,6 @@ export function useTileAdaptiveStreaming() {
 			});
 			if (!controller.active || getManager() !== manager) return;
 			controller.lastSent = { visible, width, height };
-			if (controller.initialPending) {
-				controller.initialPending = false;
-			}
 		} catch (error) {
 			console.warn(
 				"Failed to update consumer preferences for",
@@ -121,6 +125,11 @@ export function useTileAdaptiveStreaming() {
 		} else if (controller.debouncedUpdate) {
 			controller.debouncedUpdate();
 		}
+	}
+
+	// Send immediately while nothing has been reported yet, debounce after.
+	function scheduleRefresh(controller: TileController) {
+		scheduleUpdate(controller, controller.lastSent == null);
 	}
 
 	function cleanupController(controller: TileController) {
@@ -144,7 +153,7 @@ export function useTileAdaptiveStreaming() {
 			(event: Event) => {
 				const customEvent = event as CustomEvent;
 				if (customEvent.detail?.participantId === controller.participantId) {
-					scheduleUpdate(controller, false);
+					scheduleRefresh(controller);
 				}
 			},
 		);
@@ -157,16 +166,17 @@ export function useTileAdaptiveStreaming() {
 			element,
 			resizeObserver: null,
 			intersectionObserver: null,
-			// Initialize with 0x0 so ResizeObserver always detects a size change
 			width: 0,
 			height: 0,
 			visible: false,
 			forceNext: true,
-			initialPending: true,
 			lastSent: null,
 			debouncedUpdate: null,
 			stopListeningForConsumer: null,
 		};
+
+		// Measure up front so the initial state is real, not a placeholder.
+		measureTile(element, controller);
 
 		controller.debouncedUpdate = debounce(() => {
 			void updateConsumerPreferences(controller);
@@ -186,8 +196,10 @@ export function useTileAdaptiveStreaming() {
 			// Update visibility check when dimensions become valid
 			if (newWidth > 0 && newHeight > 0) {
 				controller.visible = isElementInViewport(element);
+			} else {
+				controller.visible = false;
 			}
-			scheduleUpdate(controller, controller.initialPending);
+			scheduleRefresh(controller);
 		});
 		controller.resizeObserver.observe(element);
 
@@ -199,21 +211,19 @@ export function useTileAdaptiveStreaming() {
 				entry.isIntersecting && entry.intersectionRatio >= VISIBILITY_THRESHOLD;
 			if (controller.visible !== isVisible) {
 				controller.visible = isVisible;
-				scheduleUpdate(controller, controller.initialPending || isVisible);
+				scheduleUpdate(
+					controller,
+					controller.lastSent == null || isVisible,
+				);
 			} else if (isVisible) {
-				scheduleUpdate(controller, controller.initialPending);
+				scheduleRefresh(controller);
 			}
 		});
 		controller.intersectionObserver.observe(element);
 
 		const onLoadedMetadata = () => {
-			controller.width = Math.max(element.clientWidth || 0, 0);
-			controller.height = Math.max(element.clientHeight || 0, 0);
-			// Update visibility check when metadata loads
-			if (controller.width > 0 && controller.height > 0) {
-				controller.visible = isElementInViewport(element);
-			}
-			scheduleUpdate(controller, controller.initialPending);
+			measureTile(element, controller);
+			scheduleRefresh(controller);
 		};
 
 		if (element.readyState >= 1) {
@@ -222,6 +232,23 @@ export function useTileAdaptiveStreaming() {
 			element.addEventListener("loadedmetadata", onLoadedMetadata, {
 				once: true,
 			});
+		}
+
+		// One explicit initial sync, independent of observer deltas: an
+		// initially-hidden tile never produces a visible-to-hidden
+		// transition, so waiting for one would leak forwarding forever.
+		// Deferred a frame so layout has settled; skipped if an observer
+		// (or metadata) already reported.
+		const sendInitialState = () => {
+			if (!controller.active || controller.lastSent != null) return;
+			measureTile(element, controller);
+			controller.forceNext = true;
+			void updateConsumerPreferences(controller);
+		};
+		if (typeof requestAnimationFrame === "function") {
+			requestAnimationFrame(sendInitialState);
+		} else {
+			setTimeout(sendInitialState, 0);
 		}
 
 		return controller;

--- a/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
+++ b/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
@@ -57,9 +57,6 @@ export function useTileAdaptiveStreaming() {
 		return injectedManager.value;
 	}
 
-	// A tile with no visible dimensions counts as hidden. Fail closed:
-	// a wrongly-hidden tile self-corrects on the next resize, while a
-	// wrongly-visible one would leak forwarding forever.
 	function measureTile(
 		element: HTMLVideoElement,
 		target: Pick<TileController, "width" | "height" | "visible">,
@@ -90,9 +87,7 @@ export function useTileAdaptiveStreaming() {
 			!last || Math.abs(last.width - width) >= SIZE_DELTA_THRESHOLD;
 		const visibilityChanged = !last || last.visible !== visible;
 
-		// Skip if no meaningful change. forceNext is set for the first
-		// send (lastSent == null), so the initial state — visible or
-		// hidden — is always reported exactly once.
+		// Skip if no meaningful change
 		if (!controller.forceNext) {
 			if (!visibilityChanged && visible && !widthChanged) return;
 			if (!visibilityChanged && !visible) return;
@@ -127,7 +122,6 @@ export function useTileAdaptiveStreaming() {
 		}
 	}
 
-	// Send immediately while nothing has been reported yet, debounce after.
 	function scheduleRefresh(controller: TileController) {
 		scheduleUpdate(controller, controller.lastSent == null);
 	}
@@ -175,7 +169,6 @@ export function useTileAdaptiveStreaming() {
 			stopListeningForConsumer: null,
 		};
 
-		// Measure up front so the initial state is real, not a placeholder.
 		measureTile(element, controller);
 
 		controller.debouncedUpdate = debounce(() => {
@@ -234,11 +227,6 @@ export function useTileAdaptiveStreaming() {
 			});
 		}
 
-		// One explicit initial sync, independent of observer deltas: an
-		// initially-hidden tile never produces a visible-to-hidden
-		// transition, so waiting for one would leak forwarding forever.
-		// Deferred a frame so layout has settled; skipped if an observer
-		// (or metadata) already reported.
 		const sendInitialState = () => {
 			if (!controller.active || controller.lastSent != null) return;
 			measureTile(element, controller);


### PR DESCRIPTION
Tiles hidden from the moment they are created never sent consumer:update_preferences with visible=false: the initial-update guard skipped them and the visibility observer only fires on transitions. The SFU therefore kept forwarding video for tiles nobody could see, pushing rooms toward full fan-out once the visible grid filled up.

Replace the placeholder initial state with a real synchronous measurement plus one explicit initial sync deferred a frame, so the first report — visible or hidden — is always sent exactly once. Observers return to handling transitions only.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.9% (+0%) · Frontend 35.3% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.9%** (21,683 / 38,096) (+0%) | **29.8%** (2,926 / 9,818) (+0%) |
| Frontend | **35.3%** (14,372 / 40,699) (+0%) | **29.7%** (9,269 / 31,180) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33842199959) for commit `432aa30`.</sub>

</details>
<!-- suite-coverage:end -->
