### PR TITLE
fix(meet): report per-worker mediasoup resource usage

### DIFF
--- a/suite/meet/observability/grafana/provisioning/dashboards/json/sfu-overview.json
+++ b/suite/meet/observability/grafana/provisioning/dashboards/json/sfu-overview.json
@@ -237,7 +237,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 8, "y": 52 },
       "id": 21,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [{ "expr": "sum by (instance, mode) (clamp_min(rate(meet_sfu_worker_cpu_seconds{instance=~\"$instance\"}[$__rate_interval]), 0))", "legendFormat": "{{instance}} {{mode}}", "refId": "A" }],
+      "targets": [{ "expr": "sum by (instance, worker, mode) (clamp_min(rate(meet_sfu_worker_cpu_seconds{instance=~\"$instance\"}[$__rate_interval]), 0))", "legendFormat": "{{instance}} worker {{worker}} {{mode}}", "refId": "A" }],
       "title": "Worker CPU Rate",
       "type": "timeseries"
     },
@@ -247,7 +247,7 @@
       "gridPos": { "h": 8, "w": 8, "x": 16, "y": 52 },
       "id": 22,
       "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true }, "tooltip": { "mode": "multi", "sort": "desc" } },
-      "targets": [{ "expr": "meet_sfu_worker_max_resident_memory_bytes{instance=~\"$instance\"}", "legendFormat": "{{instance}}", "refId": "A" }],
+      "targets": [{ "expr": "meet_sfu_worker_max_resident_memory_bytes{instance=~\"$instance\"}", "legendFormat": "{{instance}} worker {{worker}}", "refId": "A" }],
       "title": "Worker Max Resident Memory",
       "type": "timeseries"
     },

--- a/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
@@ -209,12 +209,16 @@ export class ConsumerManager {
 		return this.consumers.size;
 	}
 
-	getConsumerCountByRoom(roomId: string): number {
-		let count = 0;
+	getConsumerCountsByWorker(
+		roomWorkerIds: Map<string, number>,
+	): Map<number, number> {
+		const counts = new Map<number, number>();
 		for (const data of this.consumers.values()) {
-			if (data.roomId === roomId) count++;
+			const workerId = roomWorkerIds.get(data.roomId);
+			if (workerId === undefined) continue;
+			counts.set(workerId, (counts.get(workerId) ?? 0) + 1);
 		}
-		return count;
+		return counts;
 	}
 
 	async pauseConsumer(consumerId: string): Promise<boolean> {

--- a/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ConsumerManager.ts
@@ -209,6 +209,14 @@ export class ConsumerManager {
 		return this.consumers.size;
 	}
 
+	getConsumerCountByRoom(roomId: string): number {
+		let count = 0;
+		for (const data of this.consumers.values()) {
+			if (data.roomId === roomId) count++;
+		}
+		return count;
+	}
+
 	async pauseConsumer(consumerId: string): Promise<boolean> {
 		const consumerData = this.consumers.get(consumerId);
 		if (!consumerData) {

--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -203,30 +203,55 @@ export class MediasoupManager {
 		this.producerClosedListeners.push(listener);
 	}
 
-	async getWorkerResourceUsage(): Promise<{
-		userCpuSeconds: number;
-		systemCpuSeconds: number;
-		maxResidentMemoryBytes: number;
-	}> {
+	async getWorkerResourceUsage(): Promise<
+		Array<{
+			worker: string;
+			userCpuSeconds?: number;
+			systemCpuSeconds?: number;
+			maxResidentMemoryBytes?: number;
+			rooms: number;
+			peers: number;
+			transports: number;
+			producers: number;
+			consumers: number;
+		}>
+	> {
+		const workers = this.workerManager.getAllWorkers();
 		const usage = await Promise.allSettled(
-			this.workerManager
-				.getAllWorkers()
-				.map(({ worker }) => worker.getResourceUsage()),
+			workers.map(({ worker }) => worker.getResourceUsage()),
 		);
-		return usage.reduce(
-			(total, result) => {
-				if (result.status === 'rejected') return total;
-				return {
-					userCpuSeconds:
-						total.userCpuSeconds + result.value.ru_utime / 1_000_000,
-					systemCpuSeconds:
-						total.systemCpuSeconds + result.value.ru_stime / 1_000_000,
-					maxResidentMemoryBytes:
-						total.maxResidentMemoryBytes + result.value.ru_maxrss * 1024,
-				};
-			},
-			{ userCpuSeconds: 0, systemCpuSeconds: 0, maxResidentMemoryBytes: 0 },
-		);
+		return workers.map(({ id }, index) => {
+			const rooms = this.roomManager
+				.getAllRooms()
+				.filter((room) => room.workerId === id);
+			const counts = rooms.reduce(
+				(total, room) => ({
+					rooms: total.rooms + 1,
+					peers: total.peers + room.peers.size,
+					transports:
+						total.transports +
+						this.transportManager.getTransportCountByRoom(room.id),
+					producers:
+						total.producers +
+						this.producerManager.getProducerCountByRoom(room.id),
+					consumers:
+						total.consumers +
+						this.consumerManager.getConsumerCountByRoom(room.id),
+				}),
+				{ rooms: 0, peers: 0, transports: 0, producers: 0, consumers: 0 },
+			);
+			const result = usage[index];
+			if (result.status === 'rejected')
+				return { worker: String(id), ...counts };
+			return {
+				worker: String(id),
+				...counts,
+				// mediasoup reports CPU time in milliseconds and max RSS in KiB.
+				userCpuSeconds: result.value.ru_utime / 1_000,
+				systemCpuSeconds: result.value.ru_stime / 1_000,
+				maxResidentMemoryBytes: result.value.ru_maxrss * 1024,
+			};
+		});
 	}
 
 	async init(): Promise<void> {
@@ -245,9 +270,10 @@ export class MediasoupManager {
 		roomId: string,
 		onActiveSpeaker?: (roomId: string, participantIds: string[]) => void,
 	): Promise<Room> {
-		const { worker, webRtcServer } = this.workerManager.getNextWorker();
+		const { id, worker, webRtcServer } = this.workerManager.getNextWorker();
 		return this.roomManager.createRoom(
 			roomId,
+			id,
 			worker,
 			webRtcServer,
 			this.config.router.mediaCodecs as RtpCodecCapability[],

--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -220,26 +220,31 @@ export class MediasoupManager {
 		const usage = await Promise.allSettled(
 			workers.map(({ worker }) => worker.getResourceUsage()),
 		);
+		const rooms = this.roomManager.getAllRooms();
+		const roomWorkerIds = new Map(
+			rooms.map((room) => [room.id, room.workerId]),
+		);
+		const roomCounts = new Map<number, { rooms: number; peers: number }>();
+		for (const room of rooms) {
+			const counts = roomCounts.get(room.workerId) ?? { rooms: 0, peers: 0 };
+			counts.rooms += 1;
+			counts.peers += room.peers.size;
+			roomCounts.set(room.workerId, counts);
+		}
+		const transportCounts =
+			this.transportManager.getTransportCountsByWorker(roomWorkerIds);
+		const producerCounts =
+			this.producerManager.getProducerCountsByWorker(roomWorkerIds);
+		const consumerCounts =
+			this.consumerManager.getConsumerCountsByWorker(roomWorkerIds);
 		return workers.map(({ id }, index) => {
-			const rooms = this.roomManager
-				.getAllRooms()
-				.filter((room) => room.workerId === id);
-			const counts = rooms.reduce(
-				(total, room) => ({
-					rooms: total.rooms + 1,
-					peers: total.peers + room.peers.size,
-					transports:
-						total.transports +
-						this.transportManager.getTransportCountByRoom(room.id),
-					producers:
-						total.producers +
-						this.producerManager.getProducerCountByRoom(room.id),
-					consumers:
-						total.consumers +
-						this.consumerManager.getConsumerCountByRoom(room.id),
-				}),
-				{ rooms: 0, peers: 0, transports: 0, producers: 0, consumers: 0 },
-			);
+			const counts = {
+				...{ rooms: 0, peers: 0 },
+				...roomCounts.get(id),
+				transports: transportCounts.get(id) ?? 0,
+				producers: producerCounts.get(id) ?? 0,
+				consumers: consumerCounts.get(id) ?? 0,
+			};
 			const result = usage[index];
 			if (result.status === 'rejected')
 				return { worker: String(id), ...counts };

--- a/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
@@ -166,6 +166,14 @@ export class ProducerManager extends EventEmitter {
 		return this.producers.size;
 	}
 
+	getProducerCountByRoom(roomId: string): number {
+		let count = 0;
+		for (const data of this.producers.values()) {
+			if (data.roomId === roomId) count++;
+		}
+		return count;
+	}
+
 	getProducerIdsByPeer(roomId: string, peerId: string): string[] {
 		return Array.from(this.producers.entries())
 			.filter(

--- a/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/ProducerManager.ts
@@ -166,12 +166,16 @@ export class ProducerManager extends EventEmitter {
 		return this.producers.size;
 	}
 
-	getProducerCountByRoom(roomId: string): number {
-		let count = 0;
+	getProducerCountsByWorker(
+		roomWorkerIds: Map<string, number>,
+	): Map<number, number> {
+		const counts = new Map<number, number>();
 		for (const data of this.producers.values()) {
-			if (data.roomId === roomId) count++;
+			const workerId = roomWorkerIds.get(data.roomId);
+			if (workerId === undefined) continue;
+			counts.set(workerId, (counts.get(workerId) ?? 0) + 1);
 		}
-		return count;
+		return counts;
 	}
 
 	getProducerIdsByPeer(roomId: string, peerId: string): string[] {

--- a/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
@@ -10,6 +10,7 @@ export class RoomManager {
 
 	async createRoom(
 		roomId: string,
+		workerId: number,
 		worker: mediasoup.types.Worker,
 		webRtcServer: mediasoup.types.WebRtcServer,
 		mediaCodecs: RtpCodecCapability[],
@@ -54,6 +55,7 @@ export class RoomManager {
 
 		const room: Room = {
 			id: roomId,
+			workerId,
 			router,
 			webRtcServer,
 			audioLevelObserver,
@@ -124,6 +126,10 @@ export class RoomManager {
 
 	getRoomCount(): number {
 		return this.rooms.size;
+	}
+
+	getAllRooms(): Room[] {
+		return Array.from(this.rooms.values());
 	}
 
 	getParticipantCount(): number {

--- a/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
@@ -211,12 +211,16 @@ export class TransportManager {
 		return this.transports.size;
 	}
 
-	getTransportCountByRoom(roomId: string): number {
-		let count = 0;
+	getTransportCountsByWorker(
+		roomWorkerIds: Map<string, number>,
+	): Map<number, number> {
+		const counts = new Map<number, number>();
 		for (const data of this.transports.values()) {
-			if (data.roomId === roomId) count++;
+			const workerId = roomWorkerIds.get(data.roomId);
+			if (workerId === undefined) continue;
+			counts.set(workerId, (counts.get(workerId) ?? 0) + 1);
 		}
-		return count;
+		return counts;
 	}
 
 	closePeerTransports(roomId: string, peerId: string): void {

--- a/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/TransportManager.ts
@@ -211,6 +211,14 @@ export class TransportManager {
 		return this.transports.size;
 	}
 
+	getTransportCountByRoom(roomId: string): number {
+		let count = 0;
+		for (const data of this.transports.values()) {
+			if (data.roomId === roomId) count++;
+		}
+		return count;
+	}
+
 	closePeerTransports(roomId: string, peerId: string): void {
 		for (const direction of ['send', 'recv'] as const) {
 			const key = `${roomId}:${peerId}:${direction}`;

--- a/suite/meet/sfu-server/src/mediasoup/WorkerManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/WorkerManager.ts
@@ -4,6 +4,7 @@ import { loggers } from '../utils/logger';
 import { captureException, flushSentry } from '../utils/sentry';
 
 interface WorkerEntry {
+	id: number;
 	worker: mediasoup.types.Worker;
 	webRtcServer: mediasoup.types.WebRtcServer;
 }
@@ -58,7 +59,7 @@ export class WorkerManager {
 				],
 			});
 
-			this.workers.push({ worker, webRtcServer });
+			this.workers.push({ id: i + 1, worker, webRtcServer });
 			loggers.workerManager.info(
 				'Created worker %d/%d with WebRtcServer on UDP port %d',
 				i + 1,

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/PeerManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/PeerManager.test.ts
@@ -11,6 +11,7 @@ import { PeerManager } from '../PeerManager';
 function makeRoom(): Room {
 	return {
 		id: 'r1',
+		workerId: 1,
 		router: {} as Room['router'],
 		audioLevelObserver: {} as Room['audioLevelObserver'],
 		peers: new Map(),

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/RoomManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/RoomManager.test.ts
@@ -72,14 +72,14 @@ describe('RoomManager', () => {
 		const worker = makeWorker({ router });
 		const webRtcServer = makeWebRtcServer();
 
-		const roomA = await mgr.createRoom('r1', worker, webRtcServer, codecs);
+		const roomA = await mgr.createRoom('r1', 1, worker, webRtcServer, codecs);
 		const routerSpy = worker.createRouter as ReturnType<typeof vi.fn>;
 		expect(routerSpy).toHaveBeenCalledTimes(1);
 		expect(mgr.getRoom('r1')).toBe(roomA);
 		expect(mgr.getRouter('r1')).toBe(router);
 		expect(mgr.getRoomCount()).toBe(1);
 
-		const roomB = await mgr.createRoom('r1', worker, webRtcServer, codecs);
+		const roomB = await mgr.createRoom('r1', 1, worker, webRtcServer, codecs);
 		expect(roomB).toBe(roomA);
 		expect(routerSpy).toHaveBeenCalledTimes(1);
 	});
@@ -93,6 +93,7 @@ describe('RoomManager', () => {
 
 		const room = await mgr.createRoom(
 			'r1',
+			1,
 			worker,
 			webRtcServer,
 			codecs,
@@ -119,6 +120,7 @@ describe('RoomManager', () => {
 
 		const room = await mgr.createRoom(
 			'r1',
+			1,
 			worker,
 			webRtcServer,
 			codecs,
@@ -141,7 +143,7 @@ describe('RoomManager', () => {
 		const router = makeRouter();
 		const worker = makeWorker({ router });
 		const webRtcServer = makeWebRtcServer();
-		await mgr.createRoom('r1', worker, webRtcServer, codecs);
+		await mgr.createRoom('r1', 1, worker, webRtcServer, codecs);
 
 		await mgr.closeRoom('r1');
 
@@ -161,7 +163,7 @@ describe('RoomManager', () => {
 		const router = makeRouter();
 		const worker = makeWorker({ router });
 		const webRtcServer = makeWebRtcServer();
-		const room = await mgr.createRoom('r1', worker, webRtcServer, codecs);
+		const room = await mgr.createRoom('r1', 1, worker, webRtcServer, codecs);
 		addPeersTo(room, 'p1', 'p2', 'recorder:session-1');
 
 		room.peers.get('p1')!.producers.set('a', {} as never);
@@ -193,8 +195,8 @@ describe('RoomManager', () => {
 		const webRtcServer1 = makeWebRtcServer();
 		const webRtcServer2 = makeWebRtcServer();
 
-		await mgr.createRoom('r1', worker1, webRtcServer1, codecs);
-		await mgr.createRoom('r2', worker2, webRtcServer2, codecs);
+		await mgr.createRoom('r1', 1, worker1, webRtcServer1, codecs);
+		await mgr.createRoom('r2', 2, worker2, webRtcServer2, codecs);
 
 		await mgr.cleanup();
 

--- a/suite/meet/sfu-server/src/server/__tests__/RouteManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RouteManager.test.ts
@@ -11,11 +11,19 @@ function createHarness(token?: string) {
 	};
 	const mediasoup = {
 		getResourceCounts: vi.fn(() => ({ rooms: 2, participants: 3, peers: 4 })),
-		getWorkerResourceUsage: vi.fn(async () => ({
-			userCpuSeconds: 1,
-			systemCpuSeconds: 0.5,
-			maxResidentMemoryBytes: 1024,
-		})),
+		getWorkerResourceUsage: vi.fn(async () => [
+			{
+				worker: '1',
+				userCpuSeconds: 1,
+				systemCpuSeconds: 0.5,
+				maxResidentMemoryBytes: 1024,
+				rooms: 2,
+				peers: 4,
+				transports: 8,
+				producers: 4,
+				consumers: 12,
+			},
+		]),
 		rooms: {
 			getRoomCount: vi.fn(() => 2),
 			getParticipantCount: vi.fn(() => 3),
@@ -73,6 +81,11 @@ describe('RouteManager metrics endpoint', () => {
 		);
 		expect(response.send).toHaveBeenCalledWith(
 			expect.stringContaining('meet_sfu_resources{resource="participants"} 3'),
+		);
+		expect(response.send).toHaveBeenCalledWith(
+			expect.stringContaining(
+				'meet_sfu_worker_resources{worker="1",resource="consumers"} 12',
+			),
 		);
 	});
 

--- a/suite/meet/sfu-server/src/telemetry/Telemetry.ts
+++ b/suite/meet/sfu-server/src/telemetry/Telemetry.ts
@@ -180,13 +180,20 @@ export class Telemetry {
 	});
 	private workerCpu = new Gauge({
 		name: 'meet_sfu_worker_cpu_seconds',
-		help: 'Aggregate mediasoup worker CPU time',
-		labelNames: ['mode'] as const,
+		help: 'Mediasoup worker CPU time',
+		labelNames: ['worker', 'mode'] as const,
 		registers: [this.registry],
 	});
 	private workerMemory = new Gauge({
 		name: 'meet_sfu_worker_max_resident_memory_bytes',
-		help: 'Aggregate mediasoup worker maximum resident memory',
+		help: 'Mediasoup worker maximum resident memory',
+		labelNames: ['worker'] as const,
+		registers: [this.registry],
+	});
+	private workerResources = new Gauge({
+		name: 'meet_sfu_worker_resources',
+		help: 'Current resources assigned to a mediasoup worker',
+		labelNames: ['worker', 'resource'] as const,
 		registers: [this.registry],
 	});
 	private resources = new Gauge({
@@ -275,14 +282,54 @@ export class Telemetry {
 		}
 	}
 
-	setWorkerResources(resources: {
-		userCpuSeconds: number;
-		systemCpuSeconds: number;
-		maxResidentMemoryBytes: number;
-	}): void {
-		this.workerCpu.set({ mode: 'user' }, resources.userCpuSeconds);
-		this.workerCpu.set({ mode: 'system' }, resources.systemCpuSeconds);
-		this.workerMemory.set(resources.maxResidentMemoryBytes);
+	setWorkerResources(
+		workers: Array<{
+			worker: string;
+			userCpuSeconds?: number;
+			systemCpuSeconds?: number;
+			maxResidentMemoryBytes?: number;
+			rooms: number;
+			peers: number;
+			transports: number;
+			producers: number;
+			consumers: number;
+		}>,
+	): void {
+		this.workerCpu.reset();
+		this.workerMemory.reset();
+		this.workerResources.reset();
+		for (const resources of workers) {
+			if (resources.userCpuSeconds !== undefined) {
+				this.workerCpu.set(
+					{ worker: resources.worker, mode: 'user' },
+					resources.userCpuSeconds,
+				);
+			}
+			if (resources.systemCpuSeconds !== undefined) {
+				this.workerCpu.set(
+					{ worker: resources.worker, mode: 'system' },
+					resources.systemCpuSeconds,
+				);
+			}
+			if (resources.maxResidentMemoryBytes !== undefined) {
+				this.workerMemory.set(
+					{ worker: resources.worker },
+					resources.maxResidentMemoryBytes,
+				);
+			}
+			for (const resource of [
+				'rooms',
+				'peers',
+				'transports',
+				'producers',
+				'consumers',
+			] as const) {
+				this.workerResources.set(
+					{ worker: resources.worker, resource },
+					resources[resource],
+				);
+			}
+		}
 	}
 
 	recordE2EEEvent(

--- a/suite/meet/sfu-server/src/telemetry/__tests__/Telemetry.test.ts
+++ b/suite/meet/sfu-server/src/telemetry/__tests__/Telemetry.test.ts
@@ -86,22 +86,37 @@ describe('Telemetry', () => {
 		expect(output).not.toContain('user-controlled-state');
 	});
 
-	it('exports aggregate worker resources and bounded media scores', async () => {
+	it('exports per-worker resources and bounded media scores', async () => {
 		const telemetry = new Telemetry();
 		telemetry.mediaScore.observe({ direction: 'recv', media: 'video' }, 7);
-		telemetry.setWorkerResources({
-			userCpuSeconds: 2,
-			systemCpuSeconds: 1,
-			maxResidentMemoryBytes: 2048,
-		});
+		telemetry.setWorkerResources([
+			{
+				worker: '1',
+				userCpuSeconds: 2,
+				systemCpuSeconds: 1,
+				maxResidentMemoryBytes: 2048,
+				rooms: 1,
+				peers: 2,
+				transports: 4,
+				producers: 4,
+				consumers: 4,
+			},
+		]);
 
 		const output = await telemetry.registry.metrics();
 
 		expect(output).toContain(
 			'meet_sfu_media_score_count{direction="recv",media="video"} 1',
 		);
-		expect(output).toContain('meet_sfu_worker_cpu_seconds{mode="user"} 2');
-		expect(output).toContain('meet_sfu_worker_max_resident_memory_bytes 2048');
+		expect(output).toContain(
+			'meet_sfu_worker_cpu_seconds{worker="1",mode="user"} 2',
+		);
+		expect(output).toContain(
+			'meet_sfu_worker_max_resident_memory_bytes{worker="1"} 2048',
+		);
+		expect(output).toContain(
+			'meet_sfu_worker_resources{worker="1",resource="consumers"} 4',
+		);
 	});
 
 	it('bounds E2EE event names', async () => {

--- a/suite/meet/sfu-server/src/types/index.ts
+++ b/suite/meet/sfu-server/src/types/index.ts
@@ -471,6 +471,7 @@ export interface ExistingProducer {
 // Mediasoup Manager types
 export interface Room {
 	id: string;
+	workerId: number;
 	router: Router;
 	webRtcServer: WebRtcServer;
 	audioLevelObserver: AudioLevelObserver;


### PR DESCRIPTION
`meet_sfu_worker_cpu_seconds` was wrong by 1,000x: mediasoup's `getResourceUsage()` reports CPU time in milliseconds (the worker converts `getrusage` to ms), but the exporter divided by 1,000,000, assuming microseconds like Node's own `process.resourceUsage()`. The unit was confirmed empirically against the OS CPU accounting of the worker process.

Worker gauges are also broken out per worker now instead of aggregated: CPU seconds, max RSS, and current rooms, peers, transports, producers, and consumers per worker, with the Grafana panel legends split by worker.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 56.9% (+0%) · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **56.9%** (21,682 / 38,096) (+0%) | **29.8%** (2,926 / 9,818) (+0%) |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/33845030738) for commit `d2ad27c`.</sub>

</details>
<!-- suite-coverage:end -->
