### PR TITLE
ci: skip redundant asset builds and cache uv packages

### DIFF
--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -116,7 +116,9 @@ jobs:
       - name: Cache pip
         uses: actions/cache@v6
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
           restore-keys: |
             ${{ runner.os }}-pip-
@@ -150,11 +152,11 @@ jobs:
         id: install-suite
         working-directory: /home/runner/frappe-bench
         run: |
-          bench get-app suite $GITHUB_WORKSPACE
+          bench get-app suite $GITHUB_WORKSPACE --skip-assets
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app suite
-          bench build
+          bench build --using-cached
         env:
           CI: "Yes"
 
@@ -348,7 +350,9 @@ jobs:
         if: steps.mail-calendar-changes.outputs.run == '1'
         uses: actions/cache@v6
         with:
-          path: ~/.cache/pip
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*requirements.txt', '**/pyproject.toml', '**/setup.py', '**/setup.cfg') }}
           restore-keys: |
             ${{ runner.os }}-pip-
@@ -372,10 +376,11 @@ jobs:
         if: steps.mail-calendar-changes.outputs.run == '1'
         working-directory: /home/runner/frappe-bench
         run: |
-          bench get-app suite $GITHUB_WORKSPACE
+          bench get-app suite $GITHUB_WORKSPACE --skip-assets
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app suite
+          bench build --using-cached
         env:
           CI: "Yes"
 


### PR DESCRIPTION
The `Install Suite` step was the longest step in the Backend job: 149s of 352s wall clock (42%), and the same cost was paid again by each mail/calendar leg.

Two of its cost centres were avoidable:

**Frontend bundled twice per job (~47s).** `bench get-app` ends with a full `bench build --app suite`, and the step then ran `bench build` over every app again. Both pass `--run-build-command` to esbuild, which shells out to `yarn workspace @suite/frontend build` (`vite build && vite build --config vite.sw.config.ts`) — ~20s each time. esbuild itself is only 0.15s/3.9s; the vite bundle is the whole cost. `bench run-tests` is Python-only and never loads a bundle, so:

- `bench get-app --skip-assets` drops the first build.
- `bench build --using-cached` drops `--run-build-command` from the second, so it still creates the asset dirs and runs esbuild (~4s) without bundling the frontend.

The mail/calendar leg had no explicit `bench build`, but `get-app` was building implicitly, so it gets `--using-cached` too to keep the asset dirs it had before.

**uv cache never restored (~37s).** Installs run through `uv pip`, but only `~/.cache/pip` was cached — uv keeps its cache in `~/.cache/uv`, so `uv pip install -e apps/suite` (`av`, `pymupdf`, `boto3`, `tantivy`, `anthropic`, `pycrdt`, …) re-resolved and re-downloaded on every run. Both paths are now cached.

Not changed: `bench get-app` still runs `yarn install --check-files` (~24s, plus ~28s to restore the yarn cache). Skipping it needs `get-app` replaced with a manual clone plus `bench apps sync`, and `bench build --using-cached` may then fail if esbuild resolves suite bundles out of `suite/node_modules`. Left for a follow-up that can be verified against a real run.

The E2E workflows keep their build: they serve `meet.test` / `drive-writer.test` to real browsers and need the vite bundle.