### PR TITLE
ci: drop the yarn cache from the backend job

### DIFF
--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -124,18 +124,6 @@ jobs:
             ${{ runner.os }}-pip-
             ${{ runner.os }}-
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: 'echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT'
-
-      - name: Cache yarn
-        uses: actions/cache@v6
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: Install MariaDB Client
         run: |
           sudo apt update


### PR DESCRIPTION
Follow-up to #823.

The Backend leg spent 44s restoring the yarn cache so that `yarn install --check-files` would take 35.5s instead of ~58s. The Mail and Calendar legs have no yarn cache step at all, which gives the uncached cost directly: 54.4s and 64.4s across the runs measured. So the restore buys back less than it costs, and it also kept ~1GB of node_modules in cache storage. Both the cache step and the `yarn cache dir` probe are gone; `bench get-app` still installs, uncached.

**Measured on this change: Backend total 567s -> 398s, Install Suite 142s -> 94s.** Two effects compose:

| | before | after |
|---|---|---|
| `yarn install --check-files` (Backend) | 35.5s | 56.4s |
| `uv pip install -e apps/suite` (Backend) | 45.2s | **0.36s** |

The uv cache added in #823 was cold on the run that introduced it, so its benefit only appears now: 45s -> 0.36s. That more than pays for the 21s the yarn install gives back.

**On pruning the uv cache — tried and reverted.** I shipped `uv cache prune --ci` in the first commit of this PR and took it back out after measuring. It removes 978 MiB, and what it removes is the unzipped archives that let uv hardlink out of its cache and finish an install in 0.36s. Pruning shrinks the 341 MB payload to save 2-4s of transfer, against a 10 GB repo cache limit we are nowhere near, while giving back most of the 45s the cache just won. It was also inert in practice: `actions/cache` skips the save when the key already exists, so it would only have activated the next time `pyproject.toml` changes — at which point it would silently slow every install after it.

**Kept deliberately:** `bench build --using-cached` stays in all three legs. It costs ~1s and is the only thing validating the asset pipeline on Python-only PRs, since the Frontend job is gated on `frontend/`, `package.json`, `yarn.lock`. Moving it to the Frontend job was considered and rejected: that job has no bench, so it would need `bench init` + `bench get-app` + `bench new-site` (~180s) to run a 1s command.