### PR TITLE
ci: build the app once, in the job that always runs

### DIFF
--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -429,7 +429,9 @@ jobs:
         if: steps.mail-calendar-changes.outputs.run == '1'
         working-directory: /home/runner/frappe-bench
         run: |
-          bench get-app suite $GITHUB_WORKSPACE --skip-assets
+          git clone "$GITHUB_WORKSPACE" apps/suite
+          uv pip install --quiet -e "$PWD/apps/suite" --python "$PWD/env/bin/python"
+          printf 'frappe\nsuite\n' > sites/apps.txt
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app suite

--- a/.github/workflows/suite-ci.yml
+++ b/.github/workflows/suite-ci.yml
@@ -138,7 +138,7 @@ jobs:
           bench setup requirements --dev
           bench new-site --db-root-password root --admin-password admin test_site
           bench --site test_site install-app suite
-          bench build --using-cached
+          bench build
         env:
           CI: "Yes"
 


### PR DESCRIPTION
Two changes.

**Backend builds for real again.**

In #823 we switched to `bench build --using-cached` to save time. It turns out that flag skips the compile step entirely — frappe's esbuild sees it, writes `assets.json`, and exits (`esbuild/esbuild.js:119-125`). It finished in ~90ms instead of ~4s, so it was never checking the bundles.

Backend now runs a full `bench build` (~24s). It is the only job that runs on every PR, so it is the right place to pay for the check. A broken bundle or a bad asset path in `hooks.py` fails CI again.

**Mail and calendar skip `node_modules`.**

Those two legs only need the cached build, which compiles nothing, so the ~56s `yarn install` that `bench get-app` always runs is wasted there. `get-app` has no flag to skip it, so we do the three steps by hand:

- `git clone` the repo into `apps/suite`
- `uv pip install -e`, to install the Python package
- write `sites/apps.txt`, so the bench knows the app exists

Only the last one needs explaining. `install-app` needs the app to be listed (`installer.py:319` raises if it is not), but `bench build` does not — esbuild just scans the `apps/` directory instead (`esbuild/utils.js:60`).

We first did this by calling `Bench.apps.sync`, a private Python API, which forced a `frappe-bench` pin. Writing the file directly avoids the private API, so no pin is needed.

**Result:** mail and calendar go from 93s to 46s each, about 112s per run. Backend grows by ~23s for the real build, and keeps its `node_modules` because the real build needs them.