### PR TITLE
fix(mail): check the account belongs to the caller before reading it

### DIFF
--- a/suite/mail/api/account.py
+++ b/suite/mail/api/account.py
@@ -12,6 +12,7 @@ from suite.mail.doctype.identity.identity import fetch_identities
 from suite.mail.doctype.mail_account_request.mail_account_request import otp_cache_key
 from suite.mail.doctype.mail_settings.mail_settings import get_signup_domains
 from suite.mail.doctype.participant_identity.participant_identity import fetch_participant_identities
+from suite.mail.doctype.user_account.user_account import is_jmap_account_belongs_to_user
 from suite.mail.stalwart import get_domains
 from suite.mail.utils import get_config, is_stalwart_configured, log_mail_error
 from suite.mail.utils.dns import parse_dns_zone_file
@@ -625,6 +626,12 @@ def is_push_notification_relay_enabled() -> bool:
 @frappe.whitelist()
 def get_quota(account: str) -> dict:
     """Return quota usage for the user"""
+
+    # The Quota rows are read straight out of the local table, which bypasses permissions,
+    # and this endpoint never reaches a JMAP service that would resolve ownership on the
+    # way — so the account has to be established as the caller's here. Same omission as
+    # get_mailboxes had.
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
 
     result = {
         "disk_quota": 0,

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -105,6 +105,14 @@ def get_mailboxes(account: str) -> list[dict]:
     if not is_jmap_configured(user):
         return []
 
+    # Whose account it is, not merely whether the caller has one of their own. Everything
+    # below reads the local tables through frappe.get_all, which bypasses permissions by
+    # design, and nothing here goes near a JMAP service — so unlike the endpoints that do,
+    # there is no ownership check further down to fall back on. Without this an account id
+    # was enough to read another user's mailbox names, counts and automation rules, and
+    # those rules carry the addresses and subjects they filter on.
+    is_jmap_account_belongs_to_user(account, raise_exception=True)
+
     mailboxes = get_user_mailboxes(account)
     if not mailboxes:
         return []

--- a/suite/mail/tests/test_mail_account_isolation.py
+++ b/suite/mail/tests/test_mail_account_isolation.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+from suite.mail.api.account import get_quota
+from suite.mail.api.mail import get_mailboxes
+from suite.mail.tests.base import StalwartIntegrationTestCase
+
+
+class TestMailAccountIsolation(StalwartIntegrationTestCase):
+    """Endpoints that take an account id must establish whose account it is.
+
+    Most of them get that for free: anything reaching a JMAP service resolves the account
+    through `get_user_for_jmap_account`, which throws for an account the session user is
+    not linked to. The ones covered here read the local tables instead — through
+    `frappe.get_all`, which bypasses permissions by design — so they have nothing to fall
+    back on and have to check for themselves.
+
+    Reported 2026-09-07 against `get_mailboxes`: any JMAP-configured user could pass
+    another user's account id and read their mailbox names, message and unread counts, and
+    automation rules — and those rules carry the addresses and subjects they filter on.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.owner = cls.create_member()
+        cls.other = cls.create_member()
+        cls.owner_account = cls.personal_account(cls.owner)
+        cls.other_account = cls.personal_account(cls.other)
+
+    def test_mailboxes_are_readable_by_their_owner(self):
+        with self.set_user(self.owner.email):
+            mailboxes = get_mailboxes(self.owner_account)
+
+        self.assertTrue(mailboxes, "The owner got nothing back for their own account.")
+
+    def test_mailboxes_are_not_readable_across_accounts(self):
+        with self.set_user(self.other.email):
+            # The other member has an account of their own, so the endpoint's
+            # is_jmap_configured gate passes and only ownership stands between them and
+            # someone else's mailboxes.
+            with self.assertRaises(frappe.ValidationError):
+                get_mailboxes(self.owner_account)
+
+    def test_quota_is_readable_by_its_owner(self):
+        with self.set_user(self.owner.email):
+            quota = get_quota(self.owner_account)
+
+        self.assertIn("used_percentage", quota)
+
+    def test_quota_is_not_readable_across_accounts(self):
+        with self.set_user(self.other.email):
+            with self.assertRaises(frappe.ValidationError):
+                get_quota(self.owner_account)


### PR DESCRIPTION
`get_mailboxes` and `get_quota` took an account id from the caller and checked only that the caller had a JMAP account of their own — never that this one was it. Both read the local tables through `frappe.get_all`, which bypasses permissions, and neither reaches a JMAP service, so there was no ownership check further down to fall back on either.

Both now call `is_jmap_account_belongs_to_user`, as the six other account-scoped endpoints in `mail.py` already did. Tests cover both endpoints in both directions — the owner reads their own, another user is refused.

`get_quota` wasn't in the report; it turned up looking for the same shape elsewhere. Two other candidates were false alarms and are left alone: `verify_otp` takes a signup token rather than an account, and `get_address_book_contact_count` resolves ownership through its JMAP service.