### PR TITLE
feat(drive): add open-in-new-tab action and Cmd+Enter shortcut

### DIFF
--- a/frontend/src/apps/drive/components/DriveListRow.vue
+++ b/frontend/src/apps/drive/components/DriveListRow.vue
@@ -45,7 +45,7 @@
         :data-testid="`drive-entity-${row.name}`"
         :data-selected="selections.has(row.name) || undefined"
         @contextmenu="(e) => !selections.size && contextMenu(e, row)"
-        @click="isModKey($event) ? props.toggleSelection(row, $event) : !selections.size && open(row)"
+        @click="onRowClick($event, row)"
         @dragstart="onDragStart($event, row)"
         @dragend="draggedItem = null"
         @dragover="
@@ -226,8 +226,8 @@ const onDragStart = (e, row) => {
 // Used as right-click doesn't trigger active in frappe-ui
 const selectedName = computed(() => activeEntity.value?.name)
 // Folders get a real `:to` route below — RouterLink handles the navigation
-// (and gives cmd/ctrl-click-to-open-in-new-tab, right-click-copy-link for
-// free) — so this only drives non-folder clicks. Suppressed during an active
+// (and gives right-click-copy-link and middle-click-new-tab for free) — so
+// this only drives non-folder clicks. Suppressed during an active
 // selection so clicking elsewhere in the row doesn't navigate away (matches
 // the existing !selections.size click guard).
 // `!renamingEntity`: the rename input sits inside the row's <button>, so a
@@ -239,6 +239,16 @@ const open = (row) =>
   openEntity(row)
 const routeFor = (row) =>
   row.is_folder && !props.selections.size ? folderRoute(row) : undefined
+// ⌘/Ctrl+click selects (file-manager convention, same as grid tiles).
+// preventDefault keeps folder rows — real links — from also opening a tab.
+const onRowClick = (e, row) => {
+  if (isModKey(e)) {
+    e.preventDefault()
+    props.toggleSelection(row, e)
+    return
+  }
+  if (!props.selections.size) open(row)
+}
 
 // Virtual nodes have no Drive children to fetch — expanding one would ask for
 // the contents of a File that doesn't exist.

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -50,6 +50,7 @@ import {
   isVirtual,
   isManaged,
   isAttachmentRef,
+  isModKey,
 } from '@/apps/drive/utils/files'
 import {
   toggleFav,
@@ -89,6 +90,7 @@ import { getFileLink } from '@/apps/drive/ui/drive/js/utils'
 import LucideClock from '~icons/lucide/clock'
 import LucideDownload from '~icons/lucide/download'
 import LucideExternalLink from '~icons/lucide/external-link'
+import LucideSquareArrowOutUpRight from '~icons/lucide/square-arrow-out-up-right'
 import LucideEye from '~icons/lucide/eye'
 import LucideInfo from '~icons/lucide/info'
 import LucideLink2 from '~icons/lucide/link-2'
@@ -235,6 +237,14 @@ onKeyDown('Backspace', (e) => {
 onKeyDown('m', (e) => {
   if (isTyping(e)) return
   if (e.ctrlKey) emitter.emit('move')
+})
+onKeyDown('Enter', (e) => {
+  if (isTyping(e)) return
+  if (document.querySelector('.dialog-content[data-state="open"]')) return
+  if (route.name === 'drive-Trash' || !isModKey(e)) return
+  if (selectedEntitities.value.length !== 1) return
+  e.preventDefault()
+  openEntity(selectedEntitities.value[0], true)
 })
 onKeyDown('Escape', (e) => {
   if (isTyping(e)) return
@@ -529,6 +539,12 @@ const actionItems = computed(() => {
         icon: LucideExternalLink,
         action: ([entity]) => openEntity(entity),
         isEnabled: (e) => e.file_type === 'Link',
+      },
+      {
+        label: __('Open in new tab'),
+        icon: LucideSquareArrowOutUpRight,
+        action: ([entity]) => openEntity(entity, true),
+        isEnabled: (e) => !isVirtual(e) && e.file_type !== 'Link',
       },
       {
         label: __('Show Info'),

--- a/frontend/src/apps/drive/components/GenericPage.vue
+++ b/frontend/src/apps/drive/components/GenericPage.vue
@@ -223,6 +223,12 @@ const isTyping = (e) =>
   e.target.tagName === 'INPUT' ||
   e.target.tagName === 'TEXTAREA'
 
+// Links keep their own confirm flow and virtual nodes have no standalone
+// page, so neither can be opened in a new tab. Shared by the context-menu
+// action and the mod+Enter shortcut.
+const canOpenInNewTab = (entity) =>
+  !isVirtual(entity) && entity.file_type !== 'Link'
+
 onKeyDown('a', (e) => {
   if (isTyping(e)) return
   if (e.metaKey || e.ctrlKey) {
@@ -243,8 +249,10 @@ onKeyDown('Enter', (e) => {
   if (document.querySelector('.dialog-content[data-state="open"]')) return
   if (route.name === 'drive-Trash' || !isModKey(e)) return
   if (selectedEntitities.value.length !== 1) return
+  const [entity] = selectedEntitities.value
+  if (!canOpenInNewTab(entity)) return
   e.preventDefault()
-  openEntity(selectedEntitities.value[0], true)
+  openEntity(entity, true)
 })
 onKeyDown('Escape', (e) => {
   if (isTyping(e)) return
@@ -544,7 +552,7 @@ const actionItems = computed(() => {
         label: __('Open in new tab'),
         icon: LucideSquareArrowOutUpRight,
         action: ([entity]) => openEntity(entity, true),
-        isEnabled: (e) => !isVirtual(e) && e.file_type !== 'Link',
+        isEnabled: canOpenInNewTab,
       },
       {
         label: __('Show Info'),

--- a/frontend/src/apps/drive/components/ShortcutsDialog.vue
+++ b/frontend/src/apps/drive/components/ShortcutsDialog.vue
@@ -72,6 +72,7 @@ const shortcutGroups = [
       [getLabel('s'), 'Share selected file(s)'],
       [getLabel('m'), 'Move selected file(s)'],
       [[metaKey.value, 'Delete'], 'Delete selected file(s)'],
+      [[findFilesKey.value, 'Enter'], 'Open selected file in new tab'],
       [getLabel('u'), 'Upload a file'],
       [getLabel('n'), 'Create a folder'],
     ],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 			"~icons/lucide/clock": path.resolve(__dirname, "src/test/icon-stub.ts"),
 			"~icons/lucide/download": path.resolve(__dirname, "src/test/icon-stub.ts"),
 			"~icons/lucide/external-link": path.resolve(__dirname, "src/test/icon-stub.ts"),
+			"~icons/lucide/square-arrow-out-up-right": path.resolve(__dirname, "src/test/icon-stub.ts"),
 			"~icons/lucide/eye": path.resolve(__dirname, "src/test/icon-stub.ts"),
 			"~icons/lucide/info": path.resolve(__dirname, "src/test/icon-stub.ts"),
 			"~icons/lucide/link-2": path.resolve(__dirname, "src/test/icon-stub.ts"),


### PR DESCRIPTION
Keeps the file-manager convention for modifier clicks and gives new-tab a dedicated affordance:

- ⌘/Ctrl+click still selects, and folder rows (real links) no longer also open a native tab on top of selection
- Right-click menu gains "Open in new tab" for files and folders; external links keep their confirm flow, virtual nodes are excluded
- ⌘/Ctrl+Enter opens the selected entity in a new tab; no-op in Trash and while a dialog is open
- Shortcut documented in the shortcuts dialog

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend 35.3% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | **35.3%** (14,394 / 40,758) (+0%) | **29.7%** (9,277 / 31,223) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34111648494) for commit `7c0353d`.</sub>

</details>
<!-- suite-coverage:end -->
