### PR TITLE
feat(mail): drag threads onto a folder to move them

### DIFF
--- a/frontend/src/apps/mail/components/AppSidebar.vue
+++ b/frontend/src/apps/mail/components/AppSidebar.vue
@@ -43,6 +43,13 @@
 								:label="item.label"
 								:icon="item.icon"
 								:to="item.to"
+								:class="
+									threadDrag.overMailbox.value === item.mailboxId &&
+									'ring-2 ring-outline-gray-3 ring-inset'
+								"
+								@dragover="onFolderDragOver($event, item)"
+								@dragleave="onFolderDragLeave(item)"
+								@drop="onFolderDrop($event, item)"
 								:active="
 									item.activeFor?.includes(
 										['mail-mailbox', 'mail-mail'].includes(route.name as string)
@@ -131,8 +138,9 @@ import {
 import { accountSubmenu } from '@/composables/accountSubmenu'
 import { useAppSwitcher } from '@/composables/useAppSwitcher'
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
-import { getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
+import { canMoveToMailbox, getIcon, getMailboxName, toTitleCase } from '@/apps/mail/utils'
 import { useAccountSwitch, useScreenSize, useSettings, useSidebar } from '@/apps/mail/utils/composables'
+import { useThreadDrag } from '@/apps/mail/composables/useThreadDrag'
 import { sessionStore } from '@/apps/mail/stores/session'
 import { SECONDARY_MAILBOX_ROLES, userStore } from '@/apps/mail/stores/user'
 import MailLogo from '@/apps/mail/components/Icons/MailLogo.vue'
@@ -197,6 +205,41 @@ const isSectionCollapsed = (section: { key?: string }) =>
 const { logout, branding } = sessionStore()
 const store = userStore()
 const { mailboxes, allInboxesUnread } = store
+
+// ── Threads dropped onto a folder ─────────────────────────────────────────────────────────────────
+// The rows are dragged in the view; the folders that take them are here. The move itself belongs to
+// the view too — the sidebar only says which folder the cursor is over, and hands the drop back.
+const threadDrag = useThreadDrag()
+
+/**
+ * Folders that can take a drop: exactly the ones the "Move to" menu offers, read from the same
+ * predicate so the two lists cannot drift. That rules out the mailbox the thread is already in,
+ * along with Sent, Drafts and the Screener; Junk and Trash stay in, since handleMoveThreads reads
+ * those as "mark as spam" and "delete", which is what dropping there means. Sidebar entries that
+ * are not real mailboxes — Starred, All Inboxes, Outbox — have no id and fall out on their own.
+ */
+const canDrop = (item: { mailboxId?: string }) =>
+	threadDrag.isDragging.value &&
+	!!mailboxes.data?.some((m: MailboxData) => m.id === item.mailboxId) &&
+	canMoveToMailbox(item.mailboxId, route.params.mailbox as string, store.mailboxIds)
+
+const onFolderDragOver = (e: DragEvent, item: { mailboxId?: string }) => {
+	if (!canDrop(item)) return
+	// Without preventDefault the browser refuses the drop and shows the "no" cursor.
+	e.preventDefault()
+	if (e.dataTransfer) e.dataTransfer.dropEffect = 'move'
+	threadDrag.overMailbox.value = item.mailboxId!
+}
+
+const onFolderDragLeave = (item: { mailboxId?: string }) => {
+	if (threadDrag.overMailbox.value === item.mailboxId) threadDrag.overMailbox.value = ''
+}
+
+const onFolderDrop = (e: DragEvent, item: { mailboxId?: string }) => {
+	if (!canDrop(item)) return
+	e.preventDefault()
+	threadDrag.drop(item.mailboxId!)
+}
 
 const user = inject('$user')
 

--- a/frontend/src/apps/mail/components/MailListItem.vue
+++ b/frontend/src/apps/mail/components/MailListItem.vue
@@ -13,7 +13,10 @@
 		:subject-italic="!mail.subject"
 		:preview-italic="!mail.preview"
 		:account-label="accountLabel"
+		:draggable
 		@set-selected="(selected: boolean) => emit('setSelected', selected)"
+		@drag-start="(e: DragEvent) => emit('dragStart', e)"
+		@drag-end="emit('dragEnd')"
 	>
 		<template #sender><span v-html="highlight(header)" /></template>
 
@@ -192,6 +195,9 @@ const {
 	selectable?: boolean
 	// Set on the members of an expanded stack, whose stack row already names the sender.
 	hideSender?: boolean
+	// Whether the row can be dragged onto a folder; the view decides, since only it
+	// knows whether a selection is riding along.
+	draggable?: boolean
 	// Mobile selection mode — forwarded to MailRow.
 	selectionMode?: boolean
 	// Which route the row links to. All Inboxes points at its own thread route so opening a
@@ -208,6 +214,8 @@ const emit = defineEmits([
 	'deleteThread',
 	'setFlagged',
 	'setSelected',
+	'dragStart',
+	'dragEnd',
 ])
 
 const route = useRoute()

--- a/frontend/src/apps/mail/components/MailRow.vue
+++ b/frontend/src/apps/mail/components/MailRow.vue
@@ -11,6 +11,9 @@
 		@touchcancel="clearTouchTimer"
 		@contextmenu="onContextMenu"
 		@click.capture="onRowClick"
+		:draggable="draggable || undefined"
+		@dragstart="onDragStart"
+		@dragend="emit('dragEnd')"
 	>
 		<!-- Selection column: checkbox on desktop, sender avatar on mobile or where the list has no
 		     bulk selection. Long-pressing the row anywhere selects it on touch. -->
@@ -179,9 +182,16 @@ const {
 	selectionMode?: boolean
 	// Which account received the mail (merged lists), shown beside the sender.
 	accountLabel?: string
+	// Whether the row can be dragged onto a folder. Off on touch, where the browser
+	// gives HTML5 drag no events at all and a long press already means selection.
+	draggable?: boolean
 }>()
 
-const emit = defineEmits<{ setSelected: [selected: boolean] }>()
+const emit = defineEmits<{
+	setSelected: [selected: boolean]
+	dragStart: [event: DragEvent]
+	dragEnd: []
+}>()
 
 const user = inject('$user') as UserResource
 const { isMobile } = useScreenSize()
@@ -193,6 +203,18 @@ const showLeading = computed(
 )
 
 const isHovered = ref(false)
+
+/**
+ * A row is a RouterLink, and dragging one of those hands the browser the URL as
+ * text — a link dropped into the composer, or onto the desktop, rather than a
+ * thread moved. Naming the payload ourselves replaces that; the id is set as
+ * plain text so a drop anywhere else is harmless rather than a stray link.
+ */
+const onDragStart = (e: DragEvent) => {
+	e.dataTransfer?.setData('text/plain', '')
+	if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move'
+	emit('dragStart', e)
+}
 
 // In selection mode a row tap toggles membership; capture-phase so the
 // RouterLink navigation never fires. Real buttons inside the row (the trailing

--- a/frontend/src/apps/mail/composables/useThreadDrag.ts
+++ b/frontend/src/apps/mail/composables/useThreadDrag.ts
@@ -1,0 +1,116 @@
+import { computed, h, ref, render } from 'vue'
+import { FolderInput } from 'lucide-vue-next'
+
+/**
+ * Dragging threads onto a folder.
+ *
+ * The two halves of the gesture sit in different trees — the rows are in the
+ * view, the folders in the sidebar beside it — so the dragged threads and the
+ * move that answers a drop are held here rather than passed between them.
+ *
+ * The move itself is `handleMoveThreads` from useThreadActions, which the view
+ * registers on mount: a drop is the same act as picking a folder from the
+ * "Move to" menu, down to the undo snapshot, the Junk diversion and the toast.
+ * Registering it rather than importing it keeps that logic bound to the view
+ * that owns the list — the sidebar never needs to know what a move involves.
+ */
+
+/** Thread ids under the cursor for the length of one drag. */
+const threadIds = ref<string[]>([])
+
+/** The mailbox the cursor is over, so the sidebar can mark the row it would drop into. */
+const overMailbox = ref('')
+
+/**
+ * What the cursor carries. Chrome's default is a snapshot of the row, which has
+ * two faults: the list's scrollbar is an overlay sitting on the row's right edge,
+ * so it gets painted into the picture, and a drag of ten selected threads looks
+ * exactly like a drag of one. A chip naming the count says what is actually
+ * moving, and owes nothing to what the row happened to look like.
+ */
+const setDragChip = (e: DragEvent, count: number) => {
+	if (!e.dataTransfer) return
+
+	const chip = document.createElement('div')
+	// gray-1 on gray-10, the pairing used wherever this app puts ink on a dark
+	// fill. `text-ink-white` is not a token — it generates nothing, and the chip
+	// came out near-black text on a near-black fill. Medium weight because the
+	// browser draws a drag image at reduced opacity, which thins it further.
+	chip.className =
+		'bg-surface-gray-10 text-ink-gray-1 rounded-4 flex items-center gap-1.5 py-1.5 pl-2.5 pr-3 text-sm font-medium shadow-lg'
+
+	// The same icon the "Move to" menu is opened by, at the size that menu draws
+	// it — a drop is that menu's act performed by hand, so it is worth looking
+	// like it. Mounted through Vue rather than hand-written as an svg string so
+	// the icon stays whatever lucide says it is; the app's `svg.lucide` rule
+	// gives it stroke 1.5, and `currentColor` takes the chip's ink.
+	const icon = document.createElement('span')
+	icon.className = 'flex'
+	render(h(FolderInput, { size: 16 }), icon)
+	// lucide also stamps `lucide-folder-input`, which collides with a generated
+	// icon utility of that exact name: 1em square, plus a mask that redraws the
+	// same glyph over the svg. Elsewhere `.icon` pins the size so the collision
+	// goes unseen, but `.icon` also fixes a colour this chip cannot use. Keeping
+	// only `lucide` sizes the icon by its own attributes and drops the redraw.
+	icon.firstElementChild?.setAttribute('class', 'lucide')
+
+	// Names the act, not just the cargo: the chip appears the moment the drag starts,
+	// before any folder is chosen, and "Moving" is what tells you the drop will move
+	// rather than copy. "Thread" is the word the toast that follows uses.
+	const label = document.createElement('span')
+	label.textContent =
+		count === 1 ? __('Moving 1 thread') : __('Moving {0} threads', [String(count)])
+
+	chip.append(icon, label)
+	// Rendered, but out of the way: setDragImage needs a laid-out element, and the
+	// browser takes its picture before the frame this was added in is painted.
+	chip.style.cssText += ';position:fixed;top:-1000px;left:-1000px;white-space:nowrap;'
+	document.body.appendChild(chip)
+
+	e.dataTransfer.setDragImage(chip, 12, 12)
+	// A timer, not requestAnimationFrame: the browser takes the picture during this
+	// event, so the next task is late enough to clean up — and rAF does not run at
+	// all in a background tab, which left a chip in the body for every drag.
+	setTimeout(() => {
+		render(null, icon)
+		chip.remove()
+	})
+}
+
+type MoveHandler = (byMailbox: Record<string, string[]>) => void
+
+let move: MoveHandler | null = null
+
+export const useThreadDrag = () => ({
+	threadIds,
+	overMailbox,
+
+	isDragging: computed(() => threadIds.value.length > 0),
+
+	/** The view lends the sidebar its move; cleared when the view goes away. */
+	setMoveHandler: (handler: MoveHandler | null) => {
+		move = handler
+	},
+
+	start: (ids: string[], e?: DragEvent) => {
+		threadIds.value = ids
+		if (e) setDragChip(e, ids.length)
+	},
+
+	/**
+	 * Ends the drag whether or not it landed. Both `dragend` on the row and
+	 * `drop` on a folder fire, in that order for a successful drop, so this has
+	 * to be safe to call twice.
+	 */
+	end: () => {
+		threadIds.value = []
+		overMailbox.value = ''
+	},
+
+	drop: (mailboxId: string) => {
+		const ids = threadIds.value
+		threadIds.value = []
+		overMailbox.value = ''
+		if (ids.length && move) move({ [mailboxId]: ids })
+	},
+})

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -297,7 +297,7 @@
 										:selection-mode="mobileSelectionMode"
 										:is-selected="selections.includes(row.thread.thread_id)"
 										:hide-sender="row.inStack"
-										:draggable="!isMobile"
+										:draggable="!isMobile && !isAllAccountsSearch"
 										:class="rowClasses(row)"
 										:data-row-key="row.key"
 										@drag-start="(e: DragEvent) => startThreadDrag(row.thread, e)"
@@ -1461,6 +1461,13 @@ onUnmounted(() => threadDrag.setMoveHandler(null))
  * leaves the selection untouched — the same reading every file manager gives
  * the gesture, and the alternative (always the selection) silently moves mail
  * the reader never pointed at.
+ *
+ * Rows are undraggable in an all-accounts search, alongside `selectable`, and
+ * for the same reason: the move below runs against the active account, while
+ * those rows can belong to any. There is no cross-account handler to route to
+ * either — the ones above work by reading a role off the row's own account
+ * (`mail.archive`, `mail.trash`), and the folder being dropped on is one of
+ * *this* account's, which another account has no counterpart for.
  */
 const startThreadDrag = (thread: Thread, e: DragEvent) => {
 	const id = thread.thread_id

--- a/frontend/src/apps/mail/pages/MailboxView.vue
+++ b/frontend/src/apps/mail/pages/MailboxView.vue
@@ -297,8 +297,11 @@
 										:selection-mode="mobileSelectionMode"
 										:is-selected="selections.includes(row.thread.thread_id)"
 										:hide-sender="row.inStack"
+										:draggable="!isMobile"
 										:class="rowClasses(row)"
 										:data-row-key="row.key"
+										@drag-start="(e: DragEvent) => startThreadDrag(row.thread, e)"
+										@drag-end="threadDrag.end()"
 										@set-seen="(seen: boolean) => rowSetSeen(row.thread, seen)"
 										@archive-thread="rowArchive(row.thread)"
 										@trash-thread="rowTrash(row.thread)"
@@ -510,6 +513,7 @@ import {
 	useSwipeNav,
 	useUndo,
 } from '@/apps/mail/utils/composables'
+import { useThreadDrag } from '@/apps/mail/composables/useThreadDrag'
 import { useStoredFilter } from '@/apps/mail/utils/listFilter'
 import { useListRows } from '@/apps/mail/composables/useListRows'
 import {
@@ -1441,6 +1445,27 @@ const {
 	goToMailbox,
 	goToNextThreadOrMailbox,
 })
+
+// ── Dragging threads onto a folder ────────────────────────────────────────────────────────────────
+// A drop is the same act as picking a folder from the "Move to" menu, so it runs the same handler —
+// undo snapshot, Junk diversion and toast included. The sidebar owns the drop; it borrows the move
+// from here, since only the view knows how to perform one.
+const threadDrag = useThreadDrag()
+
+onMounted(() => threadDrag.setMoveHandler(handleMoveThreads))
+onUnmounted(() => threadDrag.setMoveHandler(null))
+
+/**
+ * What the drag carries. Dragging a row that is part of the selection takes the
+ * whole selection with it; dragging one outside it takes that row alone and
+ * leaves the selection untouched — the same reading every file manager gives
+ * the gesture, and the alternative (always the selection) silently moves mail
+ * the reader never pointed at.
+ */
+const startThreadDrag = (thread: Thread, e: DragEvent) => {
+	const id = thread.thread_id
+	threadDrag.start(selections.value.includes(id) ? [...selections.value] : [id], e)
+}
 
 // ── Cross-account search row actions ──────────────────────────────────────────────────────────────
 // In an all-accounts search the merged rows can belong to any account, so the shared handlers above

--- a/frontend/src/apps/mail/utils/index.ts
+++ b/frontend/src/apps/mail/utils/index.ts
@@ -426,6 +426,21 @@ export const getIcon = (mailbox: MailboxData) => {
 	return 'folder'
 }
 
+/**
+ * Whether a mailbox can be moved into. The "Move to" menu and the folders that
+ * take a dragged thread are the same question asked twice, so they ask it here:
+ * a thread cannot be moved to where it already is, and Sent, Drafts and the
+ * Screener hold mail that is defined by how it got there rather than by a folder
+ * anyone files into.
+ */
+export const canMoveToMailbox = (
+	mailboxId: string | undefined,
+	current: string | undefined,
+	mailboxIds: { sent?: string; drafts?: string; screener?: string },
+): boolean =>
+	!!mailboxId &&
+	![current, mailboxIds.sent, mailboxIds.drafts, mailboxIds.screener].includes(mailboxId)
+
 // The Screening folder is surfaced to users as the "Screener".
 export const getMailboxName = (mailbox: MailboxData) =>
 	mailbox._name === SCREENER_MAILBOX_NAME ? __('Screener') : mailbox._name

--- a/frontend/src/apps/mail/utils/useThreadActions.ts
+++ b/frontend/src/apps/mail/utils/useThreadActions.ts
@@ -3,7 +3,13 @@ import { Icon } from 'frappe-ui/experimental'
 import { createResource } from 'frappe-ui'
 
 import { FOLDER_ICON_COLOR_MAP } from '@/apps/mail/constants'
-import { getIcon, raiseOptimisticToast, raisePromiseToast, raiseToast } from '@/apps/mail/utils'
+import {
+	canMoveToMailbox,
+	getIcon,
+	raiseOptimisticToast,
+	raisePromiseToast,
+	raiseToast,
+} from '@/apps/mail/utils'
 import { useBlockSender, useUndo } from '@/apps/mail/utils/composables'
 import { mailCopies, mailCopyIds, mailCopyNames, rowMailIds } from '@/apps/mail/utils/mailCopies'
 import { closeComposeWindowFor } from '@/apps/mail/composables/useComposeWindow'
@@ -163,15 +169,7 @@ export function useThreadActions(deps: {
 
 	const moveToOptions = computed(() =>
 		mailboxes.data
-			?.filter(
-				(m) =>
-					![
-						mailbox.value,
-						mailboxIds.sent,
-						mailboxIds.drafts,
-						mailboxIds.screener,
-					].includes(m.id),
-			)
+			?.filter((m) => canMoveToMailbox(m.id, mailbox.value, mailboxIds))
 			.map((m) => ({
 				label: m._name,
 				icon: h(Icon, { name: getIcon(m), class: FOLDER_ICON_COLOR_MAP[m.color] }),


### PR DESCRIPTION
Move mail into folders by dragging, instead of going through the "Move to" menu each time.

Drag a row onto a sidebar folder and it moves there. It calls the same handler the menu calls, so undo, the Junk diversion and the toast behave exactly as before.

- The folders that accept a drop are exactly the ones the "Move to" menu lists — both read one predicate now, so they can't drift apart. Not the current folder, not Sent, Drafts or Screener.
- Dragging a row that's part of the selection takes the whole selection; dragging one outside it takes just that row.
- The cursor carries a chip naming the count ("Moving 3 threads"). Chrome's default drag image is a snapshot of the row, which catches the list's overlay scrollbar and looks the same for one thread or ten.
- The folder under the cursor gets a grey inset ring.
- Disabled on touch — the browser fires no drag events there, and a long press already means selection.

261 mail tests pass.