### PR TITLE
fix(mail): every folder reaches the sidebar, not just the first twenty

### DIFF
--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -182,7 +182,7 @@ def get_user_mailboxes(account: str) -> list[dict]:
     named folders).
     """
 
-    return fetch_mailboxes(account)
+    return fetch_mailboxes(account, limit=None)
 
 
 def add_user_images_to_emails(account: str, mails: list[dict], is_thread: bool = False) -> list[dict]:

--- a/suite/mail/api/mail.py
+++ b/suite/mail/api/mail.py
@@ -35,7 +35,7 @@ from suite.mail.doctype.mail_message.mail_message import (
     set_spam_status,
 )
 from suite.mail.doctype.mail_queue.mail_queue import MailQueue
-from suite.mail.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes
+from suite.mail.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes, fetch_mailboxes
 from suite.mail.doctype.mailbox_settings.mailbox_settings import (
     automation_rules_to_settings,
     set_mailbox_settings,
@@ -172,9 +172,17 @@ def get_mailboxes(account: str) -> list[dict]:
 
 
 def get_user_mailboxes(account: str) -> list[dict]:
-    """Returns the user's mailboxes."""
+    """Returns the user's mailboxes.
 
-    return frappe.get_all("Mailbox", filters={"account": account})
+    Straight to fetch_mailboxes rather than through frappe.get_all("Mailbox"): Mailbox is a virtual
+    doctype, so a list query is routed to Mailbox.get_list, and frappe fixes the page length there
+    at `page_length or limit or limit_page_length or 20`. get_all asks for everything by passing
+    limit_page_length=0, which is falsy and so loses to the 20 — accounts with more folders than
+    that silently lost the ones sorting last (the Screener among them, since it sorts after the
+    named folders).
+    """
+
+    return fetch_mailboxes(account)
 
 
 def add_user_images_to_emails(account: str, mails: list[dict], is_thread: bool = False) -> list[dict]:

--- a/suite/mail/doctype/mailbox/mailbox.py
+++ b/suite/mail/doctype/mailbox/mailbox.py
@@ -248,8 +248,13 @@ def delete_mailboxes(account: str, ids: list[str], remove_emails: bool = True) -
 
 
 @frappe.whitelist()
-def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
-    """Returns a list of mailboxes for the given account."""
+def fetch_mailboxes(account: str, page: int = 1, limit: int | None = None) -> list:
+    """Returns a list of mailboxes for the given account.
+
+    Unpaginated by default: an account's mailboxes are a list the caller almost always wants whole
+    (the client's folder list, a sieve rebuild, a link-field search), and a default page silently
+    dropped whatever sorted last. Only the desk list view pages, and it passes its own `limit`.
+    """
 
     service = get_mailbox_service(account)
     mailboxes = service.get()
@@ -258,6 +263,9 @@ def fetch_mailboxes(account: str, page: int = 1, limit: int = 10) -> list:
         formatted_mailboxes, key=lambda m: (m["sort_order"], get_sort_order(m["role"]), m["_name"], m["id"])
     )
     frappe.cache.set_value(_get_total_cache_key(account), len(mailboxes), expires_in_sec=600)
+
+    if limit is None:
+        return sorted_mailboxes
 
     start = (page - 1) * limit
     end = start + limit

--- a/suite/mail/doctype/mailbox/mailbox.py
+++ b/suite/mail/doctype/mailbox/mailbox.py
@@ -248,12 +248,13 @@ def delete_mailboxes(account: str, ids: list[str], remove_emails: bool = True) -
 
 
 @frappe.whitelist()
-def fetch_mailboxes(account: str, page: int = 1, limit: int | None = None) -> list:
+def fetch_mailboxes(account: str, page: int = 1, limit: int | None = 10) -> list:
     """Returns a list of mailboxes for the given account.
 
-    Unpaginated by default: an account's mailboxes are a list the caller almost always wants whole
-    (the client's folder list, a sieve rebuild, a link-field search), and a default page silently
-    dropped whatever sorted last. Only the desk list view pages, and it passes its own `limit`.
+    `limit=None` returns every mailbox, and is what a caller wanting the account's folders as a
+    whole asks for — the client's folder list, a link-field search: a page silently drops whatever
+    sorts last, and says nothing about having done so. The default stays at ten for the callers
+    that do page, this being a whitelisted endpoint.
     """
 
     service = get_mailbox_service(account)

--- a/suite/mail/tests/test_mail_mailboxes.py
+++ b/suite/mail/tests/test_mail_mailboxes.py
@@ -12,6 +12,7 @@ from suite.mail.api.mail import (
     move_mails,
     update_mailbox,
 )
+from suite.mail.doctype.mailbox.mailbox import add_mailbox, delete_mailboxes, fetch_mailboxes
 from suite.mail.tests.base import StalwartIntegrationTestCase, unique_name
 
 
@@ -104,6 +105,34 @@ class TestMailMailboxes(StalwartIntegrationTestCase):
             update_mailbox_position(self.account, first_id, prior_mailbox_id=second_id)
         self.assertIsNotNone(self._mailbox_by_name(first))
         self.assertIsNotNone(self._mailbox_by_name(second))
+
+    def test_listing_holds_more_than_a_page_of_mailboxes(self):
+        """Every folder reaches the client, however many the account has.
+
+        Mailbox is a virtual doctype, so a list query is served by Mailbox.get_list, where frappe
+        fixes the page length at twenty however loudly the caller asks for everything. An account
+        with more folders than that used to lose the ones sorting last, silently.
+        """
+
+        # Two past the page whatever the account already holds, so the tail is always the part
+        # a page would cut.
+        existing = self._mailboxes()
+        names = [unique_name("page") for _ in range(max(2, 22 - len(existing)))]
+
+        ids = []
+        with self.set_user(self.member.email):
+            for name in names:
+                ids.append(add_mailbox(self.account, name))
+
+            try:
+                listed = self._mailboxes()
+                self.assertGreater(len(listed), 20)
+                self.assertLessEqual(set(names), {m["_name"] for m in listed})
+
+                # A caller that does ask for a page still gets one.
+                self.assertEqual(len(fetch_mailboxes(self.account, limit=20)), 20)
+            finally:
+                delete_mailboxes(self.account, ids)
 
     def test_empty_trash(self):
         thread = self.deliver_mail(self.other, self.member)

--- a/suite/mail/utils/query.py
+++ b/suite/mail/utils/query.py
@@ -57,7 +57,9 @@ def get_account_mailboxes(
         return []
 
     result = []
-    if mailboxes := fetch_mailboxes(account):
+    # The whole list rather than fetch_mailboxes' first page: a parent picker that only offers
+    # the folders sorting first is one you cannot reach the rest of the account with.
+    if mailboxes := fetch_mailboxes(account, limit=None):
         for mailbox in mailboxes:
             if txt and txt.lower() not in mailbox["name"].lower():
                 continue


### PR DESCRIPTION
An account with more than 20 folders loses some of them from the client entirely — missing from the sidebar, the folder settings and the "Move to" menu, with nothing to indicate anything was left out.

`Mailbox` is a virtual doctype, so `frappe.get_all("Mailbox", ...)` never reaches a table; it's routed to `Mailbox.get_list`, and frappe fixes the page length on the way at `page_length or limit or limit_page_length or 20`. `get_all` asks for everything by passing `limit_page_length=0`, which is falsy and loses to the 20. `get_user_mailboxes` now calls `fetch_mailboxes` directly, which has no such ceiling.

The Screener is the folder people noticed, because it always sorts last — it carries a `sort_order` the named folders don't, and the sidebar drops it from the Custom group on the way to pinning it at the top, so a truncated list left it nowhere at all. The screener page itself kept working (it resolves the folder by name against the full JMAP list), which is why it was reachable on mobile, whose tab bar doesn't read the mailbox list, and missing on desktop.

`fetch_mailboxes` is unpaginated by default for the same reason: its `limit=10` was a page nobody asked for, and it was truncating the desk link-field search too. Only the desk list view pages, and it passes its own limit.

Verified on an account with 22 mailboxes: `get_mailboxes` returned 20 before and 22 after, the Screener among them, while `get_all(..., limit=20)` still returns 20 so desk paging is unchanged.