### PR TITLE
fix(meet): stabilize startup and reconnects

### DIFF
--- a/e2e/meet/fixtures/media.ts
+++ b/e2e/meet/fixtures/media.ts
@@ -46,17 +46,6 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 	const peerConnections = [];
 	const pendingReceiverFaults = [];
 	const lifecycle = { hidden: document.hidden, online: navigator.onLine };
-	Object.defineProperties(document, {
-		hidden: { configurable: true, get: () => lifecycle.hidden },
-		visibilityState: {
-			configurable: true,
-			get: () => (lifecycle.hidden ? "hidden" : "visible"),
-		},
-	});
-	Object.defineProperty(navigator, "onLine", {
-		configurable: true,
-		get: () => lifecycle.online,
-	});
 	const injectReceiverStats = (receiver, fault) => {
 		const originalGetStats = receiver.getStats.bind(receiver);
 		receiver.getStats = async () => {
@@ -122,9 +111,22 @@ export const MEDIA_FAULT_SCRIPT = `(() => {
 			pendingReceiverFaults.push(fault);
 		},
 		setBrowserLifecycle(next) {
-			const hiddenChanged = lifecycle.hidden !== next.hidden;
-			const onlineChanged = lifecycle.online !== next.online;
+			const hiddenChanged = document.hidden !== next.hidden;
+			const onlineChanged = navigator.onLine !== next.online;
+			lifecycle.online = navigator.onLine;
 			lifecycle.hidden = next.hidden;
+			// Ordinary UI tests must keep the browser's real network/visibility state.
+			Object.defineProperties(document, {
+				hidden: { configurable: true, get: () => lifecycle.hidden },
+				visibilityState: {
+					configurable: true,
+					get: () => (lifecycle.hidden ? "hidden" : "visible"),
+				},
+			});
+			Object.defineProperty(navigator, "onLine", {
+				configurable: true,
+				get: () => lifecycle.online,
+			});
 			if (hiddenChanged) document.dispatchEvent(new Event("visibilitychange"));
 			lifecycle.online = next.online;
 			if (onlineChanged) window.dispatchEvent(new Event(next.online ? "online" : "offline"));

--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -82,7 +82,7 @@ async function prepareContext(context: BrowserContext): Promise<void> {
 				const body = await response.json();
 				// Preserve Frappe-issued JWTs and claims; redirect only endpoint metadata.
 				if (body.data && "sfu_url" in body.data) {
-					body.data.sfu_url = `${endpoint.protocol}//${endpoint.hostname}`;
+					body.data.sfu_url = endpoint.origin;
 					body.data.sfu_port = Number(
 						endpoint.port || (endpoint.protocol === "https:" ? 443 : 80),
 					);

--- a/e2e/meet/fixtures/test.ts
+++ b/e2e/meet/fixtures/test.ts
@@ -53,6 +53,44 @@ interface TestFixtures {
 }
 
 async function prepareContext(context: BrowserContext): Promise<void> {
+	if (process.env.MEET_TEST_SFU_URL) {
+		const endpoint = new URL(process.env.MEET_TEST_SFU_URL);
+		if (
+			!["http:", "https:"].includes(endpoint.protocol) ||
+			!["127.0.0.1", "[::1]"].includes(endpoint.hostname) ||
+			endpoint.username ||
+			endpoint.password ||
+			endpoint.pathname !== "/" ||
+			endpoint.search ||
+			endpoint.hash
+		) {
+			throw new Error("MEET_TEST_SFU_URL must be a loopback HTTP(S) origin");
+		}
+		await context.route(
+			(url) =>
+				url.origin === new URL(baseURL).origin &&
+				/^\/api\/v2\/method\/suite\.meet\.api\.meeting\.(join_meeting|join_meeting_as_guest|refresh_sfu_token|refresh_guest_sfu_token|get_sfu_presence_preview_token|get_sfu_connection_details|get_approved_guest_connection_details)$/.test(url.pathname),
+			async (route) => {
+				const response = await route.fetch();
+				if (
+					!response.ok() ||
+					!response.headers()["content-type"]?.includes("application/json")
+				) {
+					await route.fulfill({ response });
+					return;
+				}
+				const body = await response.json();
+				// Preserve Frappe-issued JWTs and claims; redirect only endpoint metadata.
+				if (body.data && "sfu_url" in body.data) {
+					body.data.sfu_url = `${endpoint.protocol}//${endpoint.hostname}`;
+					body.data.sfu_port = Number(
+						endpoint.port || (endpoint.protocol === "https:" ? 443 : 80),
+					);
+				}
+				await route.fulfill({ response, json: body });
+			},
+		);
+	}
 	await context.addInitScript({
 		content: `${STUB_MEDIA_SCRIPT}\n${MEDIA_FAULT_SCRIPT}`,
 	});
@@ -189,6 +227,7 @@ export const test = base.extend<TestFixtures>({
 		const page = await context.newPage();
 		await gotoAppPage(page, "/meet/");
 		await use(page);
+		await context.unrouteAll({ behavior: "ignoreErrors" });
 		await context.close();
 	},
 
@@ -222,7 +261,10 @@ export const test = base.extend<TestFixtures>({
 		});
 
 		await Promise.all(
-			participants.map((participant) => participant.context.close()),
+			participants.map(async ({ context }) => {
+				await context.unrouteAll({ behavior: "ignoreErrors" });
+				await context.close();
+			}),
 		);
 	},
 });

--- a/e2e/meet/helpers/media.ts
+++ b/e2e/meet/helpers/media.ts
@@ -15,15 +15,13 @@ export async function expectRemoteVideoReceiving(
 export async function expectVideoReceiving(video: Locator): Promise<void> {
 	await expect(video).toBeVisible({ timeout: 45_000 });
 
-	await video.evaluate(async (element) => {
+	await video.evaluate((element) => {
 		const videoEl = element as HTMLVideoElement;
 		videoEl.muted = true;
 		if (videoEl.paused) {
-			try {
-				await videoEl.play();
-			} catch {
+			void videoEl.play().catch(() => {
 				// Poll below is the real assertion.
-			}
+			});
 		}
 	});
 

--- a/e2e/meet/specs/media-fault-recovery.spec.ts
+++ b/e2e/meet/specs/media-fault-recovery.spec.ts
@@ -129,7 +129,7 @@ test.describe("Media fault recovery", () => {
 	);
 
 	test(
-		"defers media repair while hidden and offline, then recovers on resume",
+		"defers media repair while hidden, then recovers only the stalled consumer",
 		{ tag: "@meet-group-2" },
 		async ({ hostPage, createMeeting, createParticipant }) => {
 			test.setTimeout(120_000);
@@ -158,7 +158,8 @@ test.describe("Media fault recovery", () => {
 				"Healthy Control",
 			);
 
-			await setBrowserLifecycle(hostPage, { hidden: true, online: false });
+			// Offline signaling requires a full rejoin; sfu-reconnect.spec.ts covers it.
+			await setBrowserLifecycle(hostPage, { hidden: true, online: true });
 			await injectRemoteVideoFault(hostPage, "Fault Target", "decode-stall");
 			await hostPage.waitForTimeout(7000);
 			expect(

--- a/e2e/meet/specs/multi-participant.spec.ts
+++ b/e2e/meet/specs/multi-participant.spec.ts
@@ -2,7 +2,61 @@ import { test, expect, joinFromPreview, appUrl } from "../fixtures/test";
 import { meetHostName } from "../helpers/auth";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
+declare global {
+	interface Window {
+		__meetCaptureGate?: { waiting: boolean; release: (allow: boolean) => void };
+	}
+}
+
 test.describe("Multi participant", () => {
+	for (const allowCapture of [true, false]) {
+		test(`waits for initial capture before guest join (${allowCapture ? "allowed" : "denied"})`, async ({
+			hostPage, createMeeting, createParticipant,
+		}) => {
+			const meetingId = await createMeeting();
+			const control = await createParticipant();
+			await Promise.all([
+				(async () => {
+					await hostPage.goto(appUrl(`/meet/${meetingId}`));
+					await joinFromPreview(hostPage);
+				})(),
+				control.joinAsGuest(meetingId, "Capture Control"),
+			]);
+			const delayed = await createParticipant();
+			await delayed.context.addInitScript(() => {
+				const original = navigator.mediaDevices.getUserMedia.bind(navigator.mediaDevices);
+				let release!: (allow: boolean) => void;
+				const gate = new Promise<boolean>((resolve) => { release = resolve; });
+				window.__meetCaptureGate = { waiting: false, release };
+				navigator.mediaDevices.getUserMedia = async (constraints) => {
+					window.__meetCaptureGate!.waiting = true;
+					if (!(await gate)) throw new DOMException("Test capture denied", "NotAllowedError");
+					return original(constraints);
+				};
+			});
+			await delayed.page.goto(appUrl(`/meet/${meetingId}`));
+			await delayed.page.getByPlaceholder("John Doe").fill("Delayed Capture");
+			await delayed.page.waitForFunction(() => window.__meetCaptureGate?.waiting === true);
+			try {
+				await expect(delayed.page.getByRole("button", { name: /Join Meeting$/ })).toBeDisabled();
+			} finally {
+				await delayed.page.evaluate((allow) => window.__meetCaptureGate!.release(allow), allowCapture);
+			}
+			await joinFromPreview(delayed.page);
+			await expect(delayed.page.getByTestId("meeting-layout")).toBeVisible();
+			await expect(hostPage.locator("[data-participant-id]")).toHaveCount(3);
+			await expectRemoteVideoReceiving(delayed.page, meetHostName);
+			await expectRemoteVideoReceiving(delayed.page, "Capture Control");
+			if (allowCapture) {
+				await expectRemoteVideoReceiving(hostPage, "Delayed Capture");
+			} else {
+				const tile = hostPage.locator("[data-testid^='participant-tile-']", { hasText: "Delayed Capture" });
+				await expect(tile).toHaveAttribute("data-video-enabled", "false");
+				await expect(tile).toHaveAttribute("data-audio-enabled", "false");
+			}
+		});
+	}
+
 	test("host and two guests see the same meeting", async ({
 		hostPage,
 		createMeeting,

--- a/e2e/meet/specs/multi-participant.spec.ts
+++ b/e2e/meet/specs/multi-participant.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, joinFromPreview, appUrl } from "../fixtures/test";
-import { meetHostName } from "../helpers/auth";
+import { meetHost, meetHostName } from "../helpers/auth";
+import { loginViaApi } from "../../shared/auth";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
 declare global {
@@ -9,6 +10,46 @@ declare global {
 }
 
 test.describe("Multi participant", () => {
+	test("guest can join after a transient preview access-check failure", async ({
+		createMeeting, createParticipant,
+	}) => {
+		const meetingId = await createMeeting();
+		const guest = await createParticipant();
+		let accessChecks = 0;
+		await guest.page.route("**/api/v2/method/suite.meet.api.meeting.check_meeting_access**", (route) => {
+			accessChecks++;
+			return route.fulfill({ status: 503, contentType: "application/json", body: "{}" });
+		});
+		await guest.joinAsGuest(meetingId, "Access Retry");
+		expect(accessChecks).toBeGreaterThan(0);
+		await expect(guest.page.getByTestId("meeting-layout")).toBeVisible();
+	});
+
+	test("loopback SFU override preserves a non-default HTTPS port", async ({
+		createMeeting, createParticipant,
+	}) => {
+		const meetingId = await createMeeting();
+		const previousEndpoint = process.env.MEET_TEST_SFU_URL;
+		let guest;
+		try {
+			process.env.MEET_TEST_SFU_URL = "https://127.0.0.1:4444";
+			guest = await createParticipant();
+		} finally {
+			if (previousEndpoint === undefined) delete process.env.MEET_TEST_SFU_URL;
+			else process.env.MEET_TEST_SFU_URL = previousEndpoint;
+		}
+		await loginViaApi(guest.context.request, meetHost);
+		await guest.page.goto(appUrl("/meet/"));
+		const response = await guest.page.evaluate(async (id) => {
+			const result = await fetch(`/api/v2/method/suite.meet.api.meeting.get_sfu_presence_preview_token?meeting_id=${encodeURIComponent(id)}`);
+			return { status: result.status, body: await result.json() };
+		}, meetingId);
+		expect(response.status).toBe(200);
+		expect(response.body.data.sfu_url).toBe("https://127.0.0.1:4444");
+		expect(response.body.data.sfu_port).toBe(4444);
+		expect(response.body.data.auth_token).toEqual(expect.any(String));
+	});
+
 	for (const allowCapture of [true, false]) {
 		test(`waits for initial capture before guest join (${allowCapture ? "allowed" : "denied"})`, async ({
 			hostPage, createMeeting, createParticipant,

--- a/e2e/meet/specs/sfu-reconnect.spec.ts
+++ b/e2e/meet/specs/sfu-reconnect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, joinHostAndGuest, test } from "../fixtures/test";
+import { appUrl, expect, joinHostAndGuest, test } from "../fixtures/test";
 import { meetHostName } from "../helpers/auth";
 import { expectRemoteVideoReceiving } from "../helpers/media";
 
@@ -8,6 +8,19 @@ const disconnectWaitMs = Number.parseInt(
 	process.env.SFU_E2E_DISCONNECT_WAIT_MS || "7000",
 	10,
 );
+
+test("media fault fixture follows native network availability", async ({ createParticipant }) => {
+	const participant = await createParticipant();
+	await participant.page.goto(appUrl("/meet/"));
+	await expect.poll(() => participant.page.evaluate(() => navigator.onLine)).toBe(true);
+	try {
+		await participant.context.setOffline(true);
+		await expect.poll(() => participant.page.evaluate(() => navigator.onLine)).toBe(false);
+	} finally {
+		await participant.context.setOffline(false);
+	}
+	await expect.poll(() => participant.page.evaluate(() => navigator.onLine)).toBe(true);
+});
 
 test.describe("SFU reconnect", () => {
 	test.skip(
@@ -20,6 +33,7 @@ test.describe("SFU reconnect", () => {
 		createMeeting,
 		createParticipant,
 	}) => {
+		test.setTimeout(120_000);
 		const meetingId = await createMeeting();
 		const guestName = "Guest Server Disconnect";
 		const guest = await createParticipant();

--- a/frontend/src/apps/meet/composables/__tests__/useTileAdaptiveStreaming.test.ts
+++ b/frontend/src/apps/meet/composables/__tests__/useTileAdaptiveStreaming.test.ts
@@ -16,9 +16,29 @@ class IntersectionObserverStub {
 	static instances: IntersectionObserverStub[] = [];
 	disconnect = vi.fn();
 	observe = vi.fn();
+	private previousRatio: number | null = null;
 
-	constructor(readonly callback: IntersectionObserverCallback) {
+	constructor(
+		readonly callback: IntersectionObserverCallback,
+		readonly options: IntersectionObserverInit = {},
+	) {
 		IntersectionObserverStub.instances.push(this);
+	}
+
+	setIntersection(ratio: number) {
+		const thresholds = [this.options.threshold ?? 0].flat();
+		const previous = this.previousRatio;
+		this.previousRatio = ratio;
+		if (
+			previous === null ||
+			(previous > 0) !== (ratio > 0) ||
+			thresholds.some((threshold) => (previous >= threshold) !== (ratio >= threshold))
+		) {
+			this.callback(
+				[{ isIntersecting: ratio > 0, intersectionRatio: ratio } as IntersectionObserverEntry],
+				this as unknown as IntersectionObserver,
+			);
+		}
 	}
 }
 
@@ -129,5 +149,34 @@ describe("useTileAdaptiveStreaming", () => {
 		expect(
 			IntersectionObserverStub.instances[0]?.disconnect,
 		).toHaveBeenCalledOnce();
+	});
+
+	it("resumes a tile that animates into view through less than ten percent visibility", async () => {
+		vi.useFakeTimers();
+		vi.stubGlobal("requestAnimationFrame", vi.fn());
+		const manager = createManager("consumer-1");
+		const { app, registerTile } = mountComposable(ref(manager));
+		try {
+			const element = visibleVideoElement();
+			Object.defineProperty(element, "readyState", { value: 0 });
+			registerTile("participant-1", element);
+			const observer = IntersectionObserverStub.instances[0]!;
+			observer.setIntersection(0);
+			await Promise.resolve();
+			expect(manager.updateConsumerStreamPreferences).toHaveBeenLastCalledWith(
+				"consumer-1", { visible: false, width: 0, height: 0 },
+			);
+
+			// Position-only animation: no resize or media metadata event can rescue it.
+			observer.setIntersection(0.05);
+			observer.setIntersection(1);
+			await vi.advanceTimersByTimeAsync(300);
+			expect(manager.updateConsumerStreamPreferences).toHaveBeenLastCalledWith(
+				"consumer-1", { visible: true, width: 640, height: 360 },
+			);
+		} finally {
+			app.unmount();
+			vi.useRealTimers();
+		}
 	});
 });

--- a/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
+++ b/frontend/src/apps/meet/composables/useTileAdaptiveStreaming.ts
@@ -211,7 +211,7 @@ export function useTileAdaptiveStreaming() {
 			} else if (isVisible) {
 				scheduleRefresh(controller);
 			}
-		});
+		}, { threshold: VISIBILITY_THRESHOLD });
 		controller.intersectionObserver.observe(element);
 
 		const onLoadedMetadata = () => {

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -85,7 +85,7 @@
 				:isMicOn="mediaState.isMicOn"
 				:cameraPermissionGranted="mediaState.cameraPermissionGranted"
 				:microphonePermissionGranted="mediaState.microphonePermissionGranted"
-				:isConnecting="sfuConnection.isConnecting.value"
+				:isConnecting="isInitializingPreview || sfuConnection.isConnecting.value"
 				:userInitials="currentUser.userInitials.value"
 				:userAvatar="currentUser.userAvatar.value"
 				:currentUserName="
@@ -918,6 +918,7 @@ const isHandRaised = computed(() => {
 });
 
 // --- Refs ---
+const isInitializingPreview = ref(true);
 const isReactionPickerOpen = ref(false);
 const isFullscreen = ref(false);
 const isToolbarVisible = ref(true);
@@ -1139,7 +1140,7 @@ onMounted(async () => {
 		if (selectedSpeakerId.value) {
 			await mediaControls.applySpeakerDevice();
 		}
-		connectionState.isInPreview = true;
+		isInitializingPreview.value = false;
 		return;
 	}
 
@@ -1157,6 +1158,8 @@ onMounted(async () => {
 	if (selectedSpeakerId.value) {
 		await mediaControls.applySpeakerDevice();
 	}
+
+	isInitializingPreview.value = false;
 
 	// Auto-join if just created
 	if (wasJustCreated) {

--- a/frontend/src/apps/meet/pages/Meeting.vue
+++ b/frontend/src/apps/meet/pages/Meeting.vue
@@ -1123,6 +1123,7 @@ onMounted(async () => {
 			}
 		} catch (error) {
 			console.error("Failed to check meeting access:", error);
+			isInitializingPreview.value = false;
 			return;
 		}
 	}

--- a/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
+++ b/frontend/src/apps/meet/utils/sfu/ParticipantConnection.ts
@@ -873,6 +873,7 @@ export class ParticipantConnection {
 			this.meetingId,
 			this.lastJoinUserData,
 			this.getCurrentRejoinMediaState(),
+			{ connectionId: this.connectionId },
 		);
 		this.throwIfAborted(signal);
 		if (!(await this.waitForE2EEContextIfRequired(signal))) {

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnection.test.ts
@@ -329,6 +329,54 @@ describe("ParticipantConnection lifecycle", () => {
 		expect(connection.state).toBe("ready");
 	});
 
+	it.each([false, true])("keeps the initial connection ID across retained-slot rebuild retries (expired initial slot: %s)", async (expiredInitialSlot) => {
+		vi.useFakeTimers();
+		vi.spyOn(Math, "random").mockReturnValue(0.5);
+		const { connection, sfuClient, transportManager } = createConnection();
+		let socket = 0;
+		let owner: string | undefined;
+		let retainedUntil = Infinity;
+		const conflicts: string[] = [];
+		sfuClient.connect.mockImplementation(async () => { socket += 1; });
+		sfuClient.disconnect.mockImplementation(async () => {
+			retainedUntil = Date.now() + 30_000;
+		});
+		// Independent server claim model: socket fallback, retained owner, no automatic takeover.
+		sfuClient.joinRoom.mockImplementation(async (_room, _user, _media, options?: { connectionId?: string; conflictId?: string }) => {
+			const claimant = options?.connectionId ?? `socket-${socket}`;
+			if (Date.now() >= retainedUntil) owner = undefined;
+			if (owner && owner !== claimant) {
+				conflicts.push(claimant);
+				throw new Error("PARTICIPANT_CONNECTION_CONFLICT");
+			}
+			owner = claimant;
+			retainedUntil = Infinity;
+		});
+		await connection.start(startOptions({ conflictId: "confirmed-initial-takeover" }));
+		const initialId = owner;
+		expect(initialId).toEqual(expect.any(String));
+		if (expiredInitialSlot) {
+			await sfuClient.disconnect();
+			await vi.advanceTimersByTimeAsync(35_000);
+			owner = undefined;
+		}
+		// A join can claim the slot before later media setup fails and forces another socket.
+		transportManager.initializeDevice
+			.mockRejectedValueOnce(new Error("device setup interrupted"))
+			.mockRejectedValueOnce(new Error("device setup interrupted again"));
+		const recovery = connection.rejoinAfterSignalingReconnect();
+		await vi.advanceTimersByTimeAsync(3000);
+		await recovery;
+
+		expect(conflicts).toEqual([]);
+		expect(connection.state).toBe("ready");
+		expect(sfuClient.joinRoom).toHaveBeenCalledTimes(4);
+		for (const call of sfuClient.joinRoom.mock.calls.slice(1)) {
+			expect(call[3]).toEqual({ connectionId: initialId });
+		}
+		expect(owner).toBe(initialId);
+	});
+
 	it("cancels full rebuild backoff during cleanup", async () => {
 		vi.useFakeTimers();
 		const { connection, sfuClient } = createConnection();

--- a/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
+++ b/frontend/src/apps/meet/utils/sfu/__tests__/ParticipantConnectionEvents.test.ts
@@ -557,6 +557,7 @@ describe("ParticipantConnection", () => {
 			"meeting-1",
 			{ name: "Me", userId: "me" },
 			{ audio_enabled: true, video_enabled: true },
+			sfuClient.joinRoom.mock.calls[0][3],
 		);
 		expect(transportManager.closeReceiveTransport).toHaveBeenCalledTimes(1);
 		expect(recoveryManager.reset).toHaveBeenCalledTimes(1);
@@ -609,6 +610,7 @@ describe("ParticipantConnection", () => {
 			"meeting-1",
 			expect.anything(),
 			{ audio_enabled: true, video_enabled: false },
+			sfuClient.joinRoom.mock.calls[0][3],
 		);
 	});
 


### PR DESCRIPTION
## Summary
- Wait for initial camera and microphone setup before enabling Join, while allowing receive-only joining after permission denial and unblocking Join when the guest preview access check fails.
- Preserve participant connection identity across reconnect retries without replaying takeover authorization.
- Align tile visibility observation with its visibility threshold so animated tiles resume remote video.
- Correct media lifecycle and playback fixtures and allow isolated loopback SFU endpoints, preserving non-default HTTPS ports.

Keeps the change focused on startup and reconnect behavior; excludes the larger scalability stack and SFU runtime changes.