### PR TITLE
fix(meet): serialize concurrent room creation

### DIFF
--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -47,6 +47,7 @@ export interface ProducerClosedLifecycle extends ProducerCloseMetadata {
 
 export class MediasoupManager {
 	private readonly closingRooms = new Set<string>();
+	private creatingRooms = new Map<string, Promise<Room>>();
 	private workerManager = new WorkerManager();
 	private roomManager = new RoomManager();
 	private peerManager = new PeerManager();
@@ -275,8 +276,13 @@ export class MediasoupManager {
 		roomId: string,
 		onActiveSpeaker?: (roomId: string, participantIds: string[]) => void,
 	): Promise<Room> {
+		const room = this.roomManager.getRoom(roomId);
+		if (room) return room;
+		const pending = this.creatingRooms.get(roomId);
+		if (pending) return pending;
+
 		const { id, worker, webRtcServer } = this.workerManager.getNextWorker();
-		return this.roomManager.createRoom(
+		const creation = this.roomManager.createRoom(
 			roomId,
 			id,
 			worker,
@@ -284,6 +290,12 @@ export class MediasoupManager {
 			this.config.router.mediaCodecs as RtpCodecCapability[],
 			onActiveSpeaker,
 		);
+		this.creatingRooms.set(roomId, creation);
+		try {
+			return await creation;
+		} finally {
+			this.creatingRooms.delete(roomId);
+		}
 	}
 
 	async closeRoom(roomId: string): Promise<void> {

--- a/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
@@ -7,6 +7,7 @@ const MAX_AUDIO_LEVEL_ENTRIES = 20;
 export class RoomManager {
 	private rooms = new Map<string, Room>();
 	private routers = new Map<string, mediasoup.types.Router>();
+	private creatingRooms = new Map<string, Promise<Room>>();
 
 	async createRoom(
 		roomId: string,
@@ -19,55 +20,70 @@ export class RoomManager {
 		if (this.rooms.has(roomId)) {
 			return this.rooms.get(roomId)!;
 		}
+		const pending = this.creatingRooms.get(roomId);
+		if (pending) return pending;
 
-		loggers.roomManager.info('Creating room: %s', roomId);
+		const creation = (async () => {
+			loggers.roomManager.info('Creating room: %s', roomId);
 
-		const router = await worker.createRouter({
-			mediaCodecs,
-		});
+			const router = await worker.createRouter({
+				mediaCodecs,
+			});
 
-		const audioLevelObserver = await router.createAudioLevelObserver({
-			maxEntries: MAX_AUDIO_LEVEL_ENTRIES,
-			threshold: -70,
-			interval: 800,
-		});
+			try {
+				const audioLevelObserver = await router.createAudioLevelObserver({
+					maxEntries: MAX_AUDIO_LEVEL_ENTRIES,
+					threshold: -70,
+					interval: 800,
+				});
 
-		if (onActiveSpeaker) {
-			audioLevelObserver.on('volumes', (volumes) => {
-				const activeSpeakerIds: string[] = [];
+				if (onActiveSpeaker) {
+					audioLevelObserver.on('volumes', (volumes) => {
+						const activeSpeakerIds: string[] = [];
 
-				for (const { producer, volume } of volumes) {
-					if (volume > -70) {
-						const peer = Array.from(room.peers.values()).find((p) =>
-							Array.from(p.producers.values()).some(
-								(prod) => prod.id === producer.id,
-							),
-						);
-						if (peer && !activeSpeakerIds.includes(peer.id)) {
-							activeSpeakerIds.push(peer.id);
+						for (const { producer, volume } of volumes) {
+							if (volume > -70) {
+								const peer = Array.from(room.peers.values()).find((p) =>
+									Array.from(p.producers.values()).some(
+										(prod) => prod.id === producer.id,
+									),
+								);
+								if (peer && !activeSpeakerIds.includes(peer.id)) {
+									activeSpeakerIds.push(peer.id);
+								}
+							}
 						}
-					}
+
+						onActiveSpeaker(roomId, activeSpeakerIds);
+					});
 				}
 
-				onActiveSpeaker(roomId, activeSpeakerIds);
-			});
+				const room: Room = {
+					id: roomId,
+					workerId,
+					router,
+					webRtcServer,
+					audioLevelObserver,
+					peers: new Map(),
+					created: new Date(),
+				};
+
+				this.rooms.set(roomId, room);
+				this.routers.set(roomId, router);
+
+				loggers.roomManager.info('Room created: %s', roomId);
+				return room;
+			} catch (error) {
+				router.close();
+				throw error;
+			}
+		})();
+		this.creatingRooms.set(roomId, creation);
+		try {
+			return await creation;
+		} finally {
+			this.creatingRooms.delete(roomId);
 		}
-
-		const room: Room = {
-			id: roomId,
-			workerId,
-			router,
-			webRtcServer,
-			audioLevelObserver,
-			peers: new Map(),
-			created: new Date(),
-		};
-
-		this.rooms.set(roomId, room);
-		this.routers.set(roomId, router);
-
-		loggers.roomManager.info('Room created: %s', roomId);
-		return room;
 	}
 
 	async closeRoom(roomId: string): Promise<void> {

--- a/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/RoomManager.ts
@@ -7,7 +7,6 @@ const MAX_AUDIO_LEVEL_ENTRIES = 20;
 export class RoomManager {
 	private rooms = new Map<string, Room>();
 	private routers = new Map<string, mediasoup.types.Router>();
-	private creatingRooms = new Map<string, Promise<Room>>();
 
 	async createRoom(
 		roomId: string,
@@ -20,69 +19,58 @@ export class RoomManager {
 		if (this.rooms.has(roomId)) {
 			return this.rooms.get(roomId)!;
 		}
-		const pending = this.creatingRooms.get(roomId);
-		if (pending) return pending;
+		loggers.roomManager.info('Creating room: %s', roomId);
 
-		const creation = (async () => {
-			loggers.roomManager.info('Creating room: %s', roomId);
+		const router = await worker.createRouter({
+			mediaCodecs,
+		});
 
-			const router = await worker.createRouter({
-				mediaCodecs,
+		try {
+			const audioLevelObserver = await router.createAudioLevelObserver({
+				maxEntries: MAX_AUDIO_LEVEL_ENTRIES,
+				threshold: -70,
+				interval: 800,
 			});
 
-			try {
-				const audioLevelObserver = await router.createAudioLevelObserver({
-					maxEntries: MAX_AUDIO_LEVEL_ENTRIES,
-					threshold: -70,
-					interval: 800,
-				});
+			if (onActiveSpeaker) {
+				audioLevelObserver.on('volumes', (volumes) => {
+					const activeSpeakerIds: string[] = [];
 
-				if (onActiveSpeaker) {
-					audioLevelObserver.on('volumes', (volumes) => {
-						const activeSpeakerIds: string[] = [];
-
-						for (const { producer, volume } of volumes) {
-							if (volume > -70) {
-								const peer = Array.from(room.peers.values()).find((p) =>
-									Array.from(p.producers.values()).some(
-										(prod) => prod.id === producer.id,
-									),
-								);
-								if (peer && !activeSpeakerIds.includes(peer.id)) {
-									activeSpeakerIds.push(peer.id);
-								}
+					for (const { producer, volume } of volumes) {
+						if (volume > -70) {
+							const peer = Array.from(room.peers.values()).find((p) =>
+								Array.from(p.producers.values()).some(
+									(prod) => prod.id === producer.id,
+								),
+							);
+							if (peer && !activeSpeakerIds.includes(peer.id)) {
+								activeSpeakerIds.push(peer.id);
 							}
 						}
+					}
 
-						onActiveSpeaker(roomId, activeSpeakerIds);
-					});
-				}
-
-				const room: Room = {
-					id: roomId,
-					workerId,
-					router,
-					webRtcServer,
-					audioLevelObserver,
-					peers: new Map(),
-					created: new Date(),
-				};
-
-				this.rooms.set(roomId, room);
-				this.routers.set(roomId, router);
-
-				loggers.roomManager.info('Room created: %s', roomId);
-				return room;
-			} catch (error) {
-				router.close();
-				throw error;
+					onActiveSpeaker(roomId, activeSpeakerIds);
+				});
 			}
-		})();
-		this.creatingRooms.set(roomId, creation);
-		try {
-			return await creation;
-		} finally {
-			this.creatingRooms.delete(roomId);
+
+			const room: Room = {
+				id: roomId,
+				workerId,
+				router,
+				webRtcServer,
+				audioLevelObserver,
+				peers: new Map(),
+				created: new Date(),
+			};
+
+			this.rooms.set(roomId, room);
+			this.routers.set(roomId, router);
+
+			loggers.roomManager.info('Room created: %s', roomId);
+			return room;
+		} catch (error) {
+			router.close();
+			throw error;
 		}
 	}
 

--- a/suite/meet/sfu-server/src/server/__tests__/ConcurrentRoomCreation.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/ConcurrentRoomCreation.test.ts
@@ -65,6 +65,28 @@ function join(socket: MockSocket) {
 
 afterEach(() => vi.restoreAllMocks());
 
+it('places the next room on the next worker after concurrent first joins', async () => {
+	const { media, createRouter, sockets } = fixture();
+	createRouter.mockImplementation(async () => router());
+	const workers = [1, 2].map((id) => ({
+		id,
+		worker: { createRouter } as unknown as Worker,
+		webRtcServer: {} as WebRtcServer,
+	}));
+	let nextWorker = 0;
+	vi.mocked(WorkerManager.prototype.getNextWorker).mockImplementation(
+		() => workers[nextWorker++ % workers.length],
+	);
+	for (const result of await Promise.all(sockets.map(join)))
+		expect(result).toMatchObject({ success: true });
+	expect((await media.createRoom('room-2')).workerId).toBe(2);
+	expect((await media.createRoom('room-1')).workerId).toBe(1);
+	expect((await media.createRoom('room-3')).workerId).toBe(1);
+	await media.closeRoom('room-1');
+	await media.closeRoom('room-2');
+	await media.closeRoom('room-3');
+});
+
 it('allows another room to admit a participant while creation is pending', async () => {
 	const { media, createRouter, sockets } = fixture();
 	const pending = deferred<Router>();

--- a/suite/meet/sfu-server/src/server/__tests__/ConcurrentRoomCreation.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/ConcurrentRoomCreation.test.ts
@@ -1,0 +1,163 @@
+import { EventEmitter } from 'node:events';
+import type {
+	AudioLevelObserver,
+	Router,
+	WebRtcServer,
+	Worker,
+} from 'mediasoup/types';
+import { afterEach, expect, it, vi } from 'vitest';
+import { loadConfig } from '../../config';
+import { MediasoupManager } from '../../mediasoup/MediasoupManager';
+import { WorkerManager } from '../../mediasoup/WorkerManager';
+import { createManager, type MockSocket } from './test-helpers';
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (error: Error) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function router() {
+	return {
+		close: vi.fn(),
+		createAudioLevelObserver: vi
+			.fn()
+			.mockResolvedValue(new EventEmitter() as AudioLevelObserver),
+	} as unknown as Router;
+}
+
+function fixture() {
+	const createRouter = vi.fn<Worker['createRouter']>();
+	vi.spyOn(WorkerManager.prototype, 'getNextWorker').mockReturnValue({
+		id: 1,
+		worker: { createRouter } as unknown as Worker,
+		webRtcServer: {} as WebRtcServer,
+	});
+	const media = new MediasoupManager(
+		loadConfig({ NODE_ENV: 'test', JWT_SECRET: 'test-secret' }).mediasoup,
+	);
+	const harness = createManager(undefined, undefined, media);
+	const sockets = ['alice', 'bob'].map((userId) => {
+		const socket = harness.createSocket({ id: userId, userId });
+		harness.connect(socket);
+		return socket;
+	});
+	return { media, createRouter, sockets };
+}
+
+function join(socket: MockSocket) {
+	return new Promise<unknown>((resolve) =>
+		socket.fire(
+			'join_room',
+			{
+				roomId: socket.meetingId,
+				userData: { name: socket.userId },
+				mediaState: { audio_enabled: true, video_enabled: true },
+			},
+			resolve,
+		),
+	);
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+it('allows another room to admit a participant while creation is pending', async () => {
+	const { media, createRouter, sockets } = fixture();
+	const pending = deferred<Router>();
+	createRouter.mockReturnValueOnce(pending.promise).mockResolvedValue(router());
+	const firstJoin = join(sockets[0]);
+	await new Promise((resolve) => setImmediate(resolve));
+	sockets[1].meetingId = 'room-2';
+	expect(await join(sockets[1])).toMatchObject({ success: true });
+	expect(media.getRoomPeers('room-1')).toBeUndefined();
+	expect([...media.getRoomPeers('room-2')!.keys()]).toEqual(['bob']);
+	pending.resolve(router());
+	expect(await firstJoin).toMatchObject({ success: true });
+	await media.closeRoom('room-1');
+	await media.closeRoom('room-2');
+});
+
+it('closes every allocated router after simultaneous joins and room closure', async () => {
+	const { media, createRouter, sockets } = fixture();
+	const routers: Router[] = [];
+	createRouter.mockImplementation(async () => {
+		const allocated = router();
+		routers.push(allocated);
+		return allocated;
+	});
+	for (const result of await Promise.all(sockets.map(join))) {
+		expect(result).toMatchObject({ success: true });
+	}
+	expect([...media.getRoomPeers('room-1')!.keys()].sort()).toEqual([
+		'alice',
+		'bob',
+	]);
+	await media.closeRoom('room-1');
+	for (const allocated of routers)
+		expect(allocated.close).toHaveBeenCalledOnce();
+	expect(routers).toHaveLength(1);
+});
+
+it('retains both admitted peers when a concurrent room creation finishes after the first join', async () => {
+	const { media, createRouter, sockets } = fixture();
+	const first = deferred<Router>();
+	const second = deferred<Router>();
+	const routers = [router(), router()];
+	createRouter
+		.mockReturnValueOnce(first.promise)
+		.mockReturnValueOnce(second.promise);
+	const joins = sockets.map(join);
+	await new Promise((resolve) => setImmediate(resolve));
+	first.resolve(routers[0]);
+	expect(await joins[0]).toMatchObject({ success: true });
+	expect(media.getRoomPeers('room-1')?.has('alice')).toBe(true);
+	second.resolve(routers[1]);
+	expect(await joins[1]).toMatchObject({ success: true });
+	expect([...media.getRoomPeers('room-1')!.keys()].sort()).toEqual([
+		'alice',
+		'bob',
+	]);
+	expect(createRouter).toHaveBeenCalledTimes(1);
+	await media.closeRoom('room-1');
+	expect(routers[0].close).toHaveBeenCalledOnce();
+});
+
+it.each([
+	'router',
+	'observer',
+])('rolls back concurrent joins on %s failure and permits retry', async (stage) => {
+	const { media, createRouter, sockets } = fixture();
+	const pending = deferred<Router>();
+	const observer = deferred<AudioLevelObserver>();
+	const failedRouter = router();
+	vi.mocked(failedRouter.createAudioLevelObserver).mockReturnValue(
+		observer.promise,
+	);
+	createRouter.mockReturnValue(pending.promise);
+	const joins = sockets.map(join);
+	await new Promise((resolve) => setImmediate(resolve));
+	if (stage === 'router') pending.reject(new Error('initialization failed'));
+	else {
+		pending.resolve(failedRouter);
+		await new Promise((resolve) => setImmediate(resolve));
+		observer.reject(new Error('initialization failed'));
+	}
+	expect(await Promise.all(joins)).toEqual([
+		{ success: false, error: 'initialization failed' },
+		{ success: false, error: 'initialization failed' },
+	]);
+	expect(media.getRoomPeers('room-1')).toBeUndefined();
+	if (stage === 'observer') expect(failedRouter.close).toHaveBeenCalledOnce();
+	createRouter.mockResolvedValue(router());
+	for (const socket of sockets)
+		expect(await join(socket)).toMatchObject({ success: true });
+	expect([...media.getRoomPeers('room-1')!.keys()].sort()).toEqual([
+		'alice',
+		'bob',
+	]);
+	await media.closeRoom('room-1');
+});

--- a/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
@@ -270,9 +270,9 @@ export function createManager(
 		allowPlainTransport: false,
 		bypassRateLimits: false,
 	},
+	mediasoup: MediasoupManager = createMockMediasoupManager(),
 ): ManagerHarness {
 	const io = createMockServer();
-	const mediasoup = createMockMediasoupManager();
 	const authManager = createMockAuthManager();
 	const roster = new E2eeRosterStore(new InMemoryRosterPersistence());
 	const telemetry = new Telemetry();


### PR DESCRIPTION
Concurrent first joins to the same Meet Room now share one in-flight room creation, preserving both admitted peers and avoiding orphaned routers. Different rooms can still initialize independently.

Deduplication happens before worker selection, so duplicate joins and requests for existing rooms do not advance round-robin placement.

Failed initialization clears the pending creation so later joins can retry. If audio observer setup fails, the allocated router is closed before the error reaches waiting joins.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34203322358) for commit `6497cdf`.</sub>

</details>
<!-- suite-coverage:end -->
