### PR TITLE
test(meet): add bounded load measurement harness

### DIFF
--- a/e2e/meet/load/.gitignore
+++ b/e2e/meet/load/.gitignore
@@ -1,0 +1,2 @@
+results/
+tokens.jsonl

--- a/e2e/meet/load/README.md
+++ b/e2e/meet/load/README.md
@@ -1,0 +1,66 @@
+# Meet Measurement Harness
+
+This is a bounded measurement client for the current SFU signaling contract. Every
+artifact says `qualified: false`. A successful local run proves only that its own
+synthetic Participant Connections joined, optionally exchanged media, and cleaned
+up. It is not a capacity, production-browser, source-fidelity, bitrate, or recorder
+result.
+
+## Safety
+
+- The default target is loopback port 3001. Port 3000 is always rejected because it
+  is the shared development SFU. Non-loopback targets require
+  `--allow-remote-target`, which represents explicit operator authorization.
+- Runs require an idle `/health` and authenticated `/metrics` before sending traffic.
+  The unique default Meet Room and `load.test` site namespace identify run-owned
+  resources. Counts are bounded to 1-150, holds to 1-600 seconds, and ramps to 0-5000
+  milliseconds. Cleanup polling defaults to 65 seconds and is bounded to 90.
+- JWTs and metrics credentials come from named environment variables or a JSONL
+  token file. They are not accepted on the command line, written to reports, or
+  included in raw errors. Output and conventional token files are denied by Vite.
+- Cleanup stops local tracks, closes only harness browsers/server, emits `leave_room`,
+  then verifies SFU health, resource gauges, and local tracks returned to idle.
+
+## Run
+
+Use an isolated SFU configured with the same random secrets and a non-3000 port:
+
+```bash
+SFU_LOAD_JWT_SECRET=local-secret SFU_METRICS_TOKEN=local-metrics \
+  yarn --cwd e2e load:meet --sfu-url http://127.0.0.1:4317 \
+  --count 2 --media none --duration-seconds 2 \
+  --output /tmp/meet-load-local.json
+```
+
+`--media audio|video|both` uses Chromium's synthetic fake devices. Reports retain
+actual capture settings and observed RTP byte counters, but synthetic devices do not
+model representative speech/cameras and requested settings do not prove delivered
+resolution, frame rate, or bitrate. `--consume none` isolates publication.
+
+Server measurements need a dedicated authorized SFU, valid full-scope participant
+tokens matching the generated room/site (or its signing secret), and authenticated
+Prometheus metrics. A token file contains exactly `--count` JSONL rows shaped as
+`{"userId":"...","name":"...","token":"..."}`. Reports record endpoint,
+loopback classification, resolved workload, browser/host identity, generator process
+resource deltas, before/hold/after SFU resource gauges, participant observations, and
+cleanup outcome.
+
+## Progressive Scenarios
+
+Only admission plus idle hold and uniform synthetic media are implemented. The
+intended representative suite remains: participant admission plus idle, ten rotating
+audio talkers, forty 720p30 cameras, two 1080p30 screens capped at 4 Mbps, and one
+Recorder Endpoint. Rotation, pinned representative media, actual delivered media
+constraints, screen publication, and recorder support must be implemented and
+measured before those scenario names or properties are claimed.
+
+## Verification
+
+```bash
+yarn --cwd e2e test:meet-load
+yarn --cwd e2e typecheck
+yarn knip:e2e
+yarn check:meet-types
+yarn test:meet-type-policy
+git diff --check
+```

--- a/e2e/meet/load/client.ts
+++ b/e2e/meet/load/client.ts
@@ -1,0 +1,139 @@
+import { Device } from "mediasoup-client";
+import type { Consumer, Producer, RtpParameters, TransportOptions } from "mediasoup-client/types";
+import { io, type Socket } from "socket.io-client";
+
+type Transport = ReturnType<Device["createSendTransport"]> | ReturnType<Device["createRecvTransport"]>;
+type Media = "audio" | "video" | "both" | "none";
+interface Config {
+	sfuUrl: string; meetingId: string; token: string; userId: string; name: string;
+	media: Media; consume: boolean; renderMedia: boolean;
+}
+interface ProducerEvent { producerId: string; participantId?: string; user_id?: string; id?: string; }
+
+let socket: Socket | undefined;
+let device: Device | undefined;
+let send: Transport | undefined;
+let receive: Transport | undefined;
+let stream: MediaStream | undefined;
+let phase = "idle";
+let joinMs: number | null = null;
+let firstRemoteMediaMs: number | null = null;
+let started = 0;
+let stopping = false;
+const producers = new Map<string, Producer>();
+const consumers = new Map<string, Consumer>();
+const pending = new Map<string, Promise<void>>();
+const errors: string[] = [];
+
+function request<T extends object>(event: string, data: object): Promise<T & { success: true }> {
+	return new Promise((resolve, reject) => socket?.timeout(15_000).emit(event, data,
+		(error: Error | null, response?: T & { success?: boolean }) => {
+			if (error || response?.success !== true) reject(new Error(`${event} failed`));
+			else resolve(response as T & { success: true });
+		}));
+}
+
+function wire(transport: Transport) {
+	transport.on("connect", ({ dtlsParameters }, done, fail) => {
+		request("connect_webrtc_transport", { transportId: transport.id, dtlsParameters }).then(() => done()).catch(fail);
+	});
+}
+
+async function receiveTransport() {
+	if (receive) return receive;
+	const options = await request<TransportOptions>("create_webrtc_transport", { direction: "recv", encryptionEnabled: false });
+	receive = device!.createRecvTransport(options);
+	wire(receive);
+	return receive;
+}
+
+async function subscribe(config: Config, event: ProducerEvent) {
+	const producerId = event.producerId || event.id || "";
+	const owner = event.participantId || event.user_id;
+	if (stopping || !config.consume || owner === config.userId || consumers.has(producerId) || pending.has(producerId)) return;
+	const work = (async () => {
+		const transport = await receiveTransport();
+		const options = await request<{ id: string; producerId: string; kind: "audio" | "video"; rtpParameters: RtpParameters }>(
+			"create_consumer", { transportId: transport.id, producerId, rtpCapabilities: device!.rtpCapabilities });
+		const consumer = await transport.consume(options);
+		if (stopping) return consumer.close();
+		consumers.set(producerId, consumer);
+		if (config.renderMedia) {
+			const element = document.createElement(consumer.kind);
+			element.autoplay = true; element.muted = true; element.srcObject = new MediaStream([consumer.track]);
+			document.querySelector("#media")?.append(element); void element.play();
+		}
+	})();
+	pending.set(producerId, work);
+	try { await work; } catch { errors.push("consumer setup failed"); } finally { pending.delete(producerId); }
+}
+
+async function publish(config: Config) {
+	if (config.media === "none") return;
+	const audio = config.media === "audio" || config.media === "both";
+	const video = config.media === "video" || config.media === "both";
+	stream = await navigator.mediaDevices.getUserMedia({ audio, video });
+	const options = await request<TransportOptions>("create_webrtc_transport", { direction: "send", encryptionEnabled: false });
+	send = device!.createSendTransport(options); wire(send);
+	send.on("produce", ({ kind, rtpParameters, appData }, done, fail) => {
+		request<{ id: string }>("create_producer", { transportId: send!.id, kind, rtpParameters, appData })
+			.then(({ id }) => done({ id })).catch(fail);
+	});
+	for (const track of stream.getTracks()) {
+		const producer = await send.produce({ track, stopTracks: false, appData: { type: "camera" } });
+		producers.set(producer.id, producer);
+	}
+}
+
+async function start(config: Config) {
+	if (phase !== "idle") throw new Error("client already used");
+	phase = "starting"; started = performance.now();
+	const url = new URL(config.sfuUrl);
+	socket = io(url.origin, { path: `${url.pathname.replace(/\/$/, "") || ""}/socket.io`, auth: { token: config.token }, transports: ["websocket"], reconnection: false });
+	await new Promise<void>((resolve, reject) => {
+		socket!.once("connect", resolve); socket!.once("connect_error", () => reject(new Error("socket connection failed")));
+	});
+	const queued: ProducerEvent[] = [];
+	socket.on("producer_created", (event: ProducerEvent) => device ? void subscribe(config, event) : queued.push(event));
+	socket.on("disconnect", () => { if (!stopping) phase = "failed"; });
+	const joined = performance.now();
+	await request("join_room", {
+		roomId: config.meetingId, connectionId: crypto.randomUUID(),
+		userData: { name: config.name, userId: config.userId, is_guest: false },
+		mediaState: { audio_enabled: ["audio", "both"].includes(config.media), video_enabled: ["video", "both"].includes(config.media) },
+		e2ee: { enabled: false, capability: { supported: false, mode: "none" } },
+	});
+	joinMs = performance.now() - joined;
+	const router = await request<{ rtpCapabilities: object }>("get_router_rtp_capabilities", {});
+	device = new Device(); await device.load({ routerRtpCapabilities: router.rtpCapabilities as never });
+	await publish(config);
+	const existing = await request<{ producers: ProducerEvent[] }>("get_existing_producers", {});
+	await Promise.all([...queued, ...existing.producers].map((event) => subscribe(config, event)));
+	phase = "running";
+	return status();
+}
+
+async function status() {
+	let bytesSent = 0, bytesReceived = 0, packetsLost = 0, packetsReceived = 0;
+	for (const endpoint of producers.values()) for (const report of (await endpoint.getStats()).values())
+		if (report.type === "outbound-rtp" && !report.isRemote) bytesSent += Number(report.bytesSent || 0);
+	for (const endpoint of consumers.values()) for (const report of (await endpoint.getStats()).values()) if (report.type === "inbound-rtp" && !report.isRemote) {
+		bytesReceived += Number(report.bytesReceived || 0); packetsLost += Number(report.packetsLost || 0); packetsReceived += Number(report.packetsReceived || 0);
+	}
+	if (bytesReceived && firstRemoteMediaMs === null) firstRemoteMediaMs = performance.now() - started;
+	return { phase, joinMs, firstRemoteMediaMs, producerCount: producers.size, consumerCount: consumers.size,
+		bytesSent, bytesReceived, packetsLost, packetsReceived, errors: [...errors],
+		capture: stream?.getTracks().map((track) => ({ kind: track.kind, settings: track.getSettings() })) || [] };
+}
+
+async function stop() {
+	stopping = true; await Promise.allSettled(pending.values());
+	for (const endpoint of consumers.values()) endpoint.close();
+	for (const endpoint of producers.values()) endpoint.close();
+	receive?.close(); send?.close(); stream?.getTracks().forEach((track) => track.stop());
+	if (socket?.connected) socket.emit("leave_room", {}); socket?.disconnect(); phase = "stopped";
+	return { localMediaReleased: !stream || stream.getTracks().every((track) => track.readyState === "ended") };
+}
+
+declare global { interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop } } }
+window.meetLoad = { start, status, stop };

--- a/e2e/meet/load/index.html
+++ b/e2e/meet/load/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+	<head><meta charset="UTF-8"><title>Meet measurement client</title></head>
+	<body><main id="media"></main><script type="module" src="/client.ts"></script></body>
+</html>

--- a/e2e/meet/load/report.mjs
+++ b/e2e/meet/load/report.mjs
@@ -1,0 +1,55 @@
+import { isIP } from "node:net";
+
+export function boundedInteger(value, name, min, max) {
+	const number = Number(value);
+	if (!Number.isInteger(number) || number < min || number > max) {
+		throw new Error(`${name} must be an integer from ${min} to ${max}`);
+	}
+	return number;
+}
+
+export function targetMetadata(value, allowRemote) {
+	const url = new URL(value);
+	if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
+		throw new Error("SFU target must be HTTP(S) without credentials, query, or fragment");
+	}
+	const loopback = url.hostname === "localhost" || url.hostname === "::1" ||
+		(isIP(url.hostname) === 4 && url.hostname.startsWith("127."));
+	if (!loopback && !allowRemote) throw new Error("Non-loopback targets require --allow-remote-target");
+	if (url.port === "3000") throw new Error("Port 3000 is reserved for the shared SFU; use an isolated target");
+	return { endpoint: url.origin + url.pathname.replace(/\/$/, ""), loopback };
+}
+
+export function parseResourceMetrics(text) {
+	const values = {};
+	for (const line of text.split("\n")) {
+		const match = line.match(/^([^\s{]+)(?:\{([^}]*)\})?\s+(-?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?)$/i);
+		if (!match) continue;
+		const number = Number(match[3]);
+		const resource = match[2]?.match(/(?:^|,)resource="([a-z]+)"(?:,|$)/)?.[1];
+		const mode = match[2]?.match(/(?:^|,)mode="(user|system)"(?:,|$)/)?.[1];
+		if (match[1] === "meet_sfu_resources" && resource) values[resource] = number;
+		if (match[1] === "meet_sfu_worker_cpu_seconds" && mode) {
+			const key = `workerCpu${mode[0].toUpperCase()}${mode.slice(1)}Seconds`;
+			values[key] = (values[key] || 0) + number;
+		}
+		if (match[1] === "meet_sfu_worker_max_resident_memory_bytes") {
+			values.workerMaxResidentMemoryBytes = (values.workerMaxResidentMemoryBytes || 0) + number;
+		}
+		if (match[1] === "meet_sfu_process_process_resident_memory_bytes") values.processResidentMemoryBytes = number;
+	}
+	return values;
+}
+
+export function delta(before, after) {
+	return Object.fromEntries(Object.keys(after).map((key) => [key, after[key] - (before[key] ?? 0)]));
+}
+
+export function percentile(values, fraction) {
+	const finite = values.filter(Number.isFinite).sort((a, b) => a - b);
+	return finite.length ? finite[Math.ceil(finite.length * fraction) - 1] : null;
+}
+
+export function containsJwt(value) {
+	return /eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/.test(JSON.stringify(value));
+}

--- a/e2e/meet/load/report.test.mjs
+++ b/e2e/meet/load/report.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { boundedInteger, containsJwt, delta, parseResourceMetrics, percentile, targetMetadata } from "./report.mjs";
+
+test("target safety defaults to loopback and rejects shared or remote targets", () => {
+	assert.deepEqual(targetMetadata("http://127.0.0.1:4317/", false), {
+		endpoint: "http://127.0.0.1:4317",
+		loopback: true,
+	});
+	assert.throws(() => targetMetadata("http://127.0.0.1:3000", false), /shared SFU/);
+	assert.throws(() => targetMetadata("https://sfu.example.com", false), /allow-remote-target/);
+	assert.equal(targetMetadata("https://sfu.example.com/base", true).loopback, false);
+});
+
+test("bounds reject fractions and values outside the declared range", () => {
+	assert.equal(boundedInteger("40", "count", 1, 50), 40);
+	assert.equal(boundedInteger("150", "count", 1, 150), 150);
+	assert.throws(() => boundedInteger("40.5", "count", 1, 50));
+	assert.throws(() => boundedInteger("151", "count", 1, 150));
+});
+
+test("resource parser ignores unrelated and malformed Prometheus samples", () => {
+	const metrics = [
+		"# HELP ignored ignored",
+		'meet_sfu_resources{resource="rooms"} 1',
+		'meet_sfu_resources{resource="producers"} 4',
+		'meet_sfu_worker_cpu_seconds{worker="1",mode="user"} 0.25',
+		'meet_sfu_worker_cpu_seconds{worker="2",mode="user"} 0.5',
+		'meet_sfu_worker_max_resident_memory_bytes{worker="1"} 8000000',
+		"meet_sfu_process_process_resident_memory_bytes 12000000",
+		'meet_sfu_resources{resource="consumers"} NaN',
+		"process_resident_memory_bytes 99",
+	].join("\n");
+	assert.deepEqual(parseResourceMetrics(metrics), { rooms: 1, producers: 4,
+		workerCpuUserSeconds: 0.75, workerMaxResidentMemoryBytes: 8000000,
+		processResidentMemoryBytes: 12000000 });
+	assert.deepEqual(delta({ rooms: 0, producers: 1 }, { rooms: 1, producers: 4 }), {
+		rooms: 1,
+		producers: 3,
+	});
+});
+
+test("percentiles use nearest rank and reports can be checked for JWT leakage", () => {
+	assert.equal(percentile([40, 10, 30, 20], 0.5), 20);
+	assert.equal(percentile([], 0.95), null);
+	assert.equal(containsJwt({ auth: "environment" }), false);
+	assert.equal(containsJwt({ value: "eyJhbGciOiJIUzI1NiJ9.e30.signature" }), true);
+});

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -1,0 +1,179 @@
+import { createHmac, randomUUID } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { cpus, hostname, platform, release, totalmem } from "node:os";
+import { dirname, resolve } from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import { chromium } from "@playwright/test";
+import { createServer } from "vite";
+import { boundedInteger, containsJwt, delta, parseResourceMetrics, percentile, targetMetadata } from "./report.mjs";
+
+const root = dirname(fileURLToPath(import.meta.url));
+const { values } = parseArgs({ options: {
+	"sfu-url": { type: "string", default: "http://127.0.0.1:3001" },
+	"allow-remote-target": { type: "boolean", default: false },
+	"meeting-id": { type: "string", default: `load-${randomUUID()}` },
+	site: { type: "string", default: "load.test" },
+	count: { type: "string", default: "2" },
+	media: { type: "string", default: "none" },
+	consume: { type: "string", default: "all" },
+	"render-media": { type: "boolean", default: false },
+	"ramp-ms": { type: "string", default: "250" },
+	"duration-seconds": { type: "string", default: "5" },
+	"cleanup-seconds": { type: "string", default: "65" },
+	"token-file": { type: "string" },
+	"jwt-secret-env": { type: "string", default: "SFU_LOAD_JWT_SECRET" },
+	"metrics-token-env": { type: "string", default: "SFU_METRICS_TOKEN" },
+	output: { type: "string" },
+}, strict: true });
+
+const count = boundedInteger(values.count, "count", 1, 150);
+const durationSeconds = boundedInteger(values["duration-seconds"], "duration-seconds", 1, 600);
+const cleanupSeconds = boundedInteger(values["cleanup-seconds"], "cleanup-seconds", 1, 90);
+const rampMs = boundedInteger(values["ramp-ms"], "ramp-ms", 0, 5000);
+if (!["none", "audio", "video", "both"].includes(values.media)) throw new Error("media must be none, audio, video, or both");
+if (!["all", "none"].includes(values.consume)) throw new Error("consume must be all or none");
+if (!/^load-[0-9a-f-]{36}$/.test(values["meeting-id"]) || !/^load(?:[.-][a-z0-9-]+)*\.test$/i.test(values.site)) {
+	throw new Error("Use the generated load UUID room and a load*.test site namespace");
+}
+const target = targetMetadata(values["sfu-url"], values["allow-remote-target"]);
+const output = resolve(values.output || resolve(root, "results", `${new Date().toISOString().replaceAll(":", "-")}.json`));
+const metricsToken = process.env[values["metrics-token-env"]];
+if (!metricsToken) throw new Error(`Set ${values["metrics-token-env"]} for idle and cleanup measurement`);
+
+const report = {
+	schemaVersion: 1,
+	scope: target.loopback ? "local-correctness-only" : "server-measurement-only",
+	qualified: false,
+	startedAt: new Date().toISOString(),
+	target,
+	config: { count, durationSeconds, cleanupSeconds, rampMs, media: values.media, consume: values.consume,
+		renderMedia: values["render-media"], meetingId: values["meeting-id"], site: values.site,
+		authSource: values["token-file"] ? "token-file" : "environment-signed" },
+	host: { hostname: hostname(), platform: platform(), release: release(), node: process.version,
+		logicalCpus: cpus().length, cpuModel: cpus()[0]?.model, totalMemoryBytes: totalmem() },
+	browser: {}, resources: {}, samples: [], participants: [], cleanup: [], errors: [],
+};
+const beforeUsage = process.resourceUsage();
+const beforeMemory = process.memoryUsage();
+const pages = [], browsers = [];
+let vite;
+
+function endpoint(path) {
+	const url = new URL(target.endpoint); url.pathname = `${url.pathname.replace(/\/$/, "")}/${path}`; return url;
+}
+async function fetchText(path, authenticated = false) {
+	const response = await fetch(endpoint(path), { headers: authenticated ? { Authorization: `Bearer ${metricsToken}` } : {},
+		signal: AbortSignal.timeout(5000), redirect: "error" });
+	if (!response.ok) throw new Error(`${path} returned HTTP ${response.status}`);
+	const text = await response.text();
+	if (text.length > 2_000_000) throw new Error(`${path} response exceeds 2 MB`);
+	return text;
+}
+async function sample(phase) {
+	const health = JSON.parse(await fetchText("health"));
+	const resources = parseResourceMetrics(await fetchText("metrics", true));
+	const entry = { at: new Date().toISOString(), phase, health, resources };
+	report.samples.push(entry); return entry;
+}
+function isIdle(entry) {
+	return entry.health.rooms === 0 && entry.health.peers === 0 &&
+		["rooms", "participants", "peers", "transports", "producers", "consumers", "sockets"]
+			.every((key) => (entry.resources[key] ?? 0) === 0);
+}
+function signedToken(secret, participant) {
+	const encode = (value) => Buffer.from(JSON.stringify(value)).toString("base64url");
+	const now = Math.floor(Date.now() / 1000);
+	const unsigned = `${encode({ alg: "HS256", typ: "JWT" })}.${encode({ user_id: participant.userId,
+		user_name: participant.name, meeting_id: values["meeting-id"], site: values.site, scope: "full",
+		is_host: false, is_cohost: false, is_guest: false, e2ee_required: false, iat: now, exp: now + 1800 })}`;
+	return `${unsigned}.${createHmac("sha256", secret).update(unsigned).digest("base64url")}`;
+}
+async function clients() {
+	if (values["token-file"]) {
+		let parsed;
+		try { parsed = (await readFile(resolve(values["token-file"]), "utf8")).split("\n").filter(Boolean).map(JSON.parse); }
+		catch { throw new Error("Token file is unreadable or malformed"); }
+		if (parsed.length !== count) throw new Error("Token file must contain exactly count JSONL entries");
+		return parsed.map(({ userId, name, token }) => ({ userId, name, token }));
+	}
+	const secret = process.env[values["jwt-secret-env"]];
+	if (!secret) throw new Error(`Set ${values["jwt-secret-env"]} or provide --token-file`);
+	return Array.from({ length: count }, (_, index) => {
+		const participant = { userId: `load-${index + 1}@example.invalid`, name: `Load ${index + 1}` };
+		return { ...participant, token: signedToken(secret, participant) };
+	});
+}
+async function wait(ms) { return new Promise((resolveDelay) => setTimeout(resolveDelay, ms)); }
+
+try {
+	const initial = await sample("before");
+	if (!isIdle(initial)) throw new Error("Target is not idle; no traffic was sent");
+	const participants = await clients();
+	vite = await createServer({ root, logLevel: "error", server: { host: "127.0.0.1", port: 0 },
+		fs: { strict: true, allow: [root], deny: ["**/tokens.jsonl", output] } });
+	await vite.listen();
+	const address = vite.httpServer.address();
+	const clientUrl = `http://127.0.0.1:${address.port}`;
+	const browser = await chromium.launch({ headless: true, channel: process.env.CHROME_CHANNEL,
+		args: ["--use-fake-ui-for-media-stream", "--use-fake-device-for-media-stream", "--autoplay-policy=no-user-gesture-required"] });
+	browsers.push(browser); report.browser = { version: browser.version(), channel: process.env.CHROME_CHANNEL || "playwright-chromium", contexts: 1 };
+	const context = await browser.newContext({ permissions: ["camera", "microphone"] });
+	for (const [index, participant] of participants.entries()) {
+		const page = await context.newPage(); pages.push(page);
+		page.on("pageerror", () => report.errors.push(`participant ${index + 1}: page error`));
+		await page.goto(clientUrl, { waitUntil: "networkidle", timeout: 15_000 });
+		await page.evaluate((config) => window.meetLoad.start(config), { ...participant, sfuUrl: target.endpoint,
+			meetingId: values["meeting-id"], media: values.media, consume: values.consume === "all", renderMedia: values["render-media"] });
+		if (rampMs) await wait(rampMs);
+	}
+	const hold = await sample("hold");
+	if (hold.health.rooms !== 1 || hold.health.peers !== count) throw new Error("SFU hold counts do not match this run");
+	await wait(durationSeconds * 1000);
+	report.participants = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
+	for (const [index, participant] of report.participants.entries()) {
+		if (participant.phase !== "running") report.errors.push(`participant ${index + 1}: not running`);
+		if (values.media !== "none" && participant.bytesSent === 0) report.errors.push(`participant ${index + 1}: no outbound RTP observed`);
+		if (count > 1 && values.consume === "all" && values.media !== "none" && participant.bytesReceived === 0) report.errors.push(`participant ${index + 1}: no inbound RTP observed`);
+		report.errors.push(...participant.errors.map((error) => `participant ${index + 1}: ${error}`));
+	}
+} catch (error) {
+	report.errors.push(error instanceof Error ? error.message.replace(/eyJ[A-Za-z0-9._-]+/g, "[redacted]") : "run failed");
+} finally {
+	report.cleanup = await Promise.all(pages.map(async (page, index) => {
+		try { return { participant: index + 1, ...(await page.evaluate(() => window.meetLoad.stop())) }; }
+		catch { return { participant: index + 1, localMediaReleased: false }; }
+	}));
+	await Promise.allSettled(browsers.map((browser) => browser.close()));
+	if (vite) await vite.close();
+	try {
+		const cleanupStarted = Date.now();
+		while (Date.now() - cleanupStarted < cleanupSeconds * 1000) {
+			const health = JSON.parse(await fetchText("health"));
+			if (health.rooms === 0 && health.peers === 0) break;
+			await wait(1000);
+		}
+		report.cleanupElapsedMs = Date.now() - cleanupStarted;
+		const after = await sample("after");
+		report.resources = { before: report.samples[0]?.resources || {}, hold: report.samples.find((entry) => entry.phase === "hold")?.resources || {},
+			after: after.resources, holdDelta: delta(report.samples[0]?.resources || {}, report.samples.find((entry) => entry.phase === "hold")?.resources || {}),
+			afterDelta: delta(report.samples[0]?.resources || {}, after.resources) };
+		report.cleanupVerified = isIdle(after) && report.cleanup.every((entry) => entry.localMediaReleased);
+		if (!report.cleanupVerified) report.errors.push("Cleanup did not return measured resources and local media to idle");
+	} catch { report.errors.push("Final resource sample failed"); report.cleanupVerified = false; }
+	const usage = process.resourceUsage(); const memory = process.memoryUsage();
+	report.host.generatorProcessDelta = { userCpuMicros: usage.userCPUTime - beforeUsage.userCPUTime,
+		systemCpuMicros: usage.systemCPUTime - beforeUsage.systemCPUTime,
+		maxRssBytes: usage.maxRSS * 1024, rssBytes: memory.rss, rssDeltaBytes: memory.rss - beforeMemory.rss };
+	report.summary = { passed: report.errors.length === 0 && report.cleanupVerified,
+		joinP50Ms: percentile(report.participants.map((entry) => entry.joinMs), 0.5),
+		joinP95Ms: percentile(report.participants.map((entry) => entry.joinMs), 0.95),
+		firstRemoteMediaP95Ms: percentile(report.participants.map((entry) => entry.firstRemoteMediaMs), 0.95),
+		totalBytesSent: report.participants.reduce((sum, entry) => sum + entry.bytesSent, 0),
+		totalBytesReceived: report.participants.reduce((sum, entry) => sum + entry.bytesReceived, 0) };
+	report.finishedAt = new Date().toISOString();
+	if (containsJwt(report)) throw new Error("Refusing to write a report containing a JWT");
+	await mkdir(dirname(output), { recursive: true }); await writeFile(output, `${JSON.stringify(report, null, 2)}\n`, { mode: 0o600 });
+	console.log(`${report.scope}: ${report.summary.passed ? "passed" : "failed"}; qualified=false; report=${output}`);
+	process.exitCode = report.summary.passed ? 0 : 1;
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,8 @@
     "test": "yarn test:drive-backed-apps",
     "test:drive-backed-apps": "playwright test -c drive-backed-apps/playwright.config.ts",
     "test:meet": "playwright test -c meet/playwright.config.ts",
+    "test:meet-load": "node --test meet/load/*.test.mjs",
+    "load:meet": "node meet/load/run.mjs",
     "test:headed": "yarn test:drive-backed-apps --headed",
     "test:debug": "yarn test:drive-backed-apps --debug",
     "test:ui": "yarn test:drive-backed-apps --ui",
@@ -15,6 +17,9 @@
   "devDependencies": {
     "@playwright/test": "^1.59.1",
     "@types/node": "^24.10.1",
-    "typescript": "^6.0.3"
+    "mediasoup-client": "^3.18.8",
+    "socket.io-client": "^4.8.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
   }
 }

--- a/e2e/yarn.lock
+++ b/e2e/yarn.lock
@@ -2,12 +2,131 @@
 # yarn lockfile v1
 
 
+"@lukeed/csprng@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@lukeed/csprng/-/csprng-1.1.0.tgz#1e3e4bd05c1cc7a0b2ddbd8a03f39f6e4b5e6cfe"
+  integrity sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==
+
+"@lukeed/uuid@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@lukeed/uuid/-/uuid-2.0.1.tgz#4f6c34259ee0982a455e1797d56ac27bb040fd74"
+  integrity sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==
+  dependencies:
+    "@lukeed/csprng" "^1.1.0"
+
+"@oxc-project/types@=0.148.0":
+  version "0.148.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.148.0.tgz#811d188a2e1af35784461b8a0490e13a3d76837c"
+  integrity sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A==
+
 "@playwright/test@^1.59.1":
   version "1.61.1"
   resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.1.tgz#48568dc22af7819e55fa5e8e3bc79b7e6a3e6675"
   integrity sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==
   dependencies:
     playwright "1.61.1"
+
+"@rolldown/binding-android-arm-eabi@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.7.tgz#9a0f9b6752ed522254f3715e81c066e5da6de9a9"
+  integrity sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ==
+
+"@rolldown/binding-android-arm64@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.7.tgz#bbc5a5e39deaa1cca5658d073b8c74b9cee329e8"
+  integrity sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw==
+
+"@rolldown/binding-darwin-arm64@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.7.tgz#ff3858531df2592011c5ea19e7babadf22a036fa"
+  integrity sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw==
+
+"@rolldown/binding-darwin-x64@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.7.tgz#7be480c60dfa230486e84ec43184803f7e172bae"
+  integrity sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ==
+
+"@rolldown/binding-freebsd-x64@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.7.tgz#533b1b58623c6531baf78c3a911aed586c92fbcd"
+  integrity sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.7.tgz#24806b5ca49eced31d8a8c98bfd7875942f08fc4"
+  integrity sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ==
+
+"@rolldown/binding-linux-arm64-gnu@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.7.tgz#7e73c4251887102a465f7940bb40cdb6c8f2315c"
+  integrity sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg==
+
+"@rolldown/binding-linux-arm64-musl@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.7.tgz#f72f2ca9947916ae68fd790b36db1776c61b9c5d"
+  integrity sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q==
+
+"@rolldown/binding-linux-ppc64-gnu@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.7.tgz#2a6bc86254e9f400476af7d4971b8cbc532bed1d"
+  integrity sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg==
+
+"@rolldown/binding-linux-s390x-gnu@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.7.tgz#07888b936afa9336fdeacbbb2bfbf148e30f64ef"
+  integrity sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw==
+
+"@rolldown/binding-linux-x64-gnu@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.7.tgz#c6a3811c9a09323f5ebd2d4fbb79465098e18459"
+  integrity sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA==
+
+"@rolldown/binding-linux-x64-musl@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.7.tgz#ef16286f9d2c091263e65142d1f6204ab6fc4a3a"
+  integrity sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw==
+
+"@rolldown/binding-openharmony-arm64@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.7.tgz#e85c1f6cfed01fbf9e3b16c5159e32548b59a96d"
+  integrity sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w==
+
+"@rolldown/binding-win32-arm64-msvc@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.7.tgz#833546f8b04904d1453ebdaf81ef8671f95ac926"
+  integrity sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw==
+
+"@rolldown/binding-win32-x64-msvc@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.7.tgz#96186105008c63fd52b2ca9ed5ef5e74faf5907f"
+  integrity sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw==
+
+"@rolldown/pluginutils@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz#e3fcee093fbb5ce765e1ad088ff4de2889f6f9be"
+  integrity sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==
+
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz#821f8442f4175d8f0467b9daf26e3a18e2d02af2"
+  integrity sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==
+
+"@types/debug@^4.1.13":
+  version "4.1.13"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.13.tgz#22d1cc9d542d3593caea764f974306ab36286ee7"
+  integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
+  dependencies:
+    "@types/ms" "*"
+
+"@types/events-alias@npm:@types/events@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.3.tgz#a8ef894305af28d1fc6d2dfdfc98e899591ea529"
+  integrity sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==
+
+"@types/ms@*":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
+  integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@^24.10.1":
   version "24.13.3"
@@ -16,10 +135,183 @@
   dependencies:
     undici-types "~7.18.0"
 
+awaitqueue@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/awaitqueue/-/awaitqueue-3.3.1.tgz#3efed961ee080483b4657ef1953cb246fd306c9b"
+  integrity sha512-kzMN6Bdfalok/JWZvwDfI704cIyCvHDi6Ez/bApGzNPjGHQhwJ07DzGd3DDzeXH2fjr9P5g8paESFUvYnbs7rA==
+  dependencies:
+    debug "^4.4.3"
+
+debug@^4.4.3, debug@~4.4.1:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
+detect-libc@^2.0.3:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
+  integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
+
+engine.io-client@~6.6.1:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.6.6.tgz#8a8f1e451b1f6d4acf413305445e42133d1cbe9a"
+  integrity sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-parser "~5.2.1"
+    ws "~8.21.0"
+    xmlhttprequest-ssl "~2.1.1"
+
+engine.io-parser@~5.2.1:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.2.3.tgz#00dc5b97b1f233a23c9398d0209504cf5f94d92f"
+  integrity sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==
+
+"events-alias@npm:events@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+fake-mediastreamtrack@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/fake-mediastreamtrack/-/fake-mediastreamtrack-2.2.1.tgz#49a36b4d58fadb7b450eafe96bdfd9173a1c6252"
+  integrity sha512-SITLc7UTDirSdgLGORrlmqjWLJtbtfIz/xO7DwVbJH3f0ds+NQok4ccl/WEzz49NSgiUlXf2wDW0+y5C+TO6EA==
+  dependencies:
+    "@lukeed/uuid" "^2.0.1"
+
+fdir@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
+  integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
+
 fsevents@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
+fsevents@~2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+h264-profile-level-id@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/h264-profile-level-id/-/h264-profile-level-id-2.3.3.tgz#1206e6c1a536a49e8b14b51ab147255a1e44695c"
+  integrity sha512-rPd5gpyWuIfEbBiHC/f9I4wdeCpAhg0aWdYgjMRdVTqhJT22C6VrWTi4hpAAgJad1Vv8BJDEvrzAQTW7CxzmJw==
+  dependencies:
+    debug "^4.4.3"
+
+lightningcss-android-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz#9a6841f88ae50fc83502903892b41af41bc2b907"
+  integrity sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==
+
+lightningcss-darwin-arm64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz#c0f2c31c0bfd19fa4dd3f18e957a1f1a152097d6"
+  integrity sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==
+
+lightningcss-darwin-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz#cb0705965acb538c6683949ce6925fb3cdf7c361"
+  integrity sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==
+
+lightningcss-freebsd-x64@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz#763538828b26bab2680dadafcc84ee78b0eb502b"
+  integrity sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==
+
+lightningcss-linux-arm-gnueabihf@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz#6862e3176a331aedbdec1ed352b4d7d0dd0784de"
+  integrity sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==
+
+lightningcss-linux-arm64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz#c6a3a2ed15141daf6bdc2628930f8e39bdf473aa"
+  integrity sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==
+
+lightningcss-linux-arm64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz#7fa1334971fc82845f9827df6ef8a0b20914bac6"
+  integrity sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==
+
+lightningcss-linux-x64-gnu@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz#8b927862ea8c2bbc6831a46509244b50d9936e55"
+  integrity sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==
+
+lightningcss-linux-x64-musl@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz#0c525bb077dfd94404c059cfe42dad797e96aeaf"
+  integrity sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==
+
+lightningcss-win32-arm64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz#850ee1103dac989cfab50e3ac22d1a69e394e63d"
+  integrity sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==
+
+lightningcss-win32-x64-msvc@1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz#e343ae152eed3609dc6e11949d1a3bf39a1c946f"
+  integrity sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==
+
+lightningcss@^1.33.0:
+  version "1.33.0"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.33.0.tgz#c08867d71a79385c6e190214fd72fef3e5f95f0b"
+  integrity sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==
+  dependencies:
+    detect-libc "^2.0.3"
+  optionalDependencies:
+    lightningcss-android-arm64 "1.33.0"
+    lightningcss-darwin-arm64 "1.33.0"
+    lightningcss-darwin-x64 "1.33.0"
+    lightningcss-freebsd-x64 "1.33.0"
+    lightningcss-linux-arm-gnueabihf "1.33.0"
+    lightningcss-linux-arm64-gnu "1.33.0"
+    lightningcss-linux-arm64-musl "1.33.0"
+    lightningcss-linux-x64-gnu "1.33.0"
+    lightningcss-linux-x64-musl "1.33.0"
+    lightningcss-win32-arm64-msvc "1.33.0"
+    lightningcss-win32-x64-msvc "1.33.0"
+
+mediasoup-client@^3.18.8:
+  version "3.23.1"
+  resolved "https://registry.yarnpkg.com/mediasoup-client/-/mediasoup-client-3.23.1.tgz#bb11913f347fa23342348602ffb79398623caffe"
+  integrity sha512-dFgIQAhYDySRhvekzgUY2trt+Vq2T2YxFKpMjeK0E9dHBbmhE0URUJNo4rKMXrse4Buy8uSbD4kzY+0G/4fw4Q==
+  dependencies:
+    "@types/debug" "^4.1.13"
+    "@types/events-alias" "npm:@types/events@^3.0.3"
+    awaitqueue "^3.3.1"
+    debug "^4.4.3"
+    events-alias "npm:events@^3.3.0"
+    fake-mediastreamtrack "^2.2.1"
+    h264-profile-level-id "^2.3.3"
+    sdp-transform "^3.0.0"
+    supports-color "^11.0.0"
+
+ms@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.18:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+picomatch@^4.0.4, picomatch@^4.0.5:
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.7.tgz#6313360034ccb36b3dc61ecbdff78121f90fe21f"
+  integrity sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA==
 
 playwright-core@1.61.1:
   version "1.61.1"
@@ -35,6 +327,80 @@ playwright@1.61.1:
   optionalDependencies:
     fsevents "2.3.2"
 
+postcss@^8.5.26:
+  version "8.5.28"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.28.tgz#da4563a99a06e62d6c1cd1acae363224bcaed6e9"
+  integrity sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==
+  dependencies:
+    nanoid "^3.3.18"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+rolldown@~1.2.4:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.2.7.tgz#bcfc48430431356f95fdf399fa404298e78f4740"
+  integrity sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig==
+  dependencies:
+    "@oxc-project/types" "=0.148.0"
+    "@rolldown/pluginutils" "^1.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm-eabi" "1.2.7"
+    "@rolldown/binding-android-arm64" "1.2.7"
+    "@rolldown/binding-darwin-arm64" "1.2.7"
+    "@rolldown/binding-darwin-x64" "1.2.7"
+    "@rolldown/binding-freebsd-x64" "1.2.7"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.2.7"
+    "@rolldown/binding-linux-arm64-gnu" "1.2.7"
+    "@rolldown/binding-linux-arm64-musl" "1.2.7"
+    "@rolldown/binding-linux-ppc64-gnu" "1.2.7"
+    "@rolldown/binding-linux-s390x-gnu" "1.2.7"
+    "@rolldown/binding-linux-x64-gnu" "1.2.7"
+    "@rolldown/binding-linux-x64-musl" "1.2.7"
+    "@rolldown/binding-openharmony-arm64" "1.2.7"
+    "@rolldown/binding-win32-arm64-msvc" "1.2.7"
+    "@rolldown/binding-win32-x64-msvc" "1.2.7"
+
+sdp-transform@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/sdp-transform/-/sdp-transform-3.0.0.tgz#863dd2d781c468d7d6a2f9c70fedcf0538f3e76c"
+  integrity sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==
+
+socket.io-client@^4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.8.3.tgz#62717edd46a318c918125b57e92dc7f8bb71c34c"
+  integrity sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+    engine.io-client "~6.6.1"
+    socket.io-parser "~4.2.4"
+
+socket.io-parser@~4.2.4:
+  version "4.2.7"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.7.tgz#679e51fe24d1c81df90fc5f7efe4a5f432fe99c0"
+  integrity sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.4.1"
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+supports-color@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-11.0.0.tgz#54f4096e9cac614c6f273dc764e697e3c2c3941d"
+  integrity sha512-/zyImLdxhdygBIaVX0xTlQhKaCDLCrm665aqHk8xqK/Pa6k61fL6gwQGQq1k31yNyz6x55PppQgF2DMyPQa5xw==
+
+tinyglobby@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
 typescript@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
@@ -44,3 +410,26 @@ undici-types@~7.18.0:
   version "7.18.2"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
   integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
+
+vite@^8.0.16:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-8.2.2.tgz#399aefad3656145145be110d137a07ea5bb55014"
+  integrity sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==
+  dependencies:
+    lightningcss "^1.33.0"
+    picomatch "^4.0.5"
+    postcss "^8.5.26"
+    rolldown "~1.2.4"
+    tinyglobby "^0.2.17"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+ws@~8.21.0:
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.3.tgz#660b4faddb6a3e575c86e078126919961f4de4fc"
+  integrity sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==
+
+xmlhttprequest-ssl@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz#e9e8023b3f29ef34b97a859f584c5e6c61418e23"
+  integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==

--- a/knip.json
+++ b/knip.json
@@ -29,12 +29,14 @@
       "entry": [
         "drive-backed-apps/global-setup.ts",
         "drive-backed-apps/global-teardown.ts",
-        "meet/global-setup.ts"
+        "meet/global-setup.ts",
+        "meet/load/client.ts",
+        "meet/load/*.test.mjs"
       ],
       "project": [
         "shared/**/*.ts",
         "drive-backed-apps/**/*.ts",
-        "meet/**/*.ts"
+        "meet/**/*.{ts,mjs}"
       ],
       "playwright": {"config": ["{drive-backed-apps,meet}/playwright.config.ts"]}
     },


### PR DESCRIPTION
## Summary

- add a bounded browser-based harness for measuring Meet participant admission, idle holds, and uniform synthetic media
- capture sanitized client, host, and authenticated SFU resource observations in explicitly unqualified reports
- document supported scenarios, operator constraints, and report interpretation

## Safety

- reject the shared SFU port and require explicit opt-in for non-loopback targets
- require idle health and authenticated metrics preflight before generating traffic
- bound participant, ramp, hold, and cleanup settings and verify run-owned resources return to idle
- keep credentials out of CLI arguments, served files, errors, and reports

## Scope

Measurement tooling and E2E configuration only. This does not change production runtime behavior or claim production capacity, representative media quality, recorder coverage, or qualification.

## Follow-up Fix

- update the E2E lockfile so frozen dependency installs include the harness dependencies