### PR TITLE
test(meet): measure rotating audio delivery

### DIFF
--- a/e2e/meet/load/README.md
+++ b/e2e/meet/load/README.md
@@ -40,9 +40,10 @@ resolution, frame rate, or bitrate. `--consume none` isolates publication.
 `--scenario rotating-audio --media audio` gives every participant one persistent,
 enabled, unpaused microphone Producer sourced from a 440 Hz Web Audio oscillator.
 Only a `GainNode` changes: `--talkers` (default 10, never above `--count`) rotate on
-the deterministic `--rotation-interval-ms` cadence. Reports include each expected
-active set, per-publisher outbound RTP and optional audio-energy deltas, per-receiver
-inbound continuity, Producer IDs, and SFU Producer/Consumer gauges for every window.
+the configured `--rotation-interval-ms` cadence. Reports include each expected
+active set, actual gain-state boundaries and duration, per-publisher outbound RTP and
+optional audio-energy deltas, per-receiver inbound continuity, Producer IDs, and SFU
+Producer/Consumer gauges for every window.
 Configured gain is not proof of acoustic delivery; `totalAudioEnergy` is recorded
 when Chromium exposes it, otherwise the report says `null`.
 

--- a/e2e/meet/load/README.md
+++ b/e2e/meet/load/README.md
@@ -37,6 +37,15 @@ actual capture settings and observed RTP byte counters, but synthetic devices do
 model representative speech/cameras and requested settings do not prove delivered
 resolution, frame rate, or bitrate. `--consume none` isolates publication.
 
+`--scenario rotating-audio --media audio` gives every participant one persistent,
+enabled, unpaused microphone Producer sourced from a 440 Hz Web Audio oscillator.
+Only a `GainNode` changes: `--talkers` (default 10, never above `--count`) rotate on
+the deterministic `--rotation-interval-ms` cadence. Reports include each expected
+active set, per-publisher outbound RTP and optional audio-energy deltas, per-receiver
+inbound continuity, Producer IDs, and SFU Producer/Consumer gauges for every window.
+Configured gain is not proof of acoustic delivery; `totalAudioEnergy` is recorded
+when Chromium exposes it, otherwise the report says `null`.
+
 Server measurements need a dedicated authorized SFU, valid full-scope participant
 tokens matching the generated room/site (or its signing secret), and authenticated
 Prometheus metrics. A token file contains exactly `--count` JSONL rows shaped as
@@ -47,12 +56,11 @@ cleanup outcome.
 
 ## Progressive Scenarios
 
-Only admission plus idle hold and uniform synthetic media are implemented. The
-intended representative suite remains: participant admission plus idle, ten rotating
-audio talkers, forty 720p30 cameras, two 1080p30 screens capped at 4 Mbps, and one
-Recorder Endpoint. Rotation, pinned representative media, actual delivered media
-constraints, screen publication, and recorder support must be implemented and
-measured before those scenario names or properties are claimed.
+Admission plus idle hold, uniform synthetic media, and rotating audio are implemented.
+The remaining representative suite is forty 720p30 cameras, two 1080p30 screens
+capped at 4 Mbps, and one Recorder Endpoint. Pinned representative video, actual
+delivered video constraints, screen publication, and recorder support must be
+implemented and measured before those properties are claimed.
 
 ## Verification
 

--- a/e2e/meet/load/client.ts
+++ b/e2e/meet/load/client.ts
@@ -6,7 +6,7 @@ type Transport = ReturnType<Device["createSendTransport"]> | ReturnType<Device["
 type Media = "audio" | "video" | "both" | "none";
 interface Config {
 	sfuUrl: string; meetingId: string; token: string; userId: string; name: string;
-	media: Media; consume: boolean; renderMedia: boolean;
+	media: Media; consume: boolean; renderMedia: boolean; rotatingAudio: boolean; audioActive: boolean;
 }
 interface ProducerEvent { producerId: string; participantId?: string; user_id?: string; id?: string; }
 
@@ -14,7 +14,10 @@ let socket: Socket | undefined;
 let device: Device | undefined;
 let send: Transport | undefined;
 let receive: Transport | undefined;
+let receivePending: Promise<Transport> | undefined;
 let stream: MediaStream | undefined;
+let audioContext: AudioContext | undefined;
+let audioGain: GainNode | undefined;
 let phase = "idle";
 let joinMs: number | null = null;
 let firstRemoteMediaMs: number | null = null;
@@ -41,10 +44,12 @@ function wire(transport: Transport) {
 
 async function receiveTransport() {
 	if (receive) return receive;
-	const options = await request<TransportOptions>("create_webrtc_transport", { direction: "recv", encryptionEnabled: false });
-	receive = device!.createRecvTransport(options);
-	wire(receive);
-	return receive;
+	if (receivePending) return receivePending;
+	receivePending = (async () => {
+		const options = await request<TransportOptions>("create_webrtc_transport", { direction: "recv", encryptionEnabled: false });
+		receive = device!.createRecvTransport(options); wire(receive); return receive;
+	})();
+	try { return await receivePending; } finally { receivePending = undefined; }
 }
 
 async function subscribe(config: Config, event: ProducerEvent) {
@@ -72,7 +77,15 @@ async function publish(config: Config) {
 	if (config.media === "none") return;
 	const audio = config.media === "audio" || config.media === "both";
 	const video = config.media === "video" || config.media === "both";
-	stream = await navigator.mediaDevices.getUserMedia({ audio, video });
+	if (config.rotatingAudio) {
+		audioContext = new AudioContext();
+		const oscillator = audioContext.createOscillator();
+		audioGain = audioContext.createGain();
+		const destination = audioContext.createMediaStreamDestination();
+		oscillator.frequency.value = 440; audioGain.gain.value = config.audioActive ? 0.15 : 0;
+		oscillator.connect(audioGain).connect(destination); oscillator.start();
+		stream = destination.stream;
+	} else stream = await navigator.mediaDevices.getUserMedia({ audio, video });
 	const options = await request<TransportOptions>("create_webrtc_transport", { direction: "send", encryptionEnabled: false });
 	send = device!.createSendTransport(options); wire(send);
 	send.on("produce", ({ kind, rtpParameters, appData }, done, fail) => {
@@ -115,15 +128,26 @@ async function start(config: Config) {
 
 async function status() {
 	let bytesSent = 0, bytesReceived = 0, packetsLost = 0, packetsReceived = 0;
-	for (const endpoint of producers.values()) for (const report of (await endpoint.getStats()).values())
-		if (report.type === "outbound-rtp" && !report.isRemote) bytesSent += Number(report.bytesSent || 0);
-	for (const endpoint of consumers.values()) for (const report of (await endpoint.getStats()).values()) if (report.type === "inbound-rtp" && !report.isRemote) {
-		bytesReceived += Number(report.bytesReceived || 0); packetsLost += Number(report.packetsLost || 0); packetsReceived += Number(report.packetsReceived || 0);
-	}
+	const producerStats = [], consumerStats = [];
+	for (const [id, endpoint] of producers) { let bytes = 0, totalAudioEnergy: number | null = null;
+		for (const report of (await endpoint.getStats()).values()) {
+			if (report.type === "outbound-rtp" && !report.isRemote) bytes += Number(report.bytesSent || 0);
+			if (report.type === "media-source" && Number.isFinite(report.totalAudioEnergy)) totalAudioEnergy = Number(report.totalAudioEnergy);
+		} bytesSent += bytes; producerStats.push({ id, bytesSent: bytes, totalAudioEnergy }); }
+	for (const [producerId, endpoint] of consumers) { let bytes = 0;
+		for (const report of (await endpoint.getStats()).values()) if (report.type === "inbound-rtp" && !report.isRemote) {
+			bytes += Number(report.bytesReceived || 0); packetsLost += Number(report.packetsLost || 0); packetsReceived += Number(report.packetsReceived || 0);
+		} bytesReceived += bytes; consumerStats.push({ producerId, bytesReceived: bytes }); }
 	if (bytesReceived && firstRemoteMediaMs === null) firstRemoteMediaMs = performance.now() - started;
 	return { phase, joinMs, firstRemoteMediaMs, producerCount: producers.size, consumerCount: consumers.size,
 		bytesSent, bytesReceived, packetsLost, packetsReceived, errors: [...errors],
+		producerStats, consumerStats,
 		capture: stream?.getTracks().map((track) => ({ kind: track.kind, settings: track.getSettings() })) || [] };
+}
+
+function setAudioActive(active: boolean) {
+	if (!audioGain || !audioContext) throw new Error("rotating audio source is unavailable");
+	audioGain.gain.setValueAtTime(active ? 0.15 : 0, audioContext.currentTime);
 }
 
 async function stop() {
@@ -131,9 +155,10 @@ async function stop() {
 	for (const endpoint of consumers.values()) endpoint.close();
 	for (const endpoint of producers.values()) endpoint.close();
 	receive?.close(); send?.close(); stream?.getTracks().forEach((track) => track.stop());
+	await audioContext?.close();
 	if (socket?.connected) socket.emit("leave_room", {}); socket?.disconnect(); phase = "stopped";
 	return { localMediaReleased: !stream || stream.getTracks().every((track) => track.readyState === "ended") };
 }
 
-declare global { interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop } } }
-window.meetLoad = { start, status, stop };
+declare global { interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop; setAudioActive: typeof setAudioActive } } }
+window.meetLoad = { start, status, stop, setAudioActive };

--- a/e2e/meet/load/report.mjs
+++ b/e2e/meet/load/report.mjs
@@ -53,3 +53,35 @@ export function percentile(values, fraction) {
 export function containsJwt(value) {
 	return /eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/.test(JSON.stringify(value));
 }
+
+export function finiteDelta(before, after) {
+	return Number.isFinite(before) && Number.isFinite(after) ? after - before : null;
+}
+
+export function rotationWindows(participantIds, talkers, durationMs, intervalMs) {
+	const windows = [];
+	for (let startMs = 0, index = 0; startMs < durationMs; startMs += intervalMs, index++) {
+		windows.push({ index, startMs, durationMs: Math.min(intervalMs, durationMs - startMs),
+			expectedActiveIds: Array.from({ length: talkers }, (_, offset) =>
+				participantIds[(index * talkers + offset) % participantIds.length]) });
+	}
+	return windows;
+}
+
+export function evaluateRotation(windows, resourceSamples) {
+	const errors = [];
+	for (const window of windows) {
+		for (const participant of window.observations) {
+			if (participant.producerIdsBefore.join() !== participant.producerIdsAfter.join())
+				errors.push(`window ${window.index}: ${participant.userId} producer IDs changed`);
+			if (participant.outboundBytesDelta <= 0)
+				errors.push(`window ${window.index}: ${participant.userId} outbound RTP did not advance`);
+			if (participant.expectedInbound > 0 && participant.inboundAdvanced !== participant.expectedInbound)
+				errors.push(`window ${window.index}: ${participant.userId} inbound RTP advanced for ${participant.inboundAdvanced}/${participant.expectedInbound} publishers`);
+		}
+	}
+	const expected = resourceSamples[0];
+	if (resourceSamples.some((sample) => sample.producers !== expected.producers || sample.consumers !== expected.consumers))
+		errors.push("producer or consumer resources changed during rotation");
+	return errors;
+}

--- a/e2e/meet/load/report.test.mjs
+++ b/e2e/meet/load/report.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { boundedInteger, containsJwt, delta, parseResourceMetrics, percentile, targetMetadata } from "./report.mjs";
+import { boundedInteger, containsJwt, delta, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 test("target safety defaults to loopback and rejects shared or remote targets", () => {
 	assert.deepEqual(targetMetadata("http://127.0.0.1:4317/", false), {
@@ -10,6 +10,28 @@ test("target safety defaults to loopback and rejects shared or remote targets", 
 	assert.throws(() => targetMetadata("http://127.0.0.1:3000", false), /shared SFU/);
 	assert.throws(() => targetMetadata("https://sfu.example.com", false), /allow-remote-target/);
 	assert.equal(targetMetadata("https://sfu.example.com/base", true).loopback, false);
+});
+
+test("rotation schedule selects bounded talkers deterministically and keeps the final partial window", () => {
+	assert.deepEqual(rotationWindows(["a", "b", "c", "d"], 2, 2500, 1000), [
+		{ index: 0, startMs: 0, durationMs: 1000, expectedActiveIds: ["a", "b"] },
+		{ index: 1, startMs: 1000, durationMs: 1000, expectedActiveIds: ["c", "d"] },
+		{ index: 2, startMs: 2000, durationMs: 500, expectedActiveIds: ["a", "b"] },
+	]);
+});
+
+test("rotation evaluation uses observed RTP continuity, stable IDs, and stable resources", () => {
+	const participant = { userId: "a", producerIdsBefore: ["p1"], producerIdsAfter: ["p1"],
+		outboundBytesDelta: 10, expectedInbound: 1, inboundAdvanced: 1 };
+	assert.deepEqual(evaluateRotation([{ index: 0, observations: [participant] }],
+		[{ producers: 2, consumers: 2 }, { producers: 2, consumers: 2 }]), []);
+	assert.match(evaluateRotation([{ index: 0, observations: [{ ...participant, producerIdsAfter: ["p2"], outboundBytesDelta: 0 }] }],
+		[{ producers: 2, consumers: 2 }, { producers: 3, consumers: 2 }]).join("; "), /producer IDs changed.*outbound RTP.*resources changed/);
+});
+
+test("optional audio-energy deltas remain null when Chromium omits the stat", () => {
+	assert.equal(finiteDelta(0.25, 0.75), 0.5);
+	assert.equal(finiteDelta(undefined, undefined), null);
 });
 
 test("bounds reject fractions and values outside the declared range", () => {

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -143,11 +143,17 @@ try {
 		report.rotation = { source: "Web Audio oscillator -> GainNode -> MediaStreamDestination", frequencyHz: 440, activeGain: 0.15,
 			silenceGain: 0, windows: [], limitations: "Gain schedule is configured locally; audio energy is reported only when Chromium exposes totalAudioEnergy." };
 		const resourceSamples = [hold.resources];
+		let previousWindow;
 		for (const window of schedule) {
 			await Promise.all(pages.map((page, index) => page.evaluate(({ active }) => window.meetLoad.setAudioActive(active),
 				{ active: window.expectedActiveIds.includes(participants[index].userId) })));
+			const actualStartedAt = new Date();
+			if (previousWindow) {
+				previousWindow.actualEndedAt = actualStartedAt.toISOString();
+				previousWindow.actualDurationMs = actualStartedAt - new Date(previousWindow.actualStartedAt);
+			}
 			const before = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
-			const actualStartedAt = new Date().toISOString(); await wait(window.durationMs);
+			await wait(window.durationMs);
 			const after = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
 			const rotationSample = await sample(`rotation-${window.index}`); resourceSamples.push(rotationSample.resources);
 			const observations = participants.map((participant, index) => ({ userId: participant.userId,
@@ -157,8 +163,13 @@ try {
 				outboundAudioEnergyDelta: finiteDelta(before[index].producerStats[0]?.totalAudioEnergy, after[index].producerStats[0]?.totalAudioEnergy),
 				expectedInbound: values.consume === "all" ? count - 1 : 0,
 				inboundAdvanced: after[index].consumerStats.filter((entry) => entry.bytesReceived > (before[index].consumerStats.find(({ producerId }) => producerId === entry.producerId)?.bytesReceived ?? 0)).length }));
-			report.rotation.windows.push({ ...window, actualStartedAt, observations });
+			previousWindow = { ...window, actualStartedAt: actualStartedAt.toISOString(), observations };
+			report.rotation.windows.push(previousWindow);
 		}
+		await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.setAudioActive(false))));
+		const actualEndedAt = new Date();
+		previousWindow.actualEndedAt = actualEndedAt.toISOString();
+		previousWindow.actualDurationMs = actualEndedAt - new Date(previousWindow.actualStartedAt);
 		report.errors.push(...evaluateRotation(report.rotation.windows, resourceSamples));
 	} else await wait(durationSeconds * 1000);
 	report.participants = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { createServer } from "vite";
-import { boundedInteger, containsJwt, delta, parseResourceMetrics, percentile, targetMetadata } from "./report.mjs";
+import { boundedInteger, containsJwt, delta, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const { values } = parseArgs({ options: {
@@ -16,6 +16,9 @@ const { values } = parseArgs({ options: {
 	site: { type: "string", default: "load.test" },
 	count: { type: "string", default: "2" },
 	media: { type: "string", default: "none" },
+	scenario: { type: "string", default: "uniform" },
+	talkers: { type: "string" },
+	"rotation-interval-ms": { type: "string", default: "1000" },
 	consume: { type: "string", default: "all" },
 	"render-media": { type: "boolean", default: false },
 	"ramp-ms": { type: "string", default: "250" },
@@ -31,7 +34,11 @@ const count = boundedInteger(values.count, "count", 1, 150);
 const durationSeconds = boundedInteger(values["duration-seconds"], "duration-seconds", 1, 600);
 const cleanupSeconds = boundedInteger(values["cleanup-seconds"], "cleanup-seconds", 1, 90);
 const rampMs = boundedInteger(values["ramp-ms"], "ramp-ms", 0, 5000);
+const rotationIntervalMs = boundedInteger(values["rotation-interval-ms"], "rotation-interval-ms", 250, 60_000);
+const talkers = boundedInteger(values.talkers ?? String(Math.min(10, count)), "talkers", 1, count);
 if (!["none", "audio", "video", "both"].includes(values.media)) throw new Error("media must be none, audio, video, or both");
+if (!["uniform", "rotating-audio"].includes(values.scenario)) throw new Error("scenario must be uniform or rotating-audio");
+if (values.scenario === "rotating-audio" && values.media !== "audio") throw new Error("rotating-audio requires --media audio");
 if (!["all", "none"].includes(values.consume)) throw new Error("consume must be all or none");
 if (!/^load-[0-9a-f-]{36}$/.test(values["meeting-id"]) || !/^load(?:[.-][a-z0-9-]+)*\.test$/i.test(values.site)) {
 	throw new Error("Use the generated load UUID room and a load*.test site namespace");
@@ -48,6 +55,7 @@ const report = {
 	startedAt: new Date().toISOString(),
 	target,
 	config: { count, durationSeconds, cleanupSeconds, rampMs, media: values.media, consume: values.consume,
+		scenario: values.scenario, talkers, rotationIntervalMs,
 		renderMedia: values["render-media"], meetingId: values["meeting-id"], site: values.site,
 		authSource: values["token-file"] ? "token-file" : "environment-signed" },
 	host: { hostname: hostname(), platform: platform(), release: release(), node: process.version,
@@ -124,12 +132,35 @@ try {
 		page.on("pageerror", () => report.errors.push(`participant ${index + 1}: page error`));
 		await page.goto(clientUrl, { waitUntil: "networkidle", timeout: 15_000 });
 		await page.evaluate((config) => window.meetLoad.start(config), { ...participant, sfuUrl: target.endpoint,
-			meetingId: values["meeting-id"], media: values.media, consume: values.consume === "all", renderMedia: values["render-media"] });
+			meetingId: values["meeting-id"], media: values.media, consume: values.consume === "all", renderMedia: values["render-media"],
+			rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
 		if (rampMs) await wait(rampMs);
 	}
 	const hold = await sample("hold");
 	if (hold.health.rooms !== 1 || hold.health.peers !== count) throw new Error("SFU hold counts do not match this run");
-	await wait(durationSeconds * 1000);
+	if (values.scenario === "rotating-audio") {
+		const schedule = rotationWindows(participants.map(({ userId }) => userId), talkers, durationSeconds * 1000, rotationIntervalMs);
+		report.rotation = { source: "Web Audio oscillator -> GainNode -> MediaStreamDestination", frequencyHz: 440, activeGain: 0.15,
+			silenceGain: 0, windows: [], limitations: "Gain schedule is configured locally; audio energy is reported only when Chromium exposes totalAudioEnergy." };
+		const resourceSamples = [hold.resources];
+		for (const window of schedule) {
+			await Promise.all(pages.map((page, index) => page.evaluate(({ active }) => window.meetLoad.setAudioActive(active),
+				{ active: window.expectedActiveIds.includes(participants[index].userId) })));
+			const before = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
+			const actualStartedAt = new Date().toISOString(); await wait(window.durationMs);
+			const after = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
+			const rotationSample = await sample(`rotation-${window.index}`); resourceSamples.push(rotationSample.resources);
+			const observations = participants.map((participant, index) => ({ userId: participant.userId,
+				expectedActive: window.expectedActiveIds.includes(participant.userId),
+				producerIdsBefore: before[index].producerStats.map(({ id }) => id).sort(), producerIdsAfter: after[index].producerStats.map(({ id }) => id).sort(),
+				outboundBytesDelta: after[index].bytesSent - before[index].bytesSent,
+				outboundAudioEnergyDelta: finiteDelta(before[index].producerStats[0]?.totalAudioEnergy, after[index].producerStats[0]?.totalAudioEnergy),
+				expectedInbound: values.consume === "all" ? count - 1 : 0,
+				inboundAdvanced: after[index].consumerStats.filter((entry) => entry.bytesReceived > (before[index].consumerStats.find(({ producerId }) => producerId === entry.producerId)?.bytesReceived ?? 0)).length }));
+			report.rotation.windows.push({ ...window, actualStartedAt, observations });
+		}
+		report.errors.push(...evaluateRotation(report.rotation.windows, resourceSamples));
+	} else await wait(durationSeconds * 1000);
 	report.participants = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
 	for (const [index, participant] of report.participants.entries()) {
 		if (participant.phase !== "running") report.errors.push(`participant ${index + 1}: not running`);


### PR DESCRIPTION
## Behavior

- add a deterministic rotating-audio scenario backed by persistent Web Audio producers
- rotate configured active talkers by gain without pausing or recreating producers
- record per-window outbound audio energy when available, RTP continuity, producer identity, and SFU resource stability

## Scope

This changes only the Meet load harness, its report helpers/tests, and operator documentation. It does not alter production runtime configuration or dependencies.

## Limitations

Configured gain is not proof of acoustic delivery. Chromium may omit `totalAudioEnergy`, in which case reports preserve `null`; RTP and SFU resource observations remain synthetic, unqualified measurement evidence.

## Follow-up Fix

- record actual gain-state start, end, and elapsed duration so report timing includes stats and metrics overhead