### PR TITLE
test(meet): measure representative camera delivery

### DIFF
--- a/e2e/meet/load/README.md
+++ b/e2e/meet/load/README.md
@@ -32,6 +32,20 @@ SFU_LOAD_JWT_SECRET=local-secret SFU_METRICS_TOKEN=local-metrics \
   --output /tmp/meet-load-local.json
 ```
 
+`--scenario representative-camera` publishes deterministic first `--cameras`
+(default `min(40, count)`, maximum 40) Participant Connections and leaves the rest
+idle. Each camera is a moving, time-coded 1280x720 canvas captured at a requested 30
+fps; it does not use Chromium's generic fake camera. Reports keep requested source
+properties separate from observed track settings, sender `outbound-rtp` bytes,
+`framesEncoded` and fps, `media-source` dimensions/fps, and every eager receiver's
+`inbound-rtp` bytes, decoded frames, dimensions, and fps. Missing browser stats are
+`null`; short runs do not establish bitrate or sustained fps. Producer IDs, enabled
+and unpaused state, RTP/frame progression, decoded delivery when exposed, and SFU
+Producer/Consumer counts are checked across the hold window. One muted 1x1 off-screen
+video probe per Participant Connection drives playback and exposes Chromium's browser
+decoded-frame count; this avoids O(N) rendered elements. Full rendering remains off
+unless explicitly requested.
+
 `--media audio|video|both` uses Chromium's synthetic fake devices. Reports retain
 actual capture settings and observed RTP byte counters, but synthetic devices do not
 model representative speech/cameras and requested settings do not prove delivered
@@ -57,8 +71,8 @@ cleanup outcome.
 
 ## Progressive Scenarios
 
-Admission plus idle hold, uniform synthetic media, and rotating audio are implemented.
-The remaining representative suite is forty 720p30 cameras, two 1080p30 screens
+Admission plus idle hold, uniform synthetic media, rotating audio, and representative
+camera measurement are implemented. The remaining representative suite is two 1080p30 screens
 capped at 4 Mbps, and one Recorder Endpoint. Pinned representative video, actual
 delivered video constraints, screen publication, and recorder support must be
 implemented and measured before those properties are claimed.

--- a/e2e/meet/load/client.ts
+++ b/e2e/meet/load/client.ts
@@ -7,6 +7,7 @@ type Media = "audio" | "video" | "both" | "none";
 interface Config {
 	sfuUrl: string; meetingId: string; token: string; userId: string; name: string;
 	media: Media; consume: boolean; renderMedia: boolean; rotatingAudio: boolean; audioActive: boolean;
+	representativeCamera: boolean;
 }
 interface ProducerEvent { producerId: string; participantId?: string; user_id?: string; id?: string; }
 
@@ -18,6 +19,8 @@ let receivePending: Promise<Transport> | undefined;
 let stream: MediaStream | undefined;
 let audioContext: AudioContext | undefined;
 let audioGain: GainNode | undefined;
+let cameraCanvas: HTMLCanvasElement | undefined;
+let cameraTimer: number | undefined;
 let phase = "idle";
 let joinMs: number | null = null;
 let firstRemoteMediaMs: number | null = null;
@@ -25,6 +28,7 @@ let started = 0;
 let stopping = false;
 const producers = new Map<string, Producer>();
 const consumers = new Map<string, Consumer>();
+const renderedVideos = new Map<string, HTMLVideoElement>();
 const pending = new Map<string, Promise<void>>();
 const errors: string[] = [];
 
@@ -63,9 +67,13 @@ async function subscribe(config: Config, event: ProducerEvent) {
 		const consumer = await transport.consume(options);
 		if (stopping) return consumer.close();
 		consumers.set(producerId, consumer);
-		if (config.renderMedia) {
+		if (config.renderMedia || (config.representativeCamera && consumer.kind === "video" && !renderedVideos.size)) {
 			const element = document.createElement(consumer.kind);
 			element.autoplay = true; element.muted = true; element.srcObject = new MediaStream([consumer.track]);
+			if (consumer.kind === "video") {
+				const video = element as HTMLVideoElement; renderedVideos.set(producerId, video);
+				if (!config.renderMedia) Object.assign(video.style, { position: "fixed", left: "-2px", width: "1px", height: "1px" });
+			}
 			document.querySelector("#media")?.append(element); void element.play();
 		}
 	})();
@@ -85,6 +93,16 @@ async function publish(config: Config) {
 		oscillator.frequency.value = 440; audioGain.gain.value = config.audioActive ? 0.15 : 0;
 		oscillator.connect(audioGain).connect(destination); oscillator.start();
 		stream = destination.stream;
+	} else if (config.representativeCamera) {
+		cameraCanvas = document.createElement("canvas"); cameraCanvas.width = 1280; cameraCanvas.height = 720;
+		const context = cameraCanvas.getContext("2d")!; let frame = 0;
+		const draw = () => {
+			const hue = frame * 3 % 360; context.fillStyle = `hsl(${hue} 60% 35%)`; context.fillRect(0, 0, 1280, 720);
+			context.fillStyle = "white"; context.font = "48px monospace"; context.fillText(`${config.userId} frame ${frame}`, 40, 80);
+			context.fillRect(frame * 17 % 1180, 300, 100, 100); frame++;
+		};
+		draw(); cameraTimer = window.setInterval(draw, 1000 / 30);
+		stream = cameraCanvas.captureStream(30);
 	} else stream = await navigator.mediaDevices.getUserMedia({ audio, video });
 	const options = await request<TransportOptions>("create_webrtc_transport", { direction: "send", encryptionEnabled: false });
 	send = device!.createSendTransport(options); wire(send);
@@ -129,17 +147,34 @@ async function start(config: Config) {
 async function status() {
 	let bytesSent = 0, bytesReceived = 0, packetsLost = 0, packetsReceived = 0;
 	const producerStats = [], consumerStats = [];
-	for (const [id, endpoint] of producers) { let bytes = 0, totalAudioEnergy: number | null = null;
+	for (const [id, endpoint] of producers) { let bytes = 0, framesEncoded: number | null = null, framesPerSecond: number | null = null;
+		let totalAudioEnergy: number | null = null, sourceWidth: number | null = null, sourceHeight: number | null = null, sourceFramesPerSecond: number | null = null;
 		for (const report of (await endpoint.getStats()).values()) {
-			if (report.type === "outbound-rtp" && !report.isRemote) bytes += Number(report.bytesSent || 0);
-			if (report.type === "media-source" && Number.isFinite(report.totalAudioEnergy)) totalAudioEnergy = Number(report.totalAudioEnergy);
-		} bytesSent += bytes; producerStats.push({ id, bytesSent: bytes, totalAudioEnergy }); }
-	for (const [producerId, endpoint] of consumers) { let bytes = 0;
+			if (report.type === "outbound-rtp" && !report.isRemote) {
+				bytes += Number(report.bytesSent || 0); framesEncoded = Number.isFinite(report.framesEncoded) ? Number(report.framesEncoded) : framesEncoded;
+				framesPerSecond = Number.isFinite(report.framesPerSecond) ? Number(report.framesPerSecond) : framesPerSecond;
+			}
+			if (report.type === "media-source") {
+				totalAudioEnergy = Number.isFinite(report.totalAudioEnergy) ? Number(report.totalAudioEnergy) : totalAudioEnergy;
+				sourceWidth = Number.isFinite(report.width) ? Number(report.width) : sourceWidth; sourceHeight = Number.isFinite(report.height) ? Number(report.height) : sourceHeight;
+				sourceFramesPerSecond = Number.isFinite(report.framesPerSecond) ? Number(report.framesPerSecond) : sourceFramesPerSecond;
+			}
+		} bytesSent += bytes; producerStats.push({ id, kind: endpoint.kind, paused: endpoint.paused, trackEnabled: endpoint.track?.enabled,
+			trackReadyState: endpoint.track?.readyState, bytesSent: bytes, framesEncoded, framesPerSecond, totalAudioEnergy,
+			mediaSource: { width: sourceWidth, height: sourceHeight, framesPerSecond: sourceFramesPerSecond } }); }
+	for (const [producerId, endpoint] of consumers) { let bytes = 0, framesDecoded: number | null = null, frameWidth: number | null = null;
+		let frameHeight: number | null = null, framesPerSecond: number | null = null;
 		for (const report of (await endpoint.getStats()).values()) if (report.type === "inbound-rtp" && !report.isRemote) {
 			bytes += Number(report.bytesReceived || 0); packetsLost += Number(report.packetsLost || 0); packetsReceived += Number(report.packetsReceived || 0);
-		} bytesReceived += bytes; consumerStats.push({ producerId, bytesReceived: bytes }); }
+			framesDecoded = Number.isFinite(report.framesDecoded) ? Number(report.framesDecoded) : framesDecoded;
+			frameWidth = Number.isFinite(report.frameWidth) ? Number(report.frameWidth) : frameWidth; frameHeight = Number.isFinite(report.frameHeight) ? Number(report.frameHeight) : frameHeight;
+			framesPerSecond = Number.isFinite(report.framesPerSecond) ? Number(report.framesPerSecond) : framesPerSecond;
+		} bytesReceived += bytes; consumerStats.push({ producerId, kind: endpoint.kind, paused: endpoint.paused, trackEnabled: endpoint.track.enabled,
+			trackReadyState: endpoint.track.readyState, bytesReceived: bytes, framesDecoded, frameWidth, frameHeight, framesPerSecond,
+			browserDecodedFrames: renderedVideos.get(producerId)?.webkitDecodedFrameCount ?? null }); }
 	if (bytesReceived && firstRemoteMediaMs === null) firstRemoteMediaMs = performance.now() - started;
 	return { phase, joinMs, firstRemoteMediaMs, producerCount: producers.size, consumerCount: consumers.size,
+		sendTransportState: send?.connectionState ?? null, receiveTransportState: receive?.connectionState ?? null,
 		bytesSent, bytesReceived, packetsLost, packetsReceived, errors: [...errors],
 		producerStats, consumerStats,
 		capture: stream?.getTracks().map((track) => ({ kind: track.kind, settings: track.getSettings() })) || [] };
@@ -152,13 +187,18 @@ function setAudioActive(active: boolean) {
 
 async function stop() {
 	stopping = true; await Promise.allSettled(pending.values());
+	if (cameraTimer !== undefined) window.clearInterval(cameraTimer);
 	for (const endpoint of consumers.values()) endpoint.close();
 	for (const endpoint of producers.values()) endpoint.close();
 	receive?.close(); send?.close(); stream?.getTracks().forEach((track) => track.stop());
 	await audioContext?.close();
 	if (socket?.connected) socket.emit("leave_room", {}); socket?.disconnect(); phase = "stopped";
+	cameraCanvas?.remove();
 	return { localMediaReleased: !stream || stream.getTracks().every((track) => track.readyState === "ended") };
 }
 
-declare global { interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop; setAudioActive: typeof setAudioActive } } }
+declare global {
+	interface HTMLVideoElement { webkitDecodedFrameCount?: number }
+	interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop; setAudioActive: typeof setAudioActive } }
+}
 window.meetLoad = { start, status, stop, setAudioActive };

--- a/e2e/meet/load/client.ts
+++ b/e2e/meet/load/client.ts
@@ -180,6 +180,10 @@ async function status() {
 		capture: stream?.getTracks().map((track) => ({ kind: track.kind, settings: track.getSettings() })) || [] };
 }
 
+function endpointCounts() {
+	return { producerCount: producers.size, consumerCount: consumers.size };
+}
+
 function setAudioActive(active: boolean) {
 	if (!audioGain || !audioContext) throw new Error("rotating audio source is unavailable");
 	audioGain.gain.setValueAtTime(active ? 0.15 : 0, audioContext.currentTime);
@@ -199,6 +203,6 @@ async function stop() {
 
 declare global {
 	interface HTMLVideoElement { webkitDecodedFrameCount?: number }
-	interface Window { meetLoad: { start: typeof start; status: typeof status; stop: typeof stop; setAudioActive: typeof setAudioActive } }
+	interface Window { meetLoad: { start: typeof start; status: typeof status; endpointCounts: typeof endpointCounts; stop: typeof stop; setAudioActive: typeof setAudioActive } }
 }
-window.meetLoad = { start, status, stop, setAudioActive };
+window.meetLoad = { start, status, endpointCounts, stop, setAudioActive };

--- a/e2e/meet/load/report.mjs
+++ b/e2e/meet/load/report.mjs
@@ -85,3 +85,26 @@ export function evaluateRotation(windows, resourceSamples) {
 		errors.push("producer or consumer resources changed during rotation");
 	return errors;
 }
+
+export function evaluateCameras(observations, resourceSamples, expected) {
+	const errors = [];
+	for (const participant of observations) {
+		if (participant.publisher) {
+			if (participant.producerIdsBefore.join() !== participant.producerIdsAfter.join() || participant.producerIdsAfter.length !== 1)
+				errors.push(`${participant.userId}: camera Producer was not stable`);
+			if (!participant.producerReady) errors.push(`${participant.userId}: camera Producer was not enabled and unpaused`);
+			if (participant.outboundBytesDelta <= 0) errors.push(`${participant.userId}: camera outbound RTP did not advance`);
+			if (participant.framesEncodedDelta !== null && participant.framesEncodedDelta <= 0)
+				errors.push(`${participant.userId}: camera framesEncoded did not advance`);
+		} else if (participant.producerIdsAfter.length) errors.push(`${participant.userId}: idle participant published media`);
+		if (participant.receiverCount !== participant.expectedReceivers)
+			errors.push(`${participant.userId}: received ${participant.receiverCount}/${participant.expectedReceivers} camera tracks`);
+		if (participant.inboundAdvanced !== participant.expectedReceivers)
+			errors.push(`${participant.userId}: inbound RTP advanced for ${participant.inboundAdvanced}/${participant.expectedReceivers} cameras`);
+		if (participant.decodedAvailable && participant.decodedAdvanced !== participant.expectedReceivers)
+			errors.push(`${participant.userId}: decoded frames advanced for ${participant.decodedAdvanced}/${participant.expectedReceivers} cameras`);
+	}
+	if (resourceSamples.some((sample) => sample.producers !== expected.producers || sample.consumers !== expected.consumers))
+		errors.push("camera Producer or Consumer resources were not stable at expected counts");
+	return errors;
+}

--- a/e2e/meet/load/report.mjs
+++ b/e2e/meet/load/report.mjs
@@ -101,10 +101,16 @@ export function evaluateCameras(observations, resourceSamples, expected) {
 			errors.push(`${participant.userId}: received ${participant.receiverCount}/${participant.expectedReceivers} camera tracks`);
 		if (participant.inboundAdvanced !== participant.expectedReceivers)
 			errors.push(`${participant.userId}: inbound RTP advanced for ${participant.inboundAdvanced}/${participant.expectedReceivers} cameras`);
-		if (participant.decodedAvailable && participant.decodedAdvanced !== participant.expectedReceivers)
-			errors.push(`${participant.userId}: decoded frames advanced for ${participant.decodedAdvanced}/${participant.expectedReceivers} cameras`);
+		if (participant.decodedAdvanced !== participant.decodedObserved)
+			errors.push(`${participant.userId}: decoded frames advanced for ${participant.decodedAdvanced}/${participant.decodedObserved} cameras`);
 	}
 	if (resourceSamples.some((sample) => sample.producers !== expected.producers || sample.consumers !== expected.consumers))
 		errors.push("camera Producer or Consumer resources were not stable at expected counts");
 	return errors;
+}
+
+export function cameraDeliveryReady(statuses, cameras, count) {
+	return statuses.length === count && statuses.every((status, index) =>
+		status.producerCount === (index < cameras ? 1 : 0) &&
+		status.consumerCount === cameras - (index < cameras ? 1 : 0));
 }

--- a/e2e/meet/load/report.test.mjs
+++ b/e2e/meet/load/report.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { boundedInteger, containsJwt, delta, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { boundedInteger, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 test("target safety defaults to loopback and rejects shared or remote targets", () => {
 	assert.deepEqual(targetMetadata("http://127.0.0.1:4317/", false), {
@@ -32,6 +32,16 @@ test("rotation evaluation uses observed RTP continuity, stable IDs, and stable r
 test("optional audio-energy deltas remain null when Chromium omits the stat", () => {
 	assert.equal(finiteDelta(0.25, 0.75), 0.5);
 	assert.equal(finiteDelta(undefined, undefined), null);
+});
+
+test("camera evaluation independently requires stable progressing publication, delivery, decode, and resources", () => {
+	const publisher = { userId: "a", publisher: true, producerIdsBefore: ["p1"], producerIdsAfter: ["p1"], producerReady: true,
+		outboundBytesDelta: 10, framesEncodedDelta: 3, expectedReceivers: 1, receiverCount: 1, inboundAdvanced: 1,
+		decodedAvailable: true, decodedAdvanced: 1 };
+	assert.deepEqual(evaluateCameras([publisher], [{ producers: 2, consumers: 2 }], { producers: 2, consumers: 2 }), []);
+	assert.match(evaluateCameras([{ ...publisher, producerIdsAfter: ["p2"], outboundBytesDelta: 0, framesEncodedDelta: 0,
+		receiverCount: 0, inboundAdvanced: 0, decodedAdvanced: 0 }], [{ producers: 1, consumers: 0 }],
+	{ producers: 2, consumers: 2 }).join("; "), /not stable.*outbound RTP.*framesEncoded.*received 0\/1.*inbound RTP.*decoded frames.*resources/);
 });
 
 test("bounds reject fractions and values outside the declared range", () => {

--- a/e2e/meet/load/report.test.mjs
+++ b/e2e/meet/load/report.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { boundedInteger, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 test("target safety defaults to loopback and rejects shared or remote targets", () => {
 	assert.deepEqual(targetMetadata("http://127.0.0.1:4317/", false), {
@@ -37,11 +37,19 @@ test("optional audio-energy deltas remain null when Chromium omits the stat", ()
 test("camera evaluation independently requires stable progressing publication, delivery, decode, and resources", () => {
 	const publisher = { userId: "a", publisher: true, producerIdsBefore: ["p1"], producerIdsAfter: ["p1"], producerReady: true,
 		outboundBytesDelta: 10, framesEncodedDelta: 3, expectedReceivers: 1, receiverCount: 1, inboundAdvanced: 1,
-		decodedAvailable: true, decodedAdvanced: 1 };
+		decodedObserved: 1, decodedAdvanced: 1 };
 	assert.deepEqual(evaluateCameras([publisher], [{ producers: 2, consumers: 2 }], { producers: 2, consumers: 2 }), []);
 	assert.match(evaluateCameras([{ ...publisher, producerIdsAfter: ["p2"], outboundBytesDelta: 0, framesEncodedDelta: 0,
 		receiverCount: 0, inboundAdvanced: 0, decodedAdvanced: 0 }], [{ producers: 1, consumers: 0 }],
 	{ producers: 2, consumers: 2 }).join("; "), /not stable.*outbound RTP.*framesEncoded.*received 0\/1.*inbound RTP.*decoded frames.*resources/);
+	assert.match(evaluateCameras([{ ...publisher, expectedReceivers: 2, receiverCount: 2, inboundAdvanced: 2,
+		decodedObserved: 1, decodedAdvanced: 0 }], [{ producers: 2, consumers: 2 }],
+	{ producers: 2, consumers: 2 }).join("; "), /decoded frames advanced for 0\/1 cameras/);
+});
+
+test("camera delivery waits for every expected producer and consumer", () => {
+	assert.equal(cameraDeliveryReady([{ producerCount: 1, consumerCount: 1 }, { producerCount: 1, consumerCount: 1 }], 2, 2), true);
+	assert.equal(cameraDeliveryReady([{ producerCount: 1, consumerCount: 0 }, { producerCount: 1, consumerCount: 1 }], 2, 2), false);
 });
 
 test("bounds reject fractions and values outside the declared range", () => {

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { createServer } from "vite";
-import { boundedInteger, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const { values } = parseArgs({ options: {
@@ -140,6 +140,13 @@ try {
 			representativeCamera, rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
 		if (rampMs) await wait(rampMs);
 	}
+	if (values.scenario === "representative-camera" && values.consume === "all") {
+		const deadline = Date.now() + 15_000;
+		while (!cameraDeliveryReady(await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status()))), cameras, count)) {
+			if (Date.now() >= deadline) throw new Error("Camera delivery did not converge before the hold sample");
+			await wait(100);
+		}
+	}
 	const hold = await sample("hold");
 	if (hold.health.rooms !== 1 || hold.health.peers !== count) throw new Error("SFU hold counts do not match this run");
 	if (values.scenario === "rotating-audio") {
@@ -194,7 +201,7 @@ try {
 				outboundBytesDelta: afterVideo.reduce((sum, entry) => sum + entry.bytesSent, 0) - beforeVideo.reduce((sum, entry) => sum + entry.bytesSent, 0),
 				framesEncodedDelta: finiteDelta(beforeVideo[0]?.framesEncoded, afterVideo[0]?.framesEncoded), receiverCount: afterConsumers.length,
 				inboundAdvanced: afterConsumers.filter((entry) => entry.bytesReceived > (beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.bytesReceived ?? 0)).length,
-				decodedAvailable: decoded.every((value) => value !== null), decodedAdvanced: decoded.filter((value) => value > 0).length };
+				decodedObserved: decoded.filter((value) => value !== null).length, decodedAdvanced: decoded.filter((value) => value > 0).length };
 		});
 		report.camera = { requested: { width: 1280, height: 720, framesPerSecond: 30 }, source: "deterministic time-coded moving canvas",
 			window: { durationSeconds, observations }, limitations: "Requested/source and observed sender/receiver stats are separate; unavailable Chromium stats remain null." };

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -142,7 +142,7 @@ try {
 	}
 	if (values.scenario === "representative-camera" && values.consume === "all") {
 		const deadline = Date.now() + 15_000;
-		while (!cameraDeliveryReady(await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status()))), cameras, count)) {
+		while (!cameraDeliveryReady(await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.endpointCounts()))), cameras, count)) {
 			if (Date.now() >= deadline) throw new Error("Camera delivery did not converge before the hold sample");
 			await wait(100);
 		}

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { createServer } from "vite";
-import { boundedInteger, containsJwt, delta, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { boundedInteger, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const { values } = parseArgs({ options: {
@@ -18,6 +18,7 @@ const { values } = parseArgs({ options: {
 	media: { type: "string", default: "none" },
 	scenario: { type: "string", default: "uniform" },
 	talkers: { type: "string" },
+	cameras: { type: "string" },
 	"rotation-interval-ms": { type: "string", default: "1000" },
 	consume: { type: "string", default: "all" },
 	"render-media": { type: "boolean", default: false },
@@ -36,9 +37,11 @@ const cleanupSeconds = boundedInteger(values["cleanup-seconds"], "cleanup-second
 const rampMs = boundedInteger(values["ramp-ms"], "ramp-ms", 0, 5000);
 const rotationIntervalMs = boundedInteger(values["rotation-interval-ms"], "rotation-interval-ms", 250, 60_000);
 const talkers = boundedInteger(values.talkers ?? String(Math.min(10, count)), "talkers", 1, count);
+const cameras = boundedInteger(values.cameras ?? String(Math.min(40, count)), "cameras", 1, Math.min(40, count));
 if (!["none", "audio", "video", "both"].includes(values.media)) throw new Error("media must be none, audio, video, or both");
-if (!["uniform", "rotating-audio"].includes(values.scenario)) throw new Error("scenario must be uniform or rotating-audio");
+if (!["uniform", "rotating-audio", "representative-camera"].includes(values.scenario)) throw new Error("scenario must be uniform, rotating-audio, or representative-camera");
 if (values.scenario === "rotating-audio" && values.media !== "audio") throw new Error("rotating-audio requires --media audio");
+if (values.scenario === "representative-camera" && values.media !== "none") throw new Error("representative-camera determines media; omit --media");
 if (!["all", "none"].includes(values.consume)) throw new Error("consume must be all or none");
 if (!/^load-[0-9a-f-]{36}$/.test(values["meeting-id"]) || !/^load(?:[.-][a-z0-9-]+)*\.test$/i.test(values.site)) {
 	throw new Error("Use the generated load UUID room and a load*.test site namespace");
@@ -55,7 +58,7 @@ const report = {
 	startedAt: new Date().toISOString(),
 	target,
 	config: { count, durationSeconds, cleanupSeconds, rampMs, media: values.media, consume: values.consume,
-		scenario: values.scenario, talkers, rotationIntervalMs,
+		scenario: values.scenario, talkers, rotationIntervalMs, cameras,
 		renderMedia: values["render-media"], meetingId: values["meeting-id"], site: values.site,
 		authSource: values["token-file"] ? "token-file" : "environment-signed" },
 	host: { hostname: hostname(), platform: platform(), release: release(), node: process.version,
@@ -131,9 +134,10 @@ try {
 		const page = await context.newPage(); pages.push(page);
 		page.on("pageerror", () => report.errors.push(`participant ${index + 1}: page error`));
 		await page.goto(clientUrl, { waitUntil: "networkidle", timeout: 15_000 });
+		const representativeCamera = values.scenario === "representative-camera" && index < cameras;
 		await page.evaluate((config) => window.meetLoad.start(config), { ...participant, sfuUrl: target.endpoint,
-			meetingId: values["meeting-id"], media: values.media, consume: values.consume === "all", renderMedia: values["render-media"],
-			rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
+			meetingId: values["meeting-id"], media: representativeCamera ? "video" : values.media, consume: values.consume === "all", renderMedia: values["render-media"],
+			representativeCamera, rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
 		if (rampMs) await wait(rampMs);
 	}
 	const hold = await sample("hold");
@@ -171,12 +175,37 @@ try {
 		previousWindow.actualEndedAt = actualEndedAt.toISOString();
 		previousWindow.actualDurationMs = actualEndedAt - new Date(previousWindow.actualStartedAt);
 		report.errors.push(...evaluateRotation(report.rotation.windows, resourceSamples));
+	} else if (values.scenario === "representative-camera") {
+		const before = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
+		await wait(durationSeconds * 1000);
+		const after = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
+		const cameraSample = await sample("camera-window");
+		const expectedConsumers = values.consume === "all" ? cameras * (count - 1) : 0;
+		const observations = participants.map((participant, index) => {
+			const beforeVideo = before[index].producerStats.filter(({ kind }) => kind === "video");
+			const afterVideo = after[index].producerStats.filter(({ kind }) => kind === "video");
+			const beforeConsumers = before[index].consumerStats.filter(({ kind }) => kind === "video");
+			const afterConsumers = after[index].consumerStats.filter(({ kind }) => kind === "video");
+			const expectedReceivers = values.consume === "all" ? cameras - (index < cameras ? 1 : 0) : 0;
+			const decoded = afterConsumers.map((entry) => finiteDelta(beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.framesDecoded, entry.framesDecoded));
+			return { userId: participant.userId, publisher: index < cameras, expectedReceivers,
+				producerIdsBefore: beforeVideo.map(({ id }) => id).sort(), producerIdsAfter: afterVideo.map(({ id }) => id).sort(),
+				producerReady: afterVideo.every((entry) => !entry.paused && entry.trackEnabled && entry.trackReadyState === "live"),
+				outboundBytesDelta: afterVideo.reduce((sum, entry) => sum + entry.bytesSent, 0) - beforeVideo.reduce((sum, entry) => sum + entry.bytesSent, 0),
+				framesEncodedDelta: finiteDelta(beforeVideo[0]?.framesEncoded, afterVideo[0]?.framesEncoded), receiverCount: afterConsumers.length,
+				inboundAdvanced: afterConsumers.filter((entry) => entry.bytesReceived > (beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.bytesReceived ?? 0)).length,
+				decodedAvailable: decoded.every((value) => value !== null), decodedAdvanced: decoded.filter((value) => value > 0).length };
+		});
+		report.camera = { requested: { width: 1280, height: 720, framesPerSecond: 30 }, source: "deterministic time-coded moving canvas",
+			window: { durationSeconds, observations }, limitations: "Requested/source and observed sender/receiver stats are separate; unavailable Chromium stats remain null." };
+		report.errors.push(...evaluateCameras(observations, [hold.resources, cameraSample.resources], { producers: cameras, consumers: expectedConsumers }));
 	} else await wait(durationSeconds * 1000);
 	report.participants = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
 	for (const [index, participant] of report.participants.entries()) {
 		if (participant.phase !== "running") report.errors.push(`participant ${index + 1}: not running`);
-		if (values.media !== "none" && participant.bytesSent === 0) report.errors.push(`participant ${index + 1}: no outbound RTP observed`);
-		if (count > 1 && values.consume === "all" && values.media !== "none" && participant.bytesReceived === 0) report.errors.push(`participant ${index + 1}: no inbound RTP observed`);
+		const publishes = values.media !== "none" || (values.scenario === "representative-camera" && index < cameras);
+		if (publishes && participant.bytesSent === 0) report.errors.push(`participant ${index + 1}: no outbound RTP observed`);
+		if (count > 1 && values.consume === "all" && (values.media !== "none" || values.scenario === "representative-camera") && participant.bytesReceived === 0) report.errors.push(`participant ${index + 1}: no inbound RTP observed`);
 		report.errors.push(...participant.errors.map((error) => `participant ${index + 1}: ${error}`));
 	}
 } catch (error) {


### PR DESCRIPTION
## Behavior
- adds a bounded `representative-camera` scenario with up to 40 deterministic moving 720p30 canvas sources
- records requested capture properties separately from observed sender, receiver, media-source, and browser decode statistics
- checks stable camera producers, RTP/frame progression, eager receiver delivery, and expected SFU producer/consumer counts across the hold window

## Scope
- changes only the existing Meet load harness and its report evaluator/documentation
- keeps idle participants unpublishing while allowing all participants to consume when requested
- retains the existing isolated-target, credential, cleanup, and unqualified-report safeguards

## Limitations
- canvas capture is deterministic synthetic camera motion, not physical-device or production-browser fidelity
- unavailable Chromium statistics remain `null`; short runs do not establish sustained frame rate or bitrate
- full media rendering remains opt-in; one off-screen video probe per participant only drives playback/decode observation

## Follow-up fixes
- validates every available receiver decode counter independently
- waits for the expected camera producer/consumer topology before recording the hold baseline
- polls lightweight endpoint counts during convergence instead of collecting full WebRTC statistics