### PR TITLE
test(meet): measure representative screen delivery

### DIFF
--- a/e2e/meet/load/README.md
+++ b/e2e/meet/load/README.md
@@ -46,6 +46,18 @@ video probe per Participant Connection drives playback and exposes Chromium's br
 decoded-frame count; this avoids O(N) rendered elements. Full rendering remains off
 unless explicitly requested.
 
+`--scenario representative-screen` publishes the first `--screens` Participant
+Connections (default `min(2, count)`, maximum 2) as distinct moving, time-coded
+1920x1080 canvases captured at requested 30 fps. Producers use screen semantics and
+an encoding `maxBitrate` target of 4,000,000 bps; the configured target is reported
+separately from elapsed-window sender and receiver bitrate observations. Every
+intended receiver renders every screen for a browser decoded-frame probe. Stable
+Producer identity/state, delivery, progress, eager SFU resources, dimensions, fps,
+and nullable WebRTC stats are reported. For windows of at least five seconds an
+observed sender average over the cap plus 10% tolerance fails correctness, but the
+target is not a strict instantaneous network ceiling and a short local run does not
+establish sustained <=4 Mbps.
+
 `--media audio|video|both` uses Chromium's synthetic fake devices. Reports retain
 actual capture settings and observed RTP byte counters, but synthetic devices do not
 model representative speech/cameras and requested settings do not prove delivered
@@ -71,10 +83,10 @@ cleanup outcome.
 
 ## Progressive Scenarios
 
-Admission plus idle hold, uniform synthetic media, rotating audio, and representative
-camera measurement are implemented. The remaining representative suite is two 1080p30 screens
-capped at 4 Mbps, and one Recorder Endpoint. Pinned representative video, actual
-delivered video constraints, screen publication, and recorder support must be
+Admission plus idle hold, uniform synthetic media, rotating audio, representative
+camera, and two-screen measurement are implemented. The remaining representative
+suite includes one Recorder Endpoint. Pinned representative video, actual
+delivered video constraints, and recorder support must be
 implemented and measured before those properties are claimed.
 
 ## Verification

--- a/e2e/meet/load/client.ts
+++ b/e2e/meet/load/client.ts
@@ -8,6 +8,7 @@ interface Config {
 	sfuUrl: string; meetingId: string; token: string; userId: string; name: string;
 	media: Media; consume: boolean; renderMedia: boolean; rotatingAudio: boolean; audioActive: boolean;
 	representativeCamera: boolean;
+	representativeScreen: boolean;
 }
 interface ProducerEvent { producerId: string; participantId?: string; user_id?: string; id?: string; }
 
@@ -67,7 +68,8 @@ async function subscribe(config: Config, event: ProducerEvent) {
 		const consumer = await transport.consume(options);
 		if (stopping) return consumer.close();
 		consumers.set(producerId, consumer);
-		if (config.renderMedia || (config.representativeCamera && consumer.kind === "video" && !renderedVideos.size)) {
+		if (config.renderMedia || ((config.representativeCamera || config.representativeScreen) && consumer.kind === "video" &&
+			(config.representativeScreen || !renderedVideos.size))) {
 			const element = document.createElement(consumer.kind);
 			element.autoplay = true; element.muted = true; element.srcObject = new MediaStream([consumer.track]);
 			if (consumer.kind === "video") {
@@ -93,13 +95,14 @@ async function publish(config: Config) {
 		oscillator.frequency.value = 440; audioGain.gain.value = config.audioActive ? 0.15 : 0;
 		oscillator.connect(audioGain).connect(destination); oscillator.start();
 		stream = destination.stream;
-	} else if (config.representativeCamera) {
-		cameraCanvas = document.createElement("canvas"); cameraCanvas.width = 1280; cameraCanvas.height = 720;
+	} else if (config.representativeCamera || config.representativeScreen) {
+		cameraCanvas = document.createElement("canvas"); cameraCanvas.width = config.representativeScreen ? 1920 : 1280; cameraCanvas.height = config.representativeScreen ? 1080 : 720;
 		const context = cameraCanvas.getContext("2d")!; let frame = 0;
 		const draw = () => {
-			const hue = frame * 3 % 360; context.fillStyle = `hsl(${hue} 60% 35%)`; context.fillRect(0, 0, 1280, 720);
-			context.fillStyle = "white"; context.font = "48px monospace"; context.fillText(`${config.userId} frame ${frame}`, 40, 80);
-			context.fillRect(frame * 17 % 1180, 300, 100, 100); frame++;
+			const { width, height } = cameraCanvas!; const elapsedMs = Math.round(performance.now() - started);
+			const hue = (frame * 3 + config.userId.charCodeAt(5)) % 360; context.fillStyle = `hsl(${hue} 60% 35%)`; context.fillRect(0, 0, width, height);
+			context.fillStyle = "white"; context.font = "48px monospace"; context.fillText(`${config.userId} frame ${frame} t=${elapsedMs}ms`, 40, 80);
+			context.fillRect(frame * 17 % (width - 100), Math.round(height * 0.42), 100, 100); frame++;
 		};
 		draw(); cameraTimer = window.setInterval(draw, 1000 / 30);
 		stream = cameraCanvas.captureStream(30);
@@ -111,7 +114,9 @@ async function publish(config: Config) {
 			.then(({ id }) => done({ id })).catch(fail);
 	});
 	for (const track of stream.getTracks()) {
-		const producer = await send.produce({ track, stopTracks: false, appData: { type: "camera" } });
+		const producer = await send.produce({ track, stopTracks: false,
+			appData: { type: config.representativeScreen ? "screen" : "camera" },
+			...(config.representativeScreen && track.kind === "video" ? { encodings: [{ maxBitrate: 4_000_000 }] } : {}) });
 		producers.set(producer.id, producer);
 	}
 }
@@ -171,9 +176,10 @@ async function status() {
 			framesPerSecond = Number.isFinite(report.framesPerSecond) ? Number(report.framesPerSecond) : framesPerSecond;
 		} bytesReceived += bytes; consumerStats.push({ producerId, kind: endpoint.kind, paused: endpoint.paused, trackEnabled: endpoint.track.enabled,
 			trackReadyState: endpoint.track.readyState, bytesReceived: bytes, framesDecoded, frameWidth, frameHeight, framesPerSecond,
-			browserDecodedFrames: renderedVideos.get(producerId)?.webkitDecodedFrameCount ?? null }); }
+			browserDecodedFrames: renderedVideos.get(producerId)?.getVideoPlaybackQuality().totalVideoFrames ??
+				renderedVideos.get(producerId)?.webkitDecodedFrameCount ?? null }); }
 	if (bytesReceived && firstRemoteMediaMs === null) firstRemoteMediaMs = performance.now() - started;
-	return { phase, joinMs, firstRemoteMediaMs, producerCount: producers.size, consumerCount: consumers.size,
+	return { phase, sampledAtMs: performance.now(), joinMs, firstRemoteMediaMs, producerCount: producers.size, consumerCount: consumers.size,
 		sendTransportState: send?.connectionState ?? null, receiveTransportState: receive?.connectionState ?? null,
 		bytesSent, bytesReceived, packetsLost, packetsReceived, errors: [...errors],
 		producerStats, consumerStats,

--- a/e2e/meet/load/report.mjs
+++ b/e2e/meet/load/report.mjs
@@ -8,6 +8,10 @@ export function boundedInteger(value, name, min, max) {
 	return number;
 }
 
+export function screenCount(value, count) {
+	return boundedInteger(value ?? String(Math.min(2, count)), "screens", 1, Math.min(2, count));
+}
+
 export function targetMetadata(value, allowRemote) {
 	const url = new URL(value);
 	if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || url.search || url.hash) {
@@ -56,6 +60,11 @@ export function containsJwt(value) {
 
 export function finiteDelta(before, after) {
 	return Number.isFinite(before) && Number.isFinite(after) ? after - before : null;
+}
+
+export function bitrate(bytesBefore, bytesAfter, elapsedMs) {
+	return Number.isFinite(bytesBefore) && Number.isFinite(bytesAfter) && elapsedMs > 0
+		? Math.max(0, bytesAfter - bytesBefore) * 8000 / elapsedMs : null;
 }
 
 export function rotationWindows(participantIds, talkers, durationMs, intervalMs) {
@@ -113,4 +122,26 @@ export function cameraDeliveryReady(statuses, cameras, count) {
 	return statuses.length === count && statuses.every((status, index) =>
 		status.producerCount === (index < cameras ? 1 : 0) &&
 		status.consumerCount === cameras - (index < cameras ? 1 : 0));
+}
+
+export function evaluateScreens(observations, resourceSamples, expected, capBps) {
+	const errors = [];
+	for (const participant of observations) {
+		if (participant.publisher) {
+			if (participant.producerIdsBefore.join() !== participant.producerIdsAfter.join() || participant.producerIdsAfter.length !== 1)
+				errors.push(`${participant.userId}: screen Producer was not stable`);
+			if (!participant.producerReady) errors.push(`${participant.userId}: screen Producer was not enabled and unpaused`);
+			if (participant.outboundBytesDelta <= 0) errors.push(`${participant.userId}: screen outbound RTP did not advance`);
+			if (participant.framesEncodedDelta !== null && participant.framesEncodedDelta <= 0) errors.push(`${participant.userId}: screen framesEncoded did not advance`);
+			if (participant.outboundBitrateBps !== null && participant.elapsedMs >= 5000 && participant.outboundBitrateBps > capBps * 1.1)
+				errors.push(`${participant.userId}: observed average screen bitrate exceeded configured cap tolerance`);
+		} else if (participant.producerIdsAfter.length) errors.push(`${participant.userId}: idle participant published media`);
+		if (participant.receiverCount !== participant.expectedReceivers) errors.push(`${participant.userId}: received ${participant.receiverCount}/${participant.expectedReceivers} screen tracks`);
+		if (participant.inboundAdvanced !== participant.expectedReceivers) errors.push(`${participant.userId}: inbound RTP advanced for ${participant.inboundAdvanced}/${participant.expectedReceivers} screens`);
+		if (participant.decodedAdvanced !== participant.decodedObserved) errors.push(`${participant.userId}: decoded frames advanced for ${participant.decodedAdvanced}/${participant.decodedObserved} screens`);
+		if (participant.browserDecodedAdvanced !== participant.browserDecodedObserved) errors.push(`${participant.userId}: browser decoded-frame probe advanced for ${participant.browserDecodedAdvanced}/${participant.browserDecodedObserved} screens`);
+	}
+	if (resourceSamples.some((sample) => sample.producers !== expected.producers || sample.consumers !== expected.consumers))
+		errors.push("screen Producer or Consumer resources were not stable at expected counts");
+	return errors;
 }

--- a/e2e/meet/load/report.test.mjs
+++ b/e2e/meet/load/report.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { bitrate, boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, evaluateScreens, finiteDelta, parseResourceMetrics, percentile, rotationWindows, screenCount, targetMetadata } from "./report.mjs";
 
 test("target safety defaults to loopback and rejects shared or remote targets", () => {
 	assert.deepEqual(targetMetadata("http://127.0.0.1:4317/", false), {
@@ -50,6 +50,32 @@ test("camera evaluation independently requires stable progressing publication, d
 test("camera delivery waits for every expected producer and consumer", () => {
 	assert.equal(cameraDeliveryReady([{ producerCount: 1, consumerCount: 1 }, { producerCount: 1, consumerCount: 1 }], 2, 2), true);
 	assert.equal(cameraDeliveryReady([{ producerCount: 1, consumerCount: 0 }, { producerCount: 1, consumerCount: 1 }], 2, 2), false);
+});
+
+test("screen bitrate uses precise elapsed milliseconds and preserves nullable stats", () => {
+	assert.equal(bitrate(100, 5100, 2500), 16_000);
+	assert.equal(bitrate(undefined, 5100, 2500), null);
+	assert.equal(bitrate(100, 5100, 0), null);
+});
+
+test("screen configuration defaults to at most two publishers and rejects larger values", () => {
+	assert.equal(screenCount(undefined, 1), 1);
+	assert.equal(screenCount(undefined, 4), 2);
+	assert.equal(screenCount("2", 4), 2);
+	assert.throws(() => screenCount("3", 4), /screens must be an integer from 1 to 2/);
+});
+
+test("screen evaluation independently checks stable delivery, resources, and meaningful cap windows", () => {
+	const publisher = { userId: "a", publisher: true, producerIdsBefore: ["p1"], producerIdsAfter: ["p1"], producerReady: true,
+		outboundBytesDelta: 100, outboundBitrateBps: 3_900_000, elapsedMs: 6000, framesEncodedDelta: null,
+		expectedReceivers: 1, receiverCount: 1, inboundAdvanced: 1, decodedObserved: 1, decodedAdvanced: 1,
+		browserDecodedObserved: 1, browserDecodedAdvanced: 1 };
+	assert.deepEqual(evaluateScreens([publisher], [{ producers: 2, consumers: 2 }], { producers: 2, consumers: 2 }, 4_000_000), []);
+	assert.match(evaluateScreens([{ ...publisher, producerIdsAfter: ["p2"], outboundBytesDelta: 0, outboundBitrateBps: 4_500_000,
+		receiverCount: 0, inboundAdvanced: 0, decodedAdvanced: 0, browserDecodedAdvanced: 0 }], [{ producers: 1, consumers: 0 }],
+	{ producers: 2, consumers: 2 }, 4_000_000).join("; "), /not stable.*did not advance.*exceeded.*received 0\/1.*inbound RTP.*decoded frames.*resources/);
+	assert.deepEqual(evaluateScreens([{ ...publisher, outboundBitrateBps: 9_000_000, elapsedMs: 4999 }],
+		[{ producers: 2, consumers: 2 }], { producers: 2, consumers: 2 }, 4_000_000), []);
 });
 
 test("bounds reject fractions and values outside the declared range", () => {

--- a/e2e/meet/load/run.mjs
+++ b/e2e/meet/load/run.mjs
@@ -6,7 +6,7 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { chromium } from "@playwright/test";
 import { createServer } from "vite";
-import { boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, finiteDelta, parseResourceMetrics, percentile, rotationWindows, targetMetadata } from "./report.mjs";
+import { bitrate, boundedInteger, cameraDeliveryReady, containsJwt, delta, evaluateCameras, evaluateRotation, evaluateScreens, finiteDelta, parseResourceMetrics, percentile, rotationWindows, screenCount, targetMetadata } from "./report.mjs";
 
 const root = dirname(fileURLToPath(import.meta.url));
 const { values } = parseArgs({ options: {
@@ -19,6 +19,7 @@ const { values } = parseArgs({ options: {
 	scenario: { type: "string", default: "uniform" },
 	talkers: { type: "string" },
 	cameras: { type: "string" },
+	screens: { type: "string" },
 	"rotation-interval-ms": { type: "string", default: "1000" },
 	consume: { type: "string", default: "all" },
 	"render-media": { type: "boolean", default: false },
@@ -38,10 +39,12 @@ const rampMs = boundedInteger(values["ramp-ms"], "ramp-ms", 0, 5000);
 const rotationIntervalMs = boundedInteger(values["rotation-interval-ms"], "rotation-interval-ms", 250, 60_000);
 const talkers = boundedInteger(values.talkers ?? String(Math.min(10, count)), "talkers", 1, count);
 const cameras = boundedInteger(values.cameras ?? String(Math.min(40, count)), "cameras", 1, Math.min(40, count));
+const screens = screenCount(values.screens, count);
 if (!["none", "audio", "video", "both"].includes(values.media)) throw new Error("media must be none, audio, video, or both");
-if (!["uniform", "rotating-audio", "representative-camera"].includes(values.scenario)) throw new Error("scenario must be uniform, rotating-audio, or representative-camera");
+if (!["uniform", "rotating-audio", "representative-camera", "representative-screen"].includes(values.scenario)) throw new Error("scenario must be uniform, rotating-audio, representative-camera, or representative-screen");
 if (values.scenario === "rotating-audio" && values.media !== "audio") throw new Error("rotating-audio requires --media audio");
 if (values.scenario === "representative-camera" && values.media !== "none") throw new Error("representative-camera determines media; omit --media");
+if (values.scenario === "representative-screen" && values.media !== "none") throw new Error("representative-screen determines media; omit --media");
 if (!["all", "none"].includes(values.consume)) throw new Error("consume must be all or none");
 if (!/^load-[0-9a-f-]{36}$/.test(values["meeting-id"]) || !/^load(?:[.-][a-z0-9-]+)*\.test$/i.test(values.site)) {
 	throw new Error("Use the generated load UUID room and a load*.test site namespace");
@@ -58,7 +61,7 @@ const report = {
 	startedAt: new Date().toISOString(),
 	target,
 	config: { count, durationSeconds, cleanupSeconds, rampMs, media: values.media, consume: values.consume,
-		scenario: values.scenario, talkers, rotationIntervalMs, cameras,
+		scenario: values.scenario, talkers, rotationIntervalMs, cameras, screens,
 		renderMedia: values["render-media"], meetingId: values["meeting-id"], site: values.site,
 		authSource: values["token-file"] ? "token-file" : "environment-signed" },
 	host: { hostname: hostname(), platform: platform(), release: release(), node: process.version,
@@ -135,14 +138,16 @@ try {
 		page.on("pageerror", () => report.errors.push(`participant ${index + 1}: page error`));
 		await page.goto(clientUrl, { waitUntil: "networkidle", timeout: 15_000 });
 		const representativeCamera = values.scenario === "representative-camera" && index < cameras;
+		const representativeScreen = values.scenario === "representative-screen";
 		await page.evaluate((config) => window.meetLoad.start(config), { ...participant, sfuUrl: target.endpoint,
-			meetingId: values["meeting-id"], media: representativeCamera ? "video" : values.media, consume: values.consume === "all", renderMedia: values["render-media"],
-			representativeCamera, rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
+			meetingId: values["meeting-id"], media: representativeCamera || (representativeScreen && index < screens) ? "video" : values.media, consume: values.consume === "all", renderMedia: values["render-media"],
+			representativeCamera, representativeScreen, rotatingAudio: values.scenario === "rotating-audio", audioActive: index < talkers });
 		if (rampMs) await wait(rampMs);
 	}
-	if (values.scenario === "representative-camera" && values.consume === "all") {
+	if (["representative-camera", "representative-screen"].includes(values.scenario) && values.consume === "all") {
+		const publishers = values.scenario === "representative-screen" ? screens : cameras;
 		const deadline = Date.now() + 15_000;
-		while (!cameraDeliveryReady(await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.endpointCounts()))), cameras, count)) {
+		while (!cameraDeliveryReady(await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.endpointCounts()))), publishers, count)) {
 			if (Date.now() >= deadline) throw new Error("Camera delivery did not converge before the hold sample");
 			await wait(100);
 		}
@@ -182,35 +187,47 @@ try {
 		previousWindow.actualEndedAt = actualEndedAt.toISOString();
 		previousWindow.actualDurationMs = actualEndedAt - new Date(previousWindow.actualStartedAt);
 		report.errors.push(...evaluateRotation(report.rotation.windows, resourceSamples));
-	} else if (values.scenario === "representative-camera") {
+	} else if (["representative-camera", "representative-screen"].includes(values.scenario)) {
+		const isScreen = values.scenario === "representative-screen"; const publishers = isScreen ? screens : cameras;
 		const before = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
 		await wait(durationSeconds * 1000);
 		const after = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
-		const cameraSample = await sample("camera-window");
-		const expectedConsumers = values.consume === "all" ? cameras * (count - 1) : 0;
+		const cameraSample = await sample(isScreen ? "screen-window" : "camera-window");
+		const expectedConsumers = values.consume === "all" ? publishers * (count - 1) : 0;
 		const observations = participants.map((participant, index) => {
 			const beforeVideo = before[index].producerStats.filter(({ kind }) => kind === "video");
 			const afterVideo = after[index].producerStats.filter(({ kind }) => kind === "video");
 			const beforeConsumers = before[index].consumerStats.filter(({ kind }) => kind === "video");
 			const afterConsumers = after[index].consumerStats.filter(({ kind }) => kind === "video");
-			const expectedReceivers = values.consume === "all" ? cameras - (index < cameras ? 1 : 0) : 0;
+			const expectedReceivers = values.consume === "all" ? publishers - (index < publishers ? 1 : 0) : 0;
 			const decoded = afterConsumers.map((entry) => finiteDelta(beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.framesDecoded, entry.framesDecoded));
-			return { userId: participant.userId, publisher: index < cameras, expectedReceivers,
+			const browserDecoded = afterConsumers.map((entry) => finiteDelta(beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.browserDecodedFrames, entry.browserDecodedFrames));
+			const elapsedMs = after[index].sampledAtMs - before[index].sampledAtMs;
+			const outboundBytesDelta = afterVideo.reduce((sum, entry) => sum + entry.bytesSent, 0) - beforeVideo.reduce((sum, entry) => sum + entry.bytesSent, 0);
+			return { userId: participant.userId, publisher: index < publishers, expectedReceivers, elapsedMs,
 				producerIdsBefore: beforeVideo.map(({ id }) => id).sort(), producerIdsAfter: afterVideo.map(({ id }) => id).sort(),
 				producerReady: afterVideo.every((entry) => !entry.paused && entry.trackEnabled && entry.trackReadyState === "live"),
-				outboundBytesDelta: afterVideo.reduce((sum, entry) => sum + entry.bytesSent, 0) - beforeVideo.reduce((sum, entry) => sum + entry.bytesSent, 0),
+				outboundBytesDelta, outboundBitrateBps: bitrate(0, outboundBytesDelta, elapsedMs),
 				framesEncodedDelta: finiteDelta(beforeVideo[0]?.framesEncoded, afterVideo[0]?.framesEncoded), receiverCount: afterConsumers.length,
 				inboundAdvanced: afterConsumers.filter((entry) => entry.bytesReceived > (beforeConsumers.find(({ producerId }) => producerId === entry.producerId)?.bytesReceived ?? 0)).length,
-				decodedObserved: decoded.filter((value) => value !== null).length, decodedAdvanced: decoded.filter((value) => value > 0).length };
+				inbound: afterConsumers.map((entry) => { const prior = beforeConsumers.find(({ producerId }) => producerId === entry.producerId); const bytesDelta = entry.bytesReceived - (prior?.bytesReceived ?? 0);
+					return { producerId: entry.producerId, bytesDelta, bitrateBps: bitrate(0, bytesDelta, elapsedMs), framesDecodedDelta: finiteDelta(prior?.framesDecoded, entry.framesDecoded),
+					framesPerSecond: entry.framesPerSecond, width: entry.frameWidth, height: entry.frameHeight, browserDecodedFramesDelta: finiteDelta(prior?.browserDecodedFrames, entry.browserDecodedFrames) }; }),
+				decodedObserved: decoded.filter((value) => value !== null).length, decodedAdvanced: decoded.filter((value) => value > 0).length,
+				browserDecodedObserved: browserDecoded.filter((value) => value !== null).length, browserDecodedAdvanced: browserDecoded.filter((value) => value > 0).length,
+				sender: afterVideo[0] ? { framesPerSecond: afterVideo[0].framesPerSecond, mediaSource: afterVideo[0].mediaSource } : null };
 		});
-		report.camera = { requested: { width: 1280, height: 720, framesPerSecond: 30 }, source: "deterministic time-coded moving canvas",
+		const section = { requested: { width: isScreen ? 1920 : 1280, height: isScreen ? 1080 : 720, framesPerSecond: 30 }, source: "deterministic distinct moving time-coded canvas",
 			window: { durationSeconds, observations }, limitations: "Requested/source and observed sender/receiver stats are separate; unavailable Chromium stats remain null." };
-		report.errors.push(...evaluateCameras(observations, [hold.resources, cameraSample.resources], { producers: cameras, consumers: expectedConsumers }));
+		if (isScreen) { report.screen = { ...section, configuredEncodingMaxBitrateBps: 4_000_000,
+			limitations: `${section.limitations} The encoding maxBitrate is a target cap; a short local run does not establish sustained <=4 Mbps.` };
+			report.errors.push(...evaluateScreens(observations, [hold.resources, cameraSample.resources], { producers: screens, consumers: expectedConsumers }, 4_000_000)); }
+		else { report.camera = section; report.errors.push(...evaluateCameras(observations, [hold.resources, cameraSample.resources], { producers: cameras, consumers: expectedConsumers })); }
 	} else await wait(durationSeconds * 1000);
 	report.participants = await Promise.all(pages.map((page) => page.evaluate(() => window.meetLoad.status())));
 	for (const [index, participant] of report.participants.entries()) {
 		if (participant.phase !== "running") report.errors.push(`participant ${index + 1}: not running`);
-		const publishes = values.media !== "none" || (values.scenario === "representative-camera" && index < cameras);
+		const publishes = values.media !== "none" || (values.scenario === "representative-camera" && index < cameras) || (values.scenario === "representative-screen" && index < screens);
 		if (publishes && participant.bytesSent === 0) report.errors.push(`participant ${index + 1}: no outbound RTP observed`);
 		if (count > 1 && values.consume === "all" && (values.media !== "none" || values.scenario === "representative-camera") && participant.bytesReceived === 0) report.errors.push(`participant ${index + 1}: no inbound RTP observed`);
 		report.errors.push(...participant.errors.map((error) => `participant ${index + 1}: ${error}`));


### PR DESCRIPTION
## Scope
- Add a bounded representative-screen scenario to the Meet load harness.
- Measure up to two distinct 1080p30 screen publishers and every intended eager receiver.
- Extend the JSON report and harness documentation for screen delivery observations.

## Behavior
- Publishes deterministic moving, time-coded canvases with screen media semantics and a 4 Mbps encoding target.
- Records stable producer state, RTP and decoded-frame progress, elapsed-window sender and receiver bitrates, dimensions, frame rates, and SFU resource counts.
- Fails correctness when stable delivery or resource expectations are not met, including sustained-window sender averages beyond the configured tolerance.

## Limitations
- This remains a synthetic, bounded correctness and measurement harness; reports stay unqualified.
- The encoding bitrate is a target rather than a strict instantaneous network ceiling.
- Short local runs do not establish sustained bitrate, frame rate, source fidelity, production-browser behavior, or capacity.