### PR TITLE
fix(meet): tolerate unavailable local storage

### DIFF
--- a/frontend/src/utils/localStorage.ts
+++ b/frontend/src/utils/localStorage.ts
@@ -1,3 +1,11 @@
+function setItem(key: string, value: string): void {
+	try {
+		localStorage.setItem(key, value);
+	} catch {
+		// Browser storage is best-effort and may be unavailable or full.
+	}
+}
+
 /** Read a boolean stored as "1" or "0", falling back only when the key is absent. */
 export function readBoolean(key: string, fallback = false): boolean {
 	const value = localStorage.getItem(key);
@@ -6,7 +14,7 @@ export function readBoolean(key: string, fallback = false): boolean {
 
 /** Store a boolean using the shared "1" or "0" encoding. */
 export function writeBoolean(key: string, value: boolean): void {
-	localStorage.setItem(key, value ? "1" : "0");
+	setItem(key, value ? "1" : "0");
 }
 
 /** Read a string, falling back only when the key is absent. */
@@ -16,7 +24,7 @@ export function readString(key: string, fallback = ""): string {
 
 /** Store a string without additional encoding. */
 export function writeString(key: string, value: string): void {
-	localStorage.setItem(key, value);
+	setItem(key, value);
 }
 
 /** Parse a JSON value, returning null for an absent key and propagating parse errors. */
@@ -25,12 +33,16 @@ export function readJSON(key: string): unknown | null {
 	return value === null ? null : (JSON.parse(value) as unknown);
 }
 
-/** Serialize and store a JSON value, propagating serialization and storage errors. */
+/** Serialize and store a JSON value, propagating serialization errors. */
 export function writeJSON(key: string, value: unknown): void {
-	localStorage.setItem(key, JSON.stringify(value));
+	setItem(key, JSON.stringify(value));
 }
 
 /** Remove a stored value. */
 export function remove(key: string): void {
-	localStorage.removeItem(key);
+	try {
+		localStorage.removeItem(key);
+	} catch {
+		// Browser storage is best-effort and may be unavailable.
+	}
 }


### PR DESCRIPTION
## Summary

Treat local storage writes and removals as best-effort so quota or browser availability failures do not interrupt Meet interactions. JSON serialization errors continue to propagate.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend 35.6% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | **35.6%** (14,348 / 40,305) (+0%) | **30.1%** (9,276 / 30,819) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34240340591) for commit `d9436d9`.</sub>

</details>
<!-- suite-coverage:end -->
