### PR TITLE
fix(slides): copy pasted media as attachment

### DIFF
--- a/suite/slides/doctype/presentation/presentation.py
+++ b/suite/slides/doctype/presentation/presentation.py
@@ -465,9 +465,7 @@ def get_attachment(presentation, file_url):
         if source_doc:
             source_file = frappe.get_doc("File", source_doc[0].name)
             source_file.check_permission("read")
-            new_attachment_doc = frappe.copy_doc(source_file)
-            new_attachment_doc.attached_to_name = presentation
-            new_attachment_doc.insert()
+            new_attachment_doc = source_file.create_attachment_copy("Presentation", presentation)
             attachment = new_attachment_doc.name
 
     return attachment


### PR DESCRIPTION
## Problem

PR #672 added target attachment records for media pasted between presentations. The generic `frappe.copy_doc()` path does not reliably create that target attachment on Frappe v16. A viewer who can read only the destination presentation can still receive a 403 for the private media.

## Fix

Use Frappe's `File.create_attachment_copy()` API. This API reuses the existing blob and creates a File row for the destination presentation.

## Tests

- `bench --site <site> run-tests --app suite --module suite.slides.tests.test_pasted_media`
- 3 passed