### PR TITLE
fix(calendar): use friendly date format in event and schedule pickers

### DIFF
--- a/frontend/src/apps/calendar/components/EventAlertList.vue
+++ b/frontend/src/apps/calendar/components/EventAlertList.vue
@@ -97,7 +97,7 @@ const RELATIVE_TO_OPTIONS = [
 				:model-value="alert.date"
 				type="date"
 				format="MMM D, YYYY"
-				placeholder="Select date"
+				:placeholder="__('Select date')"
 				class="mt-auto w-full"
 				@update:model-value="updateAlert(i, 'date', $event)"
 			/>
@@ -107,7 +107,7 @@ const RELATIVE_TO_OPTIONS = [
 				type="time"
 				:interval="15"
 				format="h:mm A"
-				placeholder="Select time"
+				:placeholder="__('Select time')"
 				class="mt-auto w-full"
 				@update:model-value="updateAlert(i, 'time', $event)"
 			/>

--- a/frontend/src/apps/calendar/components/EventAlertList.vue
+++ b/frontend/src/apps/calendar/components/EventAlertList.vue
@@ -96,6 +96,8 @@ const RELATIVE_TO_OPTIONS = [
 			<FormControl
 				:model-value="alert.date"
 				type="date"
+				format="MMM D, YYYY"
+				placeholder="Select date"
 				class="mt-auto w-full"
 				@update:model-value="updateAlert(i, 'date', $event)"
 			/>
@@ -103,6 +105,9 @@ const RELATIVE_TO_OPTIONS = [
 			<FormControl
 				:model-value="alert.time"
 				type="time"
+				:interval="15"
+				format="h:mm A"
+				placeholder="Select time"
 				class="mt-auto w-full"
 				@update:model-value="updateAlert(i, 'time', $event)"
 			/>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -989,14 +989,21 @@ const recurringScopeModalProps = computed(() => ({
 										{{ __('Starts') }}
 									</label>
 									<div class="flex gap-2">
-										<FormControl v-model="event.startDate" type="date" class="w-full" />
+										<FormControl
+											v-model="event.startDate"
+											type="date"
+											format="MMM D, YYYY"
+											placeholder="Select date"
+											class="w-full"
+										/>
 										<FormControl
 											v-if="!event.isAllDay"
 											v-model="event.startTime"
 											type="time"
 											:interval="15"
 											format="h:mm A"
-											class="w-full"
+											placeholder="Select time"
+											class="!w-28 shrink-0"
 										/>
 									</div>
 								</div>
@@ -1005,14 +1012,21 @@ const recurringScopeModalProps = computed(() => ({
 										{{ __('Ends') }}
 									</label>
 									<div class="flex gap-2">
-										<FormControl v-model="event.endDate" type="date" class="w-full" />
+										<FormControl
+											v-model="event.endDate"
+											type="date"
+											format="MMM D, YYYY"
+											placeholder="Select date"
+											class="w-full"
+										/>
 										<FormControl
 											v-if="!event.isAllDay"
 											v-model="event.endTime"
 											type="time"
 											:interval="15"
 											format="h:mm A"
-											class="w-full"
+											placeholder="Select time"
+											class="!w-28 shrink-0"
 										/>
 									</div>
 								</div>

--- a/frontend/src/apps/calendar/components/Modals/EventModal.vue
+++ b/frontend/src/apps/calendar/components/Modals/EventModal.vue
@@ -993,7 +993,7 @@ const recurringScopeModalProps = computed(() => ({
 											v-model="event.startDate"
 											type="date"
 											format="MMM D, YYYY"
-											placeholder="Select date"
+											:placeholder="__('Select date')"
 											class="w-full"
 										/>
 										<FormControl
@@ -1002,7 +1002,7 @@ const recurringScopeModalProps = computed(() => ({
 											type="time"
 											:interval="15"
 											format="h:mm A"
-											placeholder="Select time"
+											:placeholder="__('Select time')"
 											class="!w-28 shrink-0"
 										/>
 									</div>
@@ -1016,7 +1016,7 @@ const recurringScopeModalProps = computed(() => ({
 											v-model="event.endDate"
 											type="date"
 											format="MMM D, YYYY"
-											placeholder="Select date"
+											:placeholder="__('Select date')"
 											class="w-full"
 										/>
 										<FormControl
@@ -1025,7 +1025,7 @@ const recurringScopeModalProps = computed(() => ({
 											type="time"
 											:interval="15"
 											format="h:mm A"
-											placeholder="Select time"
+											:placeholder="__('Select time')"
 											class="!w-28 shrink-0"
 										/>
 									</div>

--- a/frontend/src/apps/meet/pages/Home.vue
+++ b/frontend/src/apps/meet/pages/Home.vue
@@ -106,7 +106,7 @@
 							label="Date"
 							type="date"
 							format="MMM D, YYYY"
-							placeholder="Select date"
+							:placeholder="__('Select date')"
 						/>
 						<FormControl
 							v-model="scheduleStartTime"
@@ -114,7 +114,7 @@
 							type="time"
 							:interval="15"
 							format="h:mm A"
-							placeholder="Select time"
+							:placeholder="__('Select time')"
 						/>
 						<FormControl
 							v-model="scheduleEndTime"
@@ -122,7 +122,7 @@
 							type="time"
 							:interval="15"
 							format="h:mm A"
-							placeholder="Select time"
+							:placeholder="__('Select time')"
 						/>
 					</div>
 					<ParticipantSelector

--- a/frontend/src/apps/meet/pages/Home.vue
+++ b/frontend/src/apps/meet/pages/Home.vue
@@ -101,13 +101,20 @@
 				<div class="space-y-4">
 					<FormControl v-model="scheduleTitle" label="Title" placeholder="Team meeting" />
 					<div class="grid grid-cols-1 gap-3 md:grid-cols-3">
-						<FormControl v-model="scheduleDate" label="Date" type="date" />
+						<FormControl
+							v-model="scheduleDate"
+							label="Date"
+							type="date"
+							format="MMM D, YYYY"
+							placeholder="Select date"
+						/>
 						<FormControl
 							v-model="scheduleStartTime"
 							label="Start"
 							type="time"
 							:interval="15"
 							format="h:mm A"
+							placeholder="Select time"
 						/>
 						<FormControl
 							v-model="scheduleEndTime"
@@ -115,6 +122,7 @@
 							type="time"
 							:interval="15"
 							format="h:mm A"
+							placeholder="Select time"
 						/>
 					</div>
 					<ParticipantSelector


### PR DESCRIPTION
<img width="2940" height="1672" alt="image" src="https://github.com/user-attachments/assets/05f94f31-8cfc-4fa2-aff2-2c935e6ff39c" />
<img width="2940" height="1672" alt="image" src="https://github.com/user-attachments/assets/7d49c8f2-7bd0-4c91-828b-f098619441af" />

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend 35.6% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | **35.6%** (14,348 / 40,305) (+0%) | **30.1%** (9,276 / 30,819) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34572591588) for commit `226782f`.</sub>

</details>
<!-- suite-coverage:end -->
