### PR TITLE
fix(calendar): an invite email names the occurrence it is about

### DIFF
--- a/suite/calendar/doctype/calendar_event/calendar_event.py
+++ b/suite/calendar/doctype/calendar_event/calendar_event.py
@@ -634,7 +634,9 @@ def update_calendar_event_instance(
             frappe.throw(_(response["description"]), title=title)
 
     if use_custom_invites:
-        _enqueue_event_notification(account, "update", event_id=master_id)
+        # Named, or the mail would be the series' own: its start is where the occurrence used to
+        # be, and the edit that just moved it lives on the occurrence alone.
+        _enqueue_event_notification(account, "update", event_id=master_id, recurrence_id=recurrence_id)
 
 
 @frappe.whitelist()

--- a/suite/calendar/doctype/calendar_event/invitations.py
+++ b/suite/calendar/doctype/calendar_event/invitations.py
@@ -12,6 +12,7 @@ API after the event is written to JMAP.
 """
 
 import re
+from copy import deepcopy
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -22,7 +23,7 @@ import frappe
 from frappe import _
 from frappe.utils import add_to_date, get_datetime, get_system_timezone, strip_html_tags
 
-from suite.calendar.doctype.calendar_event.ics import build_event_ics
+from suite.calendar.doctype.calendar_event.ics import _apply_override, build_event_ics
 from suite.calendar.doctype.calendar_event.invite_templates import (
     DEFAULT_SUBJECTS,
     DEFAULT_TEMPLATES,
@@ -101,8 +102,9 @@ def notify_participants(
     `action` is one of "invite", "update", "cancel". Pass `event_id` to fetch the current
     event, or a pre-fetched `event_snapshot` (needed for cancellations after deletion).
     For updates, `previous_emails` enables new -> invite / kept -> update / gone -> cancel;
-    omit it to send a plain update to everyone. `recurrence_id` scopes a cancellation to a
-    single occurrence of a recurring event.
+    omit it to send a plain update to everyone. `recurrence_id` scopes the mail to a single
+    occurrence of a recurring event — the date it names, and everything else it says, is that
+    occurrence's rather than the series'.
 
     Note: the snapshot arg is named `event_snapshot`, not `event` — `event` is a reserved
     kwarg of `frappe.enqueue` and would be swallowed before reaching this function.
@@ -122,7 +124,7 @@ def notify_participants(
         return
 
     user = get_user_for_jmap_account(account, raise_exception=True)
-    expires_at = _rsvp_expiry(event)
+    expires_at = _rsvp_expiry(_occurrence_view(event, recurrence_id))
 
     for email, kind in plan.items():
         try:
@@ -222,7 +224,7 @@ def notify_organizer_of_reply(
         user = get_user_for_jmap_account(account, raise_exception=True)
         responder_name = _organizer_name(account, event, responder_email)
         subject, html = _render_response(
-            event,
+            _occurrence_view(event, recurrence_id),
             organizer,
             _organizer_name(account, event, organizer),
             responder_email,
@@ -304,7 +306,10 @@ def _send(
         links = build_rsvp_links(account, event["id"], participant["uid"], email, expires_at)
 
     from_name = _organizer_name(account, event, organizer)
-    subject, html = _render(kind, event, organizer, from_name, participant, links)
+    # The .ics above speaks for the series (or for the occurrence, where one is named); the body
+    # has no such machinery, so it is rendered from the occurrence's own view of the event.
+    occurrence = _occurrence_view(event, recurrence_id)
+    subject, html = _render(kind, occurrence, organizer, from_name, participant, links)
     message = _build_mime(from_name, organizer, email, subject, html, ics, method)
 
     MailQueue._create(
@@ -356,6 +361,27 @@ def _render_response(
     subject = frappe.render_template(DEFAULT_SUBJECTS["response"], context, is_path=False)
     html = frappe.render_template(template_path(DEFAULT_TEMPLATES["response"]), context, is_path=True)
     return subject, html
+
+
+def _occurrence_view(event: dict, recurrence_id: str | None) -> dict:
+    """The event as one occurrence sees it: the series with that date's override folded in.
+
+    A mail about a single occurrence has to name that occurrence — the date it was moved to, the
+    title it was given — and the series carries none of that: its own start never moved, and the
+    edit lives in `recurrenceOverrides` under the date the occurrence was expanded at. Which is
+    the recurrence id, and so the start to fall back on when the override says nothing about it.
+
+    Returns the event untouched when the mail speaks for the whole series.
+    """
+
+    if not recurrence_id:
+        return event
+
+    view = deepcopy({k: v for k, v in event.items() if k != "recurrenceOverrides"})
+    view["start"] = recurrence_id
+    _apply_override(view, (event.get("recurrenceOverrides") or {}).get(recurrence_id) or {})
+
+    return view
 
 
 def _context(event, organizer, organizer_name, participant, links) -> dict:

--- a/suite/calendar/tests/test_calendar_invite_occurrence.py
+++ b/suite/calendar/tests/test_calendar_invite_occurrence.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2026, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from frappe.tests import IntegrationTestCase
+
+from suite.calendar.doctype.calendar_event.invitations import (
+    _format_when,
+    _occurrence_view,
+    _rsvp_expiry,
+)
+
+SERIES_START = "2026-09-08T18:00:00"
+MOVED_TO = "2026-09-11T18:00:00"
+
+
+def weekly_series(overrides: dict | None = None) -> dict:
+    return {
+        "id": "E1",
+        "title": "Catch up",
+        "start": SERIES_START,
+        "duration": "PT1H",
+        "timeZone": "Asia/Kolkata",
+        "recurrenceRule": {"frequency": "weekly", "byDay": [{"day": "tu"}]},
+        "recurrenceOverrides": overrides or {},
+    }
+
+
+class TestInviteOccurrenceView(IntegrationTestCase):
+    """What an email about one occurrence of a series says about it.
+
+    A rescheduled occurrence does not move the series: the master keeps its start and its rule,
+    and the new date lives in an override keyed by the date the occurrence used to fall on. An
+    email built from the series would name that old date — which is what the .ics does not do,
+    so the reader's calendar and the mail beside it disagreed.
+    """
+
+    def test_the_series_speaks_for_itself_when_no_occurrence_is_named(self):
+        event = weekly_series()
+
+        self.assertIs(_occurrence_view(event, None), event)
+
+    def test_a_moved_occurrence_is_named_by_where_it_moved_to(self):
+        event = weekly_series({SERIES_START: {"start": MOVED_TO}})
+
+        self.assertEqual(_occurrence_view(event, SERIES_START)["start"], MOVED_TO)
+        self.assertEqual(_format_when(_occurrence_view(event, SERIES_START)), "Friday, 11 Sep 2026, 06:00 PM")
+
+    def test_an_occurrence_that_did_not_move_is_named_by_its_own_date(self):
+        """Its override says nothing about the start, so the date it was expanded at is the date."""
+
+        event = weekly_series({MOVED_TO: {"title": "Catch up (moved)"}})
+        view = _occurrence_view(event, MOVED_TO)
+
+        self.assertEqual(view["start"], MOVED_TO)
+        self.assertEqual(view["title"], "Catch up (moved)")
+
+    def test_an_occurrence_with_no_override_at_all_is_still_its_own_date(self):
+        view = _occurrence_view(weekly_series(), "2026-09-15T18:00:00")
+
+        self.assertEqual(view["start"], "2026-09-15T18:00:00")
+        self.assertEqual(view["title"], "Catch up")
+
+    def test_the_series_is_left_as_it_was(self):
+        """The view is a copy: the event belongs to the caller, which sends the series' own .ics."""
+
+        event = weekly_series({SERIES_START: {"start": MOVED_TO, "title": "Moved"}})
+        _occurrence_view(event, SERIES_START)["title"] = "Rewritten"
+
+        self.assertEqual(event["title"], "Catch up")
+        self.assertEqual(event["start"], SERIES_START)
+
+    def test_rsvp_links_outlive_the_occurrence_they_were_sent_for(self):
+        """Expiry follows the occurrence, not the series' first date — or a link mailed about a
+        later occurrence would arrive already expired."""
+
+        event = weekly_series({SERIES_START: {"start": MOVED_TO}})
+
+        self.assertGreater(_rsvp_expiry(_occurrence_view(event, SERIES_START)), _rsvp_expiry(weekly_series()))


### PR DESCRIPTION
Rescheduling a single occurrence of a recurring event leaves the series' own start alone and stores the new date as a recurrence override. The .ics carries that override, so the recipient's calendar moves — but the email body was rendered from the series, so it kept announcing the old date.

The body now renders from the occurrence's view of the event (override folded in), and the instance update passes the recurrence id it already had. Same fix covers cancelling one occurrence and RSVP replies, which read the series too.