### PR TITLE
refactor(meet): centralize local publication outcomes

### DIFF
--- a/frontend/src/apps/meet/composables/useMediaControls.test.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.test.ts
@@ -286,8 +286,8 @@ function createCameraHarness({
 				options: { publishVideo?: boolean; publishAudio?: boolean },
 			) => {
 				const result: {
-					videoProducer?: TestVideoProducer;
-					audioProducer?: TestVideoProducer;
+					video?: { status: "published" };
+					audio?: { status: "published" };
 				} = {};
 				if (options.publishVideo) {
 					const track = stream.getVideoTracks()[0] ?? null;
@@ -295,7 +295,7 @@ function createCameraHarness({
 					if (track) {
 						const producer = await createTestProducer(track, { type: "camera" });
 						mediaHandler.setProducers({ videoProducer: producer });
-						result.videoProducer = producer;
+						result.video = { status: "published" };
 					}
 				}
 				if (options.publishAudio) {
@@ -306,7 +306,7 @@ function createCameraHarness({
 							type: "microphone",
 						});
 						mediaHandler.setProducers({ audioProducer: producer });
-						result.audioProducer = producer;
+						result.audio = { status: "published" };
 					}
 				}
 				return result;
@@ -2014,7 +2014,9 @@ describe("useMediaControls", () => {
 				cleanup: vi.fn(),
 				updateOptions: vi.fn(),
 			});
-		const publishMedia = vi.fn().mockResolvedValue({});
+		const publishMedia = vi.fn().mockResolvedValue({
+			video: { status: "published" },
+		});
 		const { controls, state } = createCameraHarness({
 			mediaState: {
 				isCameraOn: true,
@@ -2076,11 +2078,8 @@ describe("useMediaControls", () => {
 				.fn()
 				.mockResolvedValue(new FakeMediaStream([nextCamera, nextMicrophone])),
 			publishMedia: vi.fn().mockResolvedValue({
-				videoError,
-				audioProducer: {
-					id: "audio-producer",
-					track: nextMicrophone,
-				},
+				video: { status: "failed", error: videoError },
+				audio: { status: "published" },
 			}),
 		});
 
@@ -2104,7 +2103,7 @@ describe("useMediaControls", () => {
 	});
 
 	it("does not treat a falsy typed error as successful E2EE video publication", async () => {
-			const publication = { videoError: null };
+			const publication = { video: { status: "failed", error: null } };
 			const oldCamera = videoTrack("old-camera");
 			const nextCamera = videoTrack("next-camera");
 			const harness = createCameraHarness({
@@ -2130,82 +2129,6 @@ describe("useMediaControls", () => {
 			expect(harness.state.isCameraOn).toBe(false);
 			expect(harness.state.localStream.getVideoTracks()).toEqual([]);
 			expect(nextCamera.stop).toHaveBeenCalledOnce();
-	});
-
-	it("fails when a detached published producer is removed from current manager state", async () => {
-		const oldCamera = videoTrack("old-camera");
-		const nextCamera = videoTrack("next-camera");
-		const detachedProducer = {
-			id: "detached-camera-producer",
-			track: nextCamera,
-		};
-		const harness = createCameraHarness({
-			mediaState: {
-				isCameraOn: true,
-				localStream: new FakeMediaStream([oldCamera]),
-			},
-			getUserMedia: vi
-				.fn()
-				.mockResolvedValue(new FakeMediaStream([nextCamera])),
-			publishMedia: vi.fn().mockResolvedValue({
-				videoProducer: detachedProducer,
-			}),
-		});
-		harness.manager.getLocalProducerState.mockReturnValue(null);
-		harness.manager.reconcileLocalProducerTrack.mockResolvedValue({
-			id: detachedProducer.id,
-			track: nextCamera,
-			paused: false,
-		});
-
-		await expect(
-			harness.controls.republishMediaAfterE2EE({ needsCamera: true }),
-		).rejects.toThrow("Video publication did not create a producer");
-
-		expect(
-			harness.manager.reconcileLocalProducerTrack,
-		).toHaveBeenCalledWith("video", nextCamera, {});
-		expect(harness.state.isCameraOn).toBe(false);
-		expect(nextCamera.stop).toHaveBeenCalledOnce();
-	});
-
-	it("reconciles a stale pre-existing producer to the requested E2EE track", async () => {
-		const oldMicrophone = audioTrack("old-microphone");
-		const nextMicrophone = audioTrack("next-microphone");
-		const replaceTrack = vi.fn(
-			async ({ track }: { track: MediaStreamTrack }) => {
-				producer.track = track;
-			},
-		);
-		const producer: TestVideoProducer = {
-			id: "stale-audio-producer",
-			track: oldMicrophone,
-			replaceTrack,
-			resume: vi.fn(),
-		};
-		const harness = createCameraHarness({
-			mediaState: {
-				isMicOn: true,
-				localStream: new FakeMediaStream([oldMicrophone]),
-			},
-			getUserMedia: vi
-				.fn()
-				.mockResolvedValue(new FakeMediaStream([nextMicrophone])),
-			audioProducer: producer,
-			publishMedia: vi.fn().mockResolvedValue({}),
-		});
-
-		await harness.controls.republishMediaAfterE2EE({ needsMicrophone: true });
-
-		expect(replaceTrack).toHaveBeenCalledWith({ track: nextMicrophone });
-		expect(producer.track).toBe(nextMicrophone);
-		expect(harness.manager.reconcileLocalProducerTrack).toHaveBeenCalledWith(
-			"audio",
-			nextMicrophone,
-			{ resume: true },
-		);
-		expect(harness.state.isMicOn).toBe(true);
-		expect(nextMicrophone.stop).not.toHaveBeenCalled();
 	});
 
 	it("falls back to raw video when public effect replacement fails", async () => {

--- a/frontend/src/apps/meet/composables/useMediaControls.ts
+++ b/frontend/src/apps/meet/composables/useMediaControls.ts
@@ -20,7 +20,6 @@ import {
 import type { DeviceType, deviceManager } from "../utils/media/DeviceManager";
 import {
 	LocalCaptureSession,
-	type LocalCaptureKindPublicationResult,
 	type LocalCaptureOperation,
 	type MediaDeviceOverrides,
 } from "../utils/media/LocalCaptureSession";
@@ -324,93 +323,7 @@ export function useMediaControls(deps: MediaControlsDeps): MediaControlsAPI {
 			publish: async (stream, options) => {
 				const manager = sfuManager.value;
 				if (!manager) return {};
-				const requestedVideoTrack = options.publishVideo
-					? (stream
-							.getVideoTracks()
-							.find((track) => track.readyState === "live") ?? null)
-					: null;
-				const requestedAudioTrack = options.publishAudio
-					? (stream
-							.getAudioTracks()
-							.find((track) => track.readyState === "live") ?? null)
-					: null;
-				const publication = (await manager.publishMedia(stream, options)) ?? {};
-				const producerMatches = (
-					producer: { track?: MediaStreamTrack | null } | null,
-					track: MediaStreamTrack,
-				) =>
-					producer?.track?.readyState === "live" &&
-					(producer.track === track || producer.track.id === track.id);
-				const ensurePublished = async (
-					kind: "video" | "audio",
-					track: MediaStreamTrack | null,
-				): Promise<LocalCaptureKindPublicationResult> => {
-					if (!track) {
-						return {
-							status: "failed",
-							error: new Error(
-								`No live ${kind} track was requested for publication`,
-							),
-						};
-					}
-					const producer = manager.getLocalProducerState(kind);
-					if (!producerMatches(producer, track)) {
-						try {
-							await manager.reconcileLocalProducerTrack(
-								kind,
-								track,
-								kind === "audio" ? { resume: true } : {},
-							);
-						} catch (error) {
-							return { status: "failed", error };
-						}
-					}
-					const currentProducer = manager.getLocalProducerState(kind);
-					if (!currentProducer) {
-						return {
-							status: "failed",
-							error: new Error(
-								`${kind === "video" ? "Video" : "Audio"} publication did not create a producer`,
-							),
-						};
-					}
-					return producerMatches(currentProducer, track)
-						? { status: "published" }
-						: {
-								status: "failed",
-								error: new Error(
-									`${kind === "video" ? "Video" : "Audio"} publication did not publish the requested track`,
-								),
-							};
-				};
-				return {
-					...(options.publishVideo
-						? {
-								video: Object.hasOwn(publication, "videoError")
-									? {
-											status: "failed" as const,
-											error: publication.videoError,
-										}
-									: await ensurePublished(
-											"video",
-											requestedVideoTrack,
-										),
-							}
-						: {}),
-					...(options.publishAudio
-						? {
-								audio: Object.hasOwn(publication, "audioError")
-									? {
-											status: "failed" as const,
-											error: publication.audioError,
-										}
-									: await ensurePublished(
-											"audio",
-											requestedAudioTrack,
-										),
-							}
-						: {}),
-				};
+				return manager.publishMedia(stream, options);
 			},
 		},
 		getLocalStream: () => mediaState.localStream,

--- a/frontend/src/apps/meet/utils/SFUMeetingManager.ts
+++ b/frontend/src/apps/meet/utils/SFUMeetingManager.ts
@@ -61,6 +61,15 @@ interface E2EEPublicationResult {
 	audioPublished: boolean;
 }
 
+type LocalPublicationOutcome =
+	| { status: "published" }
+	| { status: "failed"; error: unknown };
+
+interface LocalMediaPublicationResult {
+	video?: LocalPublicationOutcome;
+	audio?: LocalPublicationOutcome;
+}
+
 type LocalProducerKind = "audio" | "video" | "screen";
 
 interface LocalProducerState {
@@ -394,8 +403,63 @@ export class SFUMeetingManager implements MediaAttachmentFacade {
 	async publishMedia(
 		localStream: MediaStream,
 		options: { publishVideo?: boolean; publishAudio?: boolean } = {},
-	): Promise<PublishedMedia> {
-		return this.mediaManager.publishMedia(localStream, options);
+	): Promise<LocalMediaPublicationResult> {
+		return this.mediaManager.serializeSendMediaMutation(async () => {
+			const publication: LocalMediaPublicationResult = {};
+			const publish = async (
+				kind: "video" | "audio",
+				track: MediaStreamTrack | null,
+			): Promise<LocalPublicationOutcome> => {
+				if (!track) {
+					return {
+						status: "failed",
+						error: new Error(
+							`No live ${kind} track was requested for publication`,
+						),
+					};
+				}
+
+				try {
+					await this.reconcileLocalProducerTrackNow(
+						kind,
+						track,
+						kind === "audio" ? { resume: true } : {},
+					);
+					const producer = this.getLocalProducer(kind);
+					if (
+						!producer ||
+						producer.closed ||
+						producer.track?.readyState !== "live" ||
+						(producer.track !== track && producer.track?.id !== track.id)
+					) {
+						throw new Error(
+							`${kind === "video" ? "Video" : "Audio"} publication did not publish the requested track`,
+						);
+					}
+					return { status: "published" };
+				} catch (error) {
+					return { status: "failed", error };
+				}
+			};
+
+			if (options.publishVideo) {
+				publication.video = await publish(
+					"video",
+					localStream
+						.getVideoTracks()
+						.find((track) => track.readyState === "live") ?? null,
+				);
+			}
+			if (options.publishAudio) {
+				publication.audio = await publish(
+					"audio",
+					localStream
+						.getAudioTracks()
+						.find((track) => track.readyState === "live") ?? null,
+				);
+			}
+			return publication;
+		});
 	}
 
 	async publishInitialMedia(

--- a/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
+++ b/frontend/src/apps/meet/utils/__tests__/SFUMeetingManager.test.ts
@@ -330,6 +330,65 @@ describe("SFUMeetingManager facade operations", () => {
 		expect(manager.getLocalProducerState("audio")?.id).toBe("recovered-producer");
 	});
 
+	it("publishes by replacing a stale producer with the requested track", async () => {
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const manager = createManager();
+		const previousTrack = mediaTrack("previous-video", "video");
+		const requestedTrack = mediaTrack("requested-video", "video");
+		const producer = {
+			id: "video-producer",
+			track: previousTrack,
+			closed: false,
+			paused: false,
+			replaceTrack: vi.fn(async ({ track }: { track: MediaStreamTrack }) => {
+				producer.track = track;
+			}),
+			close: vi.fn(),
+		};
+		manager.mediaHandler.setProducers({ videoProducer: producer as never });
+
+		const result = await manager.publishMedia(
+			new FakeMediaStream([requestedTrack]) as never,
+			{ publishVideo: true, publishAudio: false },
+		);
+
+		expect(result).toEqual({ video: { status: "published" } });
+		expect(producer.replaceTrack).toHaveBeenCalledWith({ track: requestedTrack });
+		expect(manager.getLocalProducerState("video")?.track).toBe(requestedTrack);
+	});
+
+	it("reports audio and video publication outcomes independently", async () => {
+		vi.stubGlobal("MediaStream", FakeMediaStream);
+		const manager = createManager({
+			isConnected: vi.fn(() => false),
+		} as never);
+		const video = mediaTrack("video", "video");
+		const audio = mediaTrack("audio", "audio");
+		const videoError = new Error("video failed");
+		const audioProducer = {
+			id: "audio-producer",
+			track: audio,
+			closed: false,
+			paused: false,
+			resume: vi.fn(),
+			close: vi.fn(),
+		};
+		vi.spyOn(manager.transportManager, "createProducer")
+			.mockRejectedValueOnce(videoError)
+			.mockResolvedValueOnce(audioProducer as never);
+
+		const result = await manager.publishMedia(
+			new FakeMediaStream([video, audio]) as never,
+			{ publishVideo: true, publishAudio: true },
+		);
+
+		expect(result).toEqual({
+			video: { status: "failed", error: videoError },
+			audio: { status: "published" },
+		});
+		expect(audioProducer.resume).toHaveBeenCalledOnce();
+	});
+
 	it("abandons a delayed screen producer after screen sharing stops", async () => {
 		const closeProducer = vi.fn().mockResolvedValue(undefined);
 		const manager = createManager({

--- a/frontend/src/apps/meet/utils/media/LocalCaptureSession.ts
+++ b/frontend/src/apps/meet/utils/media/LocalCaptureSession.ts
@@ -19,7 +19,7 @@ export interface LocalCaptureOperation {
 	publicationOwner?: object | null;
 }
 
-export type LocalCaptureKindPublicationResult =
+type LocalCaptureKindPublicationResult =
 	| { status: "published" }
 	| { status: "failed"; error: unknown };
 


### PR DESCRIPTION
## Summary

- make local media publication reconcile requested tracks before reporting success
- return explicit, independent audio and video publication outcomes
- remove duplicate producer inspection and repair logic from media controls

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend 35.6% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | **35.6%** (14,351 / 40,304) (+0%) | **30.1%** (9,269 / 30,805) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34677237964) for commit `1f5e563`.</sub>

</details>
<!-- suite-coverage:end -->
