### PR TITLE
fix(meet): make participant cleanup resilient

### DIFF
--- a/suite/meet/sfu-server/src/server/ParticipantConnectionLifecycle.ts
+++ b/suite/meet/sfu-server/src/server/ParticipantConnectionLifecycle.ts
@@ -1,0 +1,173 @@
+import type { Socket } from 'socket.io';
+import type { MediasoupManager } from '../mediasoup/MediasoupManager';
+import { loggers } from '../utils/logger';
+import type { E2EEEpochRelay } from './E2EEEpochRelay';
+import type { E2eeRosterStore } from './E2eeRosterStore';
+import { isRealParticipant } from './handlers/utils';
+import type { RoomLifecycleCoordinator } from './RoomLifecycleCoordinator';
+import type { RoomRegistry } from './RoomRegistry';
+
+export class ParticipantConnectionLifecycle {
+	constructor(
+		private readonly registry: RoomRegistry,
+		private readonly roomLifecycle: RoomLifecycleCoordinator,
+		private readonly mediasoup: MediasoupManager,
+		private readonly e2eeEpochRelay: E2EEEpochRelay,
+		private readonly e2eeRoster: E2eeRosterStore,
+	) {}
+
+	async rollbackFailedAdmission(
+		socket: Socket,
+		roomId: string,
+		participantId: string,
+		peerId: string,
+		firstConnection: boolean,
+	): Promise<void> {
+		try {
+			const participantDeparted = this.registry.releaseParticipant(
+				socket,
+				roomId,
+				participantId,
+			);
+			await this.runToCompletion([
+				() => {
+					if (!firstConnection)
+						this.publishDeparture(roomId, participantId, participantDeparted);
+				},
+				() => this.registry.leaveScope(socket, roomId, 'full'),
+				() => this.removeRosterMember(socket, roomId),
+				() => this.removePendingJoiner(socket, roomId),
+				() => this.registry.removeSender(roomId, peerId),
+				() => this.mediasoup.removePeer(roomId, peerId),
+				() => socket.leave(roomId),
+				() => {
+					socket.roomId = undefined;
+					socket.participantId = undefined;
+				},
+			]);
+		} catch (error) {
+			loggers.socketHandler.warn(
+				'Join rollback failed for user %s: %s',
+				participantId,
+				(error as Error).message,
+			);
+		} finally {
+			this.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId);
+		}
+	}
+
+	async leave(
+		socket: Socket,
+		roomId: string,
+		participantId: string,
+	): Promise<void> {
+		const peerId = socket.peerId ?? participantId;
+		const participantDeparted = this.registry.releaseParticipant(
+			socket,
+			roomId,
+			participantId,
+		);
+		await this.runToCompletion([
+			() => this.removeRosterMember(socket, roomId),
+			() => this.removePendingJoiner(socket, roomId),
+			() => this.registry.removeSender(roomId, peerId),
+			() => this.mediasoup.removePeer(roomId, peerId),
+			() => this.publishDeparture(roomId, participantId, participantDeparted),
+			() => this.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId),
+			() => socket.leave(roomId),
+			() => this.registry.leaveScope(socket, roomId, 'full'),
+			() => this.registry.leaveScope(socket, roomId, 'presence-preview'),
+			() => {
+				socket.roomId = undefined;
+				socket.peerId = undefined;
+			},
+			() =>
+				loggers.socketHandler.info('%s left room %s', participantId, roomId),
+		]);
+	}
+
+	async disconnect(
+		socket: Socket,
+		roomId: string,
+		participantId: string,
+		peerId: string,
+	): Promise<void> {
+		this.registry.leaveScope(socket, roomId, 'full');
+		this.registry.leaveScope(socket, roomId, 'presence-preview');
+		const participantDeparted = this.registry.releaseParticipant(
+			socket,
+			roomId,
+			participantId,
+		);
+		await this.runToCompletion([
+			() => this.removeRosterMember(socket, roomId),
+			() => this.removePendingJoiner(socket, roomId),
+			() => this.registry.removeSender(roomId, peerId),
+			() => this.mediasoup.removePeer(roomId, peerId),
+			() => this.publishDeparture(roomId, participantId, participantDeparted),
+			() => {
+				if (participantDeparted) {
+					loggers.socketHandler.info(
+						'Cleaned up user %s from room %s',
+						participantId,
+						roomId,
+					);
+				}
+			},
+			() => this.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId),
+		]);
+	}
+
+	private removeRosterMember(
+		socket: Socket,
+		roomId: string,
+	): Promise<void> | undefined {
+		if (socket.senderId !== undefined)
+			return this.e2eeRoster.remove(roomId, socket.senderId);
+	}
+
+	private removePendingJoiner(socket: Socket, roomId: string): void {
+		if (socket.senderId !== undefined)
+			this.e2eeEpochRelay.removePendingJoiner(roomId, socket.senderId);
+	}
+
+	private publishDeparture(
+		roomId: string,
+		participantId: string,
+		participantDeparted: boolean,
+	): void {
+		if (
+			!participantDeparted ||
+			this.registry.getParticipantSocketIds(roomId, participantId).length > 0
+		)
+			return;
+		if (isRealParticipant(participantId)) {
+			this.registry.emitParticipantEvent(
+				roomId,
+				'participant_left',
+				participantId,
+			);
+		}
+		if (!this.registry.hasRaisedHand(roomId, participantId)) return;
+		this.registry.clearRaisedHand(roomId, participantId);
+		this.registry.emitRaisedHand(roomId, {
+			participantId,
+			raised: false,
+			timestamp: new Date().toISOString(),
+		});
+	}
+
+	private async runToCompletion(
+		steps: Array<() => void | Promise<void>>,
+	): Promise<void> {
+		let firstError: unknown;
+		for (const step of steps) {
+			try {
+				await step();
+			} catch (error) {
+				firstError ??= error;
+			}
+		}
+		if (firstError) throw firstError;
+	}
+}

--- a/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
+++ b/suite/meet/sfu-server/src/server/SocketHandlerManager.ts
@@ -30,6 +30,7 @@ import { registerRoomJoinHandlers } from './handlers/RoomJoinHandlers';
 import { registerRoomQueryHandlers } from './handlers/RoomQueryHandlers';
 import { registerScreenShareHandlers } from './handlers/ScreenShareHandlers';
 import { registerWebRtcTransportHandlers } from './handlers/WebRtcTransportHandlers';
+import { ParticipantConnectionLifecycle } from './ParticipantConnectionLifecycle';
 import type { RecordingGrantManager } from './RecordingGrantManager';
 import { RoomLifecycleCoordinator } from './RoomLifecycleCoordinator';
 import { RoomRegistry } from './RoomRegistry';
@@ -45,6 +46,7 @@ export class SocketHandlerManager {
 	private rateLimiter: RateLimiter;
 	private e2eeEpochRelay: E2EEEpochRelay;
 	private roomLifecycle: RoomLifecycleCoordinator;
+	private participantConnections: ParticipantConnectionLifecycle;
 	private telemetry: Telemetry;
 	private registerHandlers: ((socket: import('socket.io').Socket) => void)[];
 	private idleExpirySweep: NodeJS.Timeout | null = null;
@@ -81,6 +83,13 @@ export class SocketHandlerManager {
 			roster,
 			this.mediasoup,
 		);
+		this.participantConnections = new ParticipantConnectionLifecycle(
+			this.registry,
+			this.roomLifecycle,
+			this.mediasoup,
+			this.e2eeEpochRelay,
+			roster,
+		);
 
 		const deps: HandlerDeps = {
 			io,
@@ -91,6 +100,7 @@ export class SocketHandlerManager {
 			rateLimiter: this.rateLimiter,
 			e2eeEpochRelay: this.e2eeEpochRelay,
 			e2eeRoster: roster,
+			participantConnections: this.participantConnections,
 			telemetry,
 			runtime: this.runtime,
 		};

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -973,6 +973,147 @@ describe('SocketHandlerManager characterization', () => {
 		vi.useRealTimers();
 	});
 
+	it('releases Participant Connection ownership when admission fails so a fresh connection can join', async () => {
+		const harness = createManager();
+		const failed = connectFullSocket(harness, {
+			id: 'sock-failed',
+			userId: 'user-1',
+		});
+		vi.spyOn(harness.roster, 'add').mockRejectedValueOnce(
+			new Error('roster unavailable'),
+		);
+		const failedCallback = vi.fn();
+
+		emitJoin(failed, { connectionId: 'failed-device' }, failedCallback);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(failedCallback).toHaveBeenCalledWith({
+			success: false,
+			error: 'roster unavailable',
+		});
+
+		const retry = connectFullSocket(harness, {
+			id: 'sock-retry',
+			userId: 'user-1',
+		});
+		const retryCallback = vi.fn();
+		emitJoin(retry, { connectionId: 'fresh-device' }, retryCallback);
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(retryCallback).toHaveBeenCalledWith({
+			success: true,
+			senderId: retry.senderId,
+		});
+	});
+
+	it('explicit leave followed by disconnect removes one Participant Connection exactly once', async () => {
+		const harness = createManager();
+		const observer = connectFullSocket(harness, {
+			id: 'sock-observer',
+			userId: 'observer-1',
+		});
+		emitJoin(observer, { userId: 'observer-1', name: 'Observer' });
+		const leaving = connectFullSocket(harness, {
+			id: 'sock-leaving',
+			userId: 'user-1',
+		});
+		emitJoin(leaving);
+		await new Promise((resolve) => setImmediate(resolve));
+		observer.emitCalls.length = 0;
+		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
+
+		leaving.fire('leave_room');
+		await new Promise((resolve) => setImmediate(resolve));
+		leaving.fire('disconnect', 'client namespace disconnect');
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledTimes(1);
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
+			'room-1',
+			'sock-leaving',
+		);
+		expect(
+			observer.emitCalls.filter((call) => call.event === 'participant_left'),
+		).toHaveLength(1);
+		expect(leaving.roomId).toBeUndefined();
+	});
+
+	it('does not publish a stale departure after a new Participant Connection joins during cleanup', async () => {
+		const harness = createManager();
+		const observer = connectFullSocket(harness, {
+			id: 'sock-observer',
+			userId: 'observer-1',
+		});
+		emitJoin(observer, { userId: 'observer-1', name: 'Observer' });
+		const leaving = connectFullSocket(harness, {
+			id: 'sock-leaving',
+			userId: 'user-1',
+		});
+		emitJoin(leaving, { connectionId: 'old-device' });
+		await new Promise((resolve) => setImmediate(resolve));
+
+		let finishRosterRemoval = () => {};
+		vi.spyOn(harness.roster, 'remove').mockImplementationOnce(
+			() =>
+				new Promise<void>((resolve) => {
+					finishRosterRemoval = resolve;
+				}),
+		);
+		observer.emitCalls.length = 0;
+		leaving.fire('leave_room');
+		await new Promise((resolve) => setImmediate(resolve));
+
+		const replacement = connectFullSocket(harness, {
+			id: 'sock-replacement',
+			userId: 'user-1',
+		});
+		const replacementCallback = vi.fn();
+		emitJoin(replacement, { connectionId: 'new-device' }, replacementCallback);
+		await new Promise((resolve) => setImmediate(resolve));
+		finishRosterRemoval();
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(replacementCallback).toHaveBeenCalledWith({
+			success: true,
+			senderId: replacement.senderId,
+		});
+		expect(
+			observer.emitCalls.filter((call) => call.event === 'participant_left'),
+		).toHaveLength(0);
+	});
+
+	it('finishes Participant Connection cleanup when one resource rejects removal', async () => {
+		const harness = createManager();
+		const observer = connectFullSocket(harness, {
+			id: 'sock-observer',
+			userId: 'observer-1',
+		});
+		emitJoin(observer, { userId: 'observer-1', name: 'Observer' });
+		const leaving = connectFullSocket(harness, {
+			id: 'sock-leaving',
+			userId: 'user-1',
+		});
+		emitJoin(leaving);
+		await new Promise((resolve) => setImmediate(resolve));
+		vi.spyOn(harness.roster, 'remove').mockRejectedValueOnce(
+			new Error('roster unavailable'),
+		);
+		observer.emitCalls.length = 0;
+		(harness.mediasoup.removePeer as ReturnType<typeof vi.fn>).mockClear();
+
+		leaving.fire('leave_room');
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(harness.mediasoup.removePeer).toHaveBeenCalledWith(
+			'room-1',
+			'sock-leaving',
+		);
+		expect(
+			observer.emitCalls.filter((call) => call.event === 'participant_left'),
+		).toHaveLength(1);
+		expect(leaving.roomId).toBeUndefined();
+	});
+
 	it('disconnect of a full-access socket removes the peer, broadcasts participant_left, and closes the room after grace when the last human leaves', async () => {
 		vi.useFakeTimers();
 		const harness = createManager();

--- a/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/DisconnectHandlers.ts
@@ -2,7 +2,6 @@ import type { Socket } from 'socket.io';
 import { normalizeDisconnectReason } from '../../telemetry/Telemetry';
 import { loggers } from '../../utils/logger';
 import type { HandlerDeps } from './Handler';
-import { isRealParticipant } from './utils';
 
 export function registerDisconnectHandlers(deps: HandlerDeps) {
 	return (socket: Socket) => {
@@ -41,47 +40,16 @@ export function registerDisconnectHandlers(deps: HandlerDeps) {
 							await deps.mediasoup.removePeer(roomId, participantId);
 						}
 					}
-					deps.registry.leaveScope(socket, roomId, 'full');
-					deps.registry.leaveScope(socket, roomId, 'presence-preview');
-
 					if (socket.scope === 'full') {
-						const participantDeparted = deps.registry.releaseParticipant(
+						await deps.participantConnections.disconnect(
 							socket,
 							roomId,
 							participantId,
+							peerId,
 						);
-						if (socket.senderId !== undefined) {
-							await deps.e2eeRoster.remove(roomId, socket.senderId);
-							deps.e2eeEpochRelay.removePendingJoiner(roomId, socket.senderId);
-						}
-						deps.registry.removeSender(roomId, peerId);
-						await deps.mediasoup.removePeer(roomId, peerId);
-
-						if (participantDeparted) {
-							if (isRealParticipant(participantId)) {
-								deps.registry.emitParticipantEvent(
-									roomId,
-									'participant_left',
-									participantId,
-								);
-							}
-
-							if (deps.registry.hasRaisedHand(roomId, participantId)) {
-								deps.registry.clearRaisedHand(roomId, participantId);
-								deps.registry.emitRaisedHand(roomId, {
-									participantId,
-									raised: false,
-									timestamp: new Date().toISOString(),
-								});
-							}
-
-							loggers.socketHandler.info(
-								'Cleaned up user %s from room %s',
-								participantId,
-								roomId,
-							);
-						}
-						deps.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId);
+					} else {
+						deps.registry.leaveScope(socket, roomId, 'full');
+						deps.registry.leaveScope(socket, roomId, 'presence-preview');
 					}
 				} catch (error) {
 					loggers.socketHandler.error('Error handling disconnect: %s', error);

--- a/suite/meet/sfu-server/src/server/handlers/Handler.ts
+++ b/suite/meet/sfu-server/src/server/handlers/Handler.ts
@@ -11,6 +11,7 @@ import type { RateLimiter } from '../../utils/rateLimiter';
 import type { AuthManager } from '../AuthManager';
 import type { E2EEEpochRelay } from '../E2EEEpochRelay';
 import type { E2eeRosterStore } from '../E2eeRosterStore';
+import type { ParticipantConnectionLifecycle } from '../ParticipantConnectionLifecycle';
 import type { RoomLifecycleCoordinator } from '../RoomLifecycleCoordinator';
 import type { RoomRegistry } from '../RoomRegistry';
 
@@ -30,6 +31,7 @@ export interface HandlerDeps {
 	rateLimiter: RateLimiter;
 	e2eeEpochRelay: E2EEEpochRelay;
 	e2eeRoster: E2eeRosterStore;
+	participantConnections: ParticipantConnectionLifecycle;
 	telemetry: Telemetry;
 	runtime: SFUConfig['runtime'];
 }

--- a/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/RoomJoinHandlers.ts
@@ -197,45 +197,16 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 		} catch (error) {
 			if (socket.scope === 'full') {
 				if (participantClaimed) {
-					const participantDeparted = deps.registry.releaseParticipant(
+					await deps.participantConnections.rollbackFailedAdmission(
 						socket,
 						getRoomId(socket),
 						participantId,
+						peerId,
+						firstConnection,
 					);
-					if (
-						participantDeparted &&
-						!firstConnection &&
-						isRealParticipant(participantId)
-					) {
-						deps.registry.emitParticipantEvent(
-							getRoomId(socket),
-							'participant_left',
-							participantId,
-						);
-					}
-					try {
-						deps.registry.leaveScope(socket, getRoomId(socket), 'full');
-						if (socket.senderId !== undefined) {
-							await deps.e2eeRoster.remove(getRoomId(socket), socket.senderId);
-							deps.e2eeEpochRelay.removePendingJoiner(
-								getRoomId(socket),
-								socket.senderId,
-							);
-						}
-						deps.registry.removeSender(getRoomId(socket), peerId);
-						await deps.mediasoup.removePeer(getRoomId(socket), peerId);
-						socket.leave(getRoomId(socket));
-						socket.roomId = undefined;
-						socket.participantId = undefined;
-					} catch (cleanupError) {
-						loggers.socketHandler.warn(
-							'Join rollback failed for user %s: %s',
-							participantId,
-							(cleanupError as Error).message,
-						);
-					}
+				} else {
+					deps.roomLifecycle.scheduleCleanupIfHumanEmpty(getRoomId(socket));
 				}
-				deps.roomLifecycle.scheduleCleanupIfHumanEmpty(getRoomId(socket));
 			}
 			deps.telemetry.recordRoomJoin(
 				{ scope, rejoin, outcome: 'failure' },
@@ -406,6 +377,14 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 			const participantId = socket.participantId;
 			if (roomId && participantId) {
 				try {
+					if (socket.scope === 'full') {
+						await deps.participantConnections.leave(
+							socket,
+							roomId,
+							participantId,
+						);
+						return;
+					}
 					if (socket.scope === 'recording') {
 						const ownsPeer = deps.registry.leaveRecorder(
 							socket,
@@ -416,43 +395,6 @@ export function registerRoomJoinHandlers(deps: HandlerDeps) {
 							await deps.mediasoup.removePeer(roomId, participantId);
 						}
 					}
-					const participantDeparted = deps.registry.releaseParticipant(
-						socket,
-						roomId,
-						participantId,
-					);
-					const peerId = socket.peerId ?? participantId;
-					if (socket.scope === 'full') {
-						if (socket.senderId !== undefined) {
-							await deps.e2eeRoster.remove(roomId, socket.senderId);
-							deps.e2eeEpochRelay.removePendingJoiner(roomId, socket.senderId);
-						}
-						deps.registry.removeSender(roomId, peerId);
-						await deps.mediasoup.removePeer(roomId, peerId);
-					}
-
-					if (participantDeparted) {
-						if (isRealParticipant(participantId)) {
-							deps.registry.emitParticipantEvent(
-								roomId,
-								'participant_left',
-								participantId,
-							);
-						}
-
-						if (deps.registry.hasRaisedHand(roomId, participantId)) {
-							deps.registry.clearRaisedHand(roomId, participantId);
-							deps.registry.emitRaisedHand(roomId, {
-								participantId,
-								raised: false,
-								timestamp: new Date().toISOString(),
-							});
-						}
-					}
-					if (socket.scope === 'full') {
-						deps.roomLifecycle.scheduleCleanupIfHumanEmpty(roomId);
-					}
-
 					socket.leave(roomId);
 					deps.registry.leaveScope(socket, roomId, 'full');
 					deps.registry.leaveScope(socket, roomId, 'presence-preview');


### PR DESCRIPTION
## Summary

- centralize Participant Connection rollback, leave, and disconnect cleanup
- complete independent cleanup steps even when one removal fails
- suppress stale departure state after a replacement connection takes ownership
- cover failed admission, repeated departure, replacement races, and partial cleanup failures

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34677344292) for commit `b04b170`.</sub>

</details>
<!-- suite-coverage:end -->
