### PR TITLE
fix(meet): complete recording publication

### DIFF
--- a/suite/meet/CONTEXT.md
+++ b/suite/meet/CONTEXT.md
@@ -90,7 +90,7 @@ _Avoid_: Server-side Encryption
 - A **Recording Artifact** belongs to exactly one **Room Owner**.
 - A **Recording Artifact** appears in Drive only after its video is valid and ready.
 - A **Recording Artifact** is named from its Meet Room title and Recording Session start time.
-- Only the **Room Owner** receives post-processing ready, partial, or failed notifications.
+- Only the **Room Owner** receives post-processing ready, partial, or failed notifications, delivered by email rather than an in-app notification.
 - Trashing a **Recording Artifact** follows normal reversible Drive behavior; permanently deleting it also deletes its Recording Session metadata.
 - A **Recording Initiator** controls a **Recording Session** but does not thereby own its **Recording Artifact**.
 - A **Recorder Endpoint** observes the **Shared Stage** but does not count as a participant or keep the room human-occupied.

--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -1244,6 +1244,10 @@ def recorder_stopped(
 def recorder_upload_chunk(
     recording_id: str, job: str, offset: int, chunk_sha256: str, protocol_version: int
 ) -> dict:
+    if protocol_version == str(PROTOCOL_VERSION):
+        protocol_version = PROTOCOL_VERSION
+    if isinstance(offset, str) and offset.isdecimal():
+        offset = int(offset)
     _validate_callback_protocol(protocol_version)
     authenticate_callback(
         protocol_version=protocol_version,

--- a/suite/meet/api/recording.py
+++ b/suite/meet/api/recording.py
@@ -1242,20 +1242,18 @@ def recorder_stopped(
 
 @frappe.whitelist(allow_guest=True, methods=["POST"])
 def recorder_upload_chunk(
-    recording_id: str, job: str, offset: int, chunk_sha256: str, protocol_version: int
+    recording_id: str, job: str, offset: str, chunk_sha256: str, protocol_version: str
 ) -> dict:
-    if protocol_version == str(PROTOCOL_VERSION):
-        protocol_version = PROTOCOL_VERSION
-    if isinstance(offset, str) and offset.isdecimal():
-        offset = int(offset)
-    _validate_callback_protocol(protocol_version)
+    if protocol_version != str(PROTOCOL_VERSION):
+        frappe.throw(_("Unsupported recording callback protocol version"))
     authenticate_callback(
-        protocol_version=protocol_version,
+        protocol_version=PROTOCOL_VERSION,
         recording=recording_id,
         job=job,
         operation="upload_chunk",
         operation_id=f"{offset}:{chunk_sha256}",
     )
+    offset_value = int(offset)
     if frappe.request.content_type != "application/octet-stream":
         frappe.throw(_("Recording upload chunks must be binary data"))
     if frappe.request.content_length is not None and frappe.request.content_length > CHUNK_SIZE:
@@ -1263,7 +1261,7 @@ def recorder_upload_chunk(
     return _callback_response(
         append_chunk(
             recording_id,
-            offset=offset,
+            offset=offset_value,
             chunk=frappe.request.get_data(cache=True),
             chunk_sha256=chunk_sha256,
         )

--- a/suite/meet/api/test/test_callback_security.py
+++ b/suite/meet/api/test/test_callback_security.py
@@ -328,7 +328,9 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
             frappe.local.request = request
             with patch("suite.meet.api.recording.append_chunk", return_value={"offset": 5}) as append:
                 self.assertEqual(
-                    recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest, 1),
+                    recorder_upload_chunk(
+                        self.recording.name, self.recording.recorder_job_id, "0", digest, "1"
+                    ),
                     {"protocol_version": 1, "offset": 5},
                 )
             append.assert_called_once_with(

--- a/suite/meet/api/test/test_callback_security.py
+++ b/suite/meet/api/test/test_callback_security.py
@@ -314,13 +314,13 @@ class IntegrationTestRecordingCallbackSecurity(IntegrationTestCase):
                     frappe.local.request = Mock(content_type=content_type, content_length=5)
                     with self.assertRaises(frappe.ValidationError):
                         recorder_upload_chunk(
-                            self.recording.name, self.recording.recorder_job_id, 0, digest, 1
+                            self.recording.name, self.recording.recorder_job_id, "0", digest, "1"
                         )
 
             request = Mock(content_type="application/octet-stream", content_length=CHUNK_SIZE + 1)
             frappe.local.request = request
             with self.assertRaises(frappe.ValidationError):
-                recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, 0, digest, 1)
+                recorder_upload_chunk(self.recording.name, self.recording.recorder_job_id, "0", digest, "1")
             request.get_data.assert_not_called()
 
             request = Mock(content_type="application/octet-stream", content_length=5)

--- a/suite/meet/api/test/test_recording.py
+++ b/suite/meet/api/test/test_recording.py
@@ -640,9 +640,10 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 sendmail.call_args.kwargs["message_id"],
                 f"meet-recording-finalization-{recording.name}@{frappe.local.site}",
             )
-            self.assertIn("could not be processed", sendmail.call_args.kwargs["message"])
-            self.assertIn("No recording was added to Drive", sendmail.call_args.kwargs["message"])
-            self.assertNotIn("/drive/f/", sendmail.call_args.kwargs["message"])
+            self.assertEqual(sendmail.call_args.kwargs["template"], "meet_recording")
+            self.assertIn("could not be processed", sendmail.call_args.kwargs["args"]["description"])
+            self.assertIn("No recording was added to Drive", sendmail.call_args.kwargs["args"]["description"])
+            self.assertIsNone(sendmail.call_args.kwargs["args"]["link"])
             self.assertFalse(frappe.db.exists("Notification Log", {"document_name": recording.name}))
         finally:
             path.unlink(missing_ok=True)
@@ -686,9 +687,9 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 sendmail.call_args.kwargs["subject"],
                 "Your recording of Weekly planning is ready",
             )
-            self.assertIn("Weekly planning", sendmail.call_args.kwargs["message"])
-            self.assertIn("Open recording in Drive", sendmail.call_args.kwargs["message"])
-            self.assertIn(artifact_url, sendmail.call_args.kwargs["message"])
+            self.assertEqual(sendmail.call_args.kwargs["template"], "meet_recording")
+            self.assertIn("Weekly planning", sendmail.call_args.kwargs["args"]["description"])
+            self.assertEqual(sendmail.call_args.kwargs["args"]["link"], artifact_url)
             self.assertFalse(frappe.db.exists("Notification Log", {"document_name": recording.name}))
         finally:
             frappe.delete_doc("File", artifact.name, force=True, ignore_permissions=True)
@@ -745,8 +746,12 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
             ):
                 deliver_recording_notification(completed.name)
             self.assertIn("partial recording", sendmail.call_args.kwargs["subject"])
-            self.assertIn("Some portions could not be captured", sendmail.call_args.kwargs["message"])
-            self.assertIn(f"/drive/f/{artifact.name}", sendmail.call_args.kwargs["message"])
+            self.assertEqual(sendmail.call_args.kwargs["template"], "meet_recording")
+            self.assertIn(
+                "Some portions could not be captured",
+                sendmail.call_args.kwargs["args"]["description"],
+            )
+            self.assertIn(f"/drive/f/{artifact.name}", sendmail.call_args.kwargs["args"]["link"])
         finally:
             path.unlink(missing_ok=True)
             if artifact:

--- a/suite/meet/api/test/test_recording.py
+++ b/suite/meet/api/test/test_recording.py
@@ -14,10 +14,13 @@ from frappe.tests import IntegrationTestCase
 from frappe.utils import add_to_date, now_datetime
 
 from suite.drive.api.storage import get_storage_reservation, get_storage_usage
+from suite.drive.utils import create_drive_file
 from suite.meet.api.recording import (
     BYTES_PER_SECOND,
     MAX_BUDGET_BYTES,
+    MAX_SECONDS,
     MINIMUM_BUDGET_BYTES,
+    STARTUP_TIMEOUT_SECONDS,
     _apply_segment_progress,
     _limits,
     _reconcile_interrupted,
@@ -461,8 +464,8 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                     "suite.meet.recording.ingest._recordings_folder",
                     return_value=recording.drive_home_folder,
                 ),
-                patch("suite.meet.recording.ingest.update_file_size"),
-                patch("suite.meet.recording.ingest.FileManager.upload_file"),
+                patch("suite.drive.utils.update_file_size"),
+                patch("suite.drive.utils.files.FileManager.upload_file"),
                 patch("suite.meet.recording.ingest.frappe.enqueue") as enqueue,
                 patch("suite.meet.api.recording._publish_state") as publish_state,
             ):
@@ -568,7 +571,7 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         finally:
             path.unlink(missing_ok=True)
 
-    def test_terminal_notification_is_owner_only_and_does_not_gate_cleanup(self):
+    def test_terminal_email_is_owner_only_and_does_not_gate_cleanup(self):
         started = start(self.room.name, str(uuid.uuid4()))
         stop(self.room.name)
         content = b"invalid-artifact"
@@ -637,18 +640,58 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                 sendmail.call_args.kwargs["message_id"],
                 f"meet-recording-finalization-{recording.name}@{frappe.local.site}",
             )
-            self.assertTrue(
-                frappe.db.exists(
-                    "Notification Log",
-                    {
-                        "for_user": self.owner,
-                        "document_type": "Meet Recording",
-                        "document_name": recording.name,
-                    },
-                )
-            )
+            self.assertIn("could not be processed", sendmail.call_args.kwargs["message"])
+            self.assertIn("No recording was added to Drive", sendmail.call_args.kwargs["message"])
+            self.assertNotIn("/drive/f/", sendmail.call_args.kwargs["message"])
+            self.assertFalse(frappe.db.exists("Notification Log", {"document_name": recording.name}))
         finally:
             path.unlink(missing_ok=True)
+
+    def test_ready_email_names_room_and_links_to_drive_artifact(self):
+        self.room.db_set("title", "Weekly planning")
+        started = start(self.room.name, str(uuid.uuid4()))
+        stop(self.room.name)
+        recording = frappe.get_doc("Meet Recording", started["name"])
+        artifact = create_drive_file(
+            "Weekly planning recording.mp4",
+            recording.drive_home_folder,
+            "Video",
+            "/weekly-planning-recording.mp4",
+            mime_type="video/mp4",
+            owner=self.owner,
+        )
+        recording.db_set(
+            {
+                "status": "Ready",
+                "artifact": artifact.name,
+                "artifact_size": 1,
+                "artifact_duration": 1,
+                "artifact_sha256": "a" * 64,
+                "notification_pending": 1,
+                "notification_next_retry_at": now_datetime(),
+            },
+            update_modified=False,
+        )
+
+        artifact_url = f"https://suite.test/drive/f/{artifact.name}"
+        try:
+            with (
+                patch("suite.meet.recording.ingest.frappe.sendmail") as sendmail,
+                patch("suite.meet.recording.ingest.frappe.utils.get_url", return_value=artifact_url),
+            ):
+                deliver_recording_notification(recording.name)
+
+            self.assertEqual(sendmail.call_args.kwargs["recipients"], [self.owner])
+            self.assertEqual(
+                sendmail.call_args.kwargs["subject"],
+                "Your recording of Weekly planning is ready",
+            )
+            self.assertIn("Weekly planning", sendmail.call_args.kwargs["message"])
+            self.assertIn("Open recording in Drive", sendmail.call_args.kwargs["message"])
+            self.assertIn(artifact_url, sendmail.call_args.kwargs["message"])
+            self.assertFalse(frappe.db.exists("Notification Log", {"document_name": recording.name}))
+        finally:
+            frappe.delete_doc("File", artifact.name, force=True, ignore_permissions=True)
 
     def test_completed_upload_with_capture_gap_creates_partial_artifact(self):
         started = start(self.room.name, str(uuid.uuid4()))
@@ -685,14 +728,25 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
                     "suite.meet.recording.ingest._recordings_folder",
                     return_value=recording.drive_home_folder,
                 ),
-                patch("suite.meet.recording.ingest.update_file_size"),
-                patch("suite.meet.recording.ingest.FileManager.upload_file"),
+                patch("suite.drive.utils.update_file_size"),
+                patch("suite.drive.utils.files.FileManager.upload_file"),
             ):
                 result = process_upload(recording.name)
             completed = frappe.get_doc("Meet Recording", recording.name)
             artifact = frappe.get_doc("File", completed.artifact)
             self.assertEqual(result["status"], "Partial")
             self.assertEqual(frappe.parse_json(completed.capture_gaps), [gap])
+            with (
+                patch("suite.meet.recording.ingest.frappe.sendmail") as sendmail,
+                patch(
+                    "suite.meet.recording.ingest.frappe.utils.get_url",
+                    return_value=f"https://suite.test/drive/f/{artifact.name}",
+                ),
+            ):
+                deliver_recording_notification(completed.name)
+            self.assertIn("partial recording", sendmail.call_args.kwargs["subject"])
+            self.assertIn("Some portions could not be captured", sendmail.call_args.kwargs["message"])
+            self.assertIn(f"/drive/f/{artifact.name}", sendmail.call_args.kwargs["message"])
         finally:
             path.unlink(missing_ok=True)
             if artifact:
@@ -735,6 +789,16 @@ class IntegrationTestRecordingApi(IntegrationTestCase):
         self.assertEqual(recording.recorder_key_thumbprint, "xx0BcA-wMohw8atYDJOe6peGModklG2wRHBlXHMvl0M")
         client.deliver_grant.assert_called_once()
         self.assertEqual(client.deliver_grant.call_args.kwargs["endpoint_generation"], 0)
+        grant = jwt.decode(
+            client.deliver_grant.call_args.kwargs["grant"],
+            frappe.conf.sfu_secret,
+            algorithms=["HS256"],
+            audience="meet-sfu-recorder",
+        )
+        self.assertLessEqual(
+            grant["authorization_expires_at"] - grant["iat"],
+            MAX_SECONDS + STARTUP_TIMEOUT_SECONDS,
+        )
 
     def test_replacement_ready_rotates_key_and_grant_once(self):
         recording, interrupted, interruption_id = self._interrupted_recording()

--- a/suite/meet/api/test/test_recording_reliability.py
+++ b/suite/meet/api/test/test_recording_reliability.py
@@ -175,8 +175,8 @@ class IntegrationTestRecordingReliability(IntegrationTestCase):
                     "suite.meet.recording.ingest._recordings_folder",
                     return_value=recording.drive_home_folder,
                 ),
-                patch("suite.meet.recording.ingest.update_file_size"),
-                patch("suite.meet.recording.ingest.FileManager.upload_file"),
+                patch("suite.drive.utils.update_file_size"),
+                patch("suite.drive.utils.files.FileManager.upload_file"),
             ):
                 result = process_upload(recording.name)
             artifact = frappe.get_doc("File", result["artifact"])

--- a/suite/meet/recording/ingest.py
+++ b/suite/meet/recording/ingest.py
@@ -549,13 +549,15 @@ def deliver_recording_notification(recording_name: str):
     frappe.db.commit()
     try:
         recording = frappe.get_doc("Meet Recording", recording_name)
-        subject, message = _recording_email_content(recording)
+        subject, args = _recording_email_content(recording)
         message_id = f"meet-recording-finalization-{recording.name}@{frappe.local.site}"
         if not frappe.db.exists("Email Queue", {"message_id": message_id}):
             frappe.sendmail(
                 recipients=[recording.room_owner],
                 subject=subject,
-                message=message,
+                template="meet_recording",
+                args=args,
+                inline_images=_meet_logo_inline_images(),
                 reference_doctype="Meet Recording",
                 reference_name=recording.name,
                 message_id=message_id,
@@ -585,35 +587,34 @@ def deliver_recording_notification(recording_name: str):
         )
 
 
-def _recording_email_content(recording) -> tuple[str, str]:
+def _recording_email_content(recording) -> tuple[str, dict]:
     room_title = frappe.db.get_value("Meet Room", recording.meet_room, "title") or _("Untitled Meet Room")
     recorded_at = format_datetime(recording.started_at or recording.creation, "medium")
-    room_title_html = frappe.utils.escape_html(room_title)
-    recorded_at_html = frappe.utils.escape_html(recorded_at)
 
     if recording.status == "Ready":
         subject = _("Your recording of {0} is ready").format(room_title)
-        description = _("The recording of <strong>{0}</strong> from {1} is ready in Drive.").format(
-            room_title_html, recorded_at_html
-        )
+        description = _("The recording of {0} from {1} is ready in Drive.").format(room_title, recorded_at)
     elif recording.status == "Partial":
         subject = _("Your partial recording of {0} is ready").format(room_title)
         description = _(
-            "A partial recording of <strong>{0}</strong> from {1} is ready in Drive. "
-            "Some portions could not be captured."
-        ).format(room_title_html, recorded_at_html)
+            "A partial recording of {0} from {1} is ready in Drive. Some portions could not be captured."
+        ).format(room_title, recorded_at)
     else:
         subject = _("Your recording of {0} could not be processed").format(room_title)
         description = _(
-            "The recording of <strong>{0}</strong> from {1} could not be processed. "
-            "No recording was added to Drive."
-        ).format(room_title_html, recorded_at_html)
+            "The recording of {0} from {1} could not be processed. No recording was added to Drive."
+        ).format(room_title, recorded_at)
 
     link = frappe.utils.get_url(f"/drive/f/{recording.artifact}") if recording.artifact else None
-    message = f"<p>{description}</p>"
-    if link:
-        message += f'<p><a href="{frappe.utils.escape_html(link)}">{_("Open recording in Drive")}</a></p>'
-    return subject, message
+    return subject, {"description": description, "link": link}
+
+
+def _meet_logo_inline_images():
+    try:
+        logo = Path(frappe.get_app_path("suite", "public", "meet", "images", "meet.png"))
+        return [{"filename": "meet-logo.png", "filecontent": logo.read_bytes()}]
+    except OSError:
+        return []
 
 
 def _locked_recording(name: str):

--- a/suite/meet/recording/ingest.py
+++ b/suite/meet/recording/ingest.py
@@ -11,16 +11,17 @@ from contextlib import suppress
 from datetime import UTC
 from fractions import Fraction
 from pathlib import Path
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
 import frappe
 from frappe import _
-from frappe.utils import add_to_date, cint, get_datetime, get_system_timezone, now_datetime
+from frappe.utils import add_to_date, cint, format_datetime, get_datetime, get_system_timezone, now_datetime
 
-from suite.drive.api.storage import acquire_owner_storage_lock, reduce_storage_reservation
-from suite.drive.utils import create_drive_file, get_new_file_name, update_file_size
-from suite.drive.utils.files import FileManager, get_s3_key, get_s3_url
 from suite.meet.doctype.meet_recording.meet_recording import recording_storage_reservation_key
+
+if TYPE_CHECKING:
+    from suite.drive.utils.files import FileManager
 
 CHUNK_SIZE = 8 * 1024 * 1024
 UPLOAD_DIRECTORY = ".recording-uploads"
@@ -53,6 +54,8 @@ def begin_upload(
     ended_at=None,
     end_reason: str | None = None,
 ) -> dict:
+    from suite.drive.api.storage import reduce_storage_reservation
+
     size = cint(size)
     duration_ms = cint(duration_ms)
     if size <= 0 or duration_ms <= 0 or not isinstance(sha256, str) or not _sha256(sha256):
@@ -341,6 +344,10 @@ def _claim_finalization(recording_name: str):
 
 
 def _publish_artifact(recording_name: str, path: Path) -> dict:
+    from suite.drive.api.storage import acquire_owner_storage_lock
+    from suite.drive.utils import create_drive_file, get_new_file_name, update_file_size
+    from suite.drive.utils.files import FileManager, get_s3_key, get_s3_url
+
     recording = _locked_recording(recording_name)
     if recording.status in ("Ready", "Partial"):
         return {"artifact": recording.artifact, "status": recording.status}
@@ -542,37 +549,13 @@ def deliver_recording_notification(recording_name: str):
     frappe.db.commit()
     try:
         recording = frappe.get_doc("Meet Recording", recording_name)
-        subject = {
-            "Ready": _("Your recording is ready"),
-            "Partial": _("Your partial recording is ready"),
-            "Failed": _("Your recording could not be processed"),
-        }[recording.status]
-        if not frappe.db.exists(
-            "Notification Log",
-            {
-                "for_user": recording.room_owner,
-                "document_type": "Meet Recording",
-                "document_name": recording.name,
-                "type": "Alert",
-            },
-        ):
-            frappe.get_doc(
-                {
-                    "doctype": "Notification Log",
-                    "subject": subject,
-                    "for_user": recording.room_owner,
-                    "type": "Alert",
-                    "document_type": "Meet Recording",
-                    "document_name": recording.name,
-                    "from_user": "Administrator",
-                }
-            ).insert(ignore_permissions=True)
+        subject, message = _recording_email_content(recording)
         message_id = f"meet-recording-finalization-{recording.name}@{frappe.local.site}"
         if not frappe.db.exists("Email Queue", {"message_id": message_id}):
             frappe.sendmail(
                 recipients=[recording.room_owner],
                 subject=subject,
-                message=subject,
+                message=message,
                 reference_doctype="Meet Recording",
                 reference_name=recording.name,
                 message_id=message_id,
@@ -600,6 +583,37 @@ def deliver_recording_notification(recording_name: str):
             title=f"Meet recording notification failed for {recording_name}",
             message=traceback,
         )
+
+
+def _recording_email_content(recording) -> tuple[str, str]:
+    room_title = frappe.db.get_value("Meet Room", recording.meet_room, "title") or _("Untitled Meet Room")
+    recorded_at = format_datetime(recording.started_at or recording.creation, "medium")
+    room_title_html = frappe.utils.escape_html(room_title)
+    recorded_at_html = frappe.utils.escape_html(recorded_at)
+
+    if recording.status == "Ready":
+        subject = _("Your recording of {0} is ready").format(room_title)
+        description = _("The recording of <strong>{0}</strong> from {1} is ready in Drive.").format(
+            room_title_html, recorded_at_html
+        )
+    elif recording.status == "Partial":
+        subject = _("Your partial recording of {0} is ready").format(room_title)
+        description = _(
+            "A partial recording of <strong>{0}</strong> from {1} is ready in Drive. "
+            "Some portions could not be captured."
+        ).format(room_title_html, recorded_at_html)
+    else:
+        subject = _("Your recording of {0} could not be processed").format(room_title)
+        description = _(
+            "The recording of <strong>{0}</strong> from {1} could not be processed. "
+            "No recording was added to Drive."
+        ).format(room_title_html, recorded_at_html)
+
+    link = frappe.utils.get_url(f"/drive/f/{recording.artifact}") if recording.artifact else None
+    message = f"<p>{description}</p>"
+    if link:
+        message += f'<p><a href="{frappe.utils.escape_html(link)}">{_("Open recording in Drive")}</a></p>'
+    return subject, message
 
 
 def _locked_recording(name: str):
@@ -759,6 +773,9 @@ def _callback_datetime(value):
 
 
 def _recordings_folder(recording) -> str:
+    from suite.drive.utils import create_drive_file
+    from suite.drive.utils.files import FileManager
+
     existing = frappe.db.get_value(
         "File",
         {

--- a/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
+++ b/suite/meet/sfu-server/src/server/RecordingGrantManager.ts
@@ -11,7 +11,7 @@ import type { RecordingGrantPersistenceFile } from './RecordingGrantPersistenceF
 
 const GRANT_TYPE = 'meet-recording-grant+jwt';
 const GRANT_AUDIENCE = 'meet-sfu-recorder';
-const MAX_AUTHORIZATION_SECONDS = 4 * 60 * 60;
+const MAX_AUTHORIZATION_SECONDS = 4 * 60 * 60 + 60;
 const CHALLENGE_SECONDS = 10;
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 const ACCEPTED_PROTOCOL_VERSIONS = new Set([1]);

--- a/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/RecordingGrantManager.test.ts
@@ -116,11 +116,20 @@ describe('RecordingGrantManager', () => {
 		['exp', NOW],
 		['exp', NOW + 3_601],
 		['authorization_expires_at', NOW],
-		['authorization_expires_at', NOW + 4 * 60 * 60 + 1],
+		['authorization_expires_at', NOW + 4 * 60 * 60 + 61],
 	] as const)('rejects invalid %s claims', (claim, value) => {
 		expect(() =>
 			manager.verifyGrant(makeToken({ [claim]: value }), NOW),
 		).toThrow();
+	});
+
+	it('allows the recording startup minute before the four-hour capture maximum', () => {
+		expect(
+			manager.verifyGrant(
+				makeToken({ authorization_expires_at: NOW + 4 * 60 * 60 + 60 }),
+				NOW,
+			),
+		).toBeTruthy();
 	});
 
 	it.each([

--- a/suite/templates/emails/meet_recording.html
+++ b/suite/templates/emails/meet_recording.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta name="color-scheme" content="light" />
+	<meta name="supported-color-schemes" content="light" />
+</head>
+<body data-fixed-palette style="margin: 0; padding: 0; background-color: #f3f3f3;">
+	<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f3f3f3; margin: 0; padding: 0;">
+		<tr>
+			<td align="center" style="padding: 32px 16px;">
+				<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="width: 100%; max-width: 600px;">
+					<tr>
+						<td align="center" style="padding: 8px 0 26px;">
+							<table role="presentation" cellpadding="0" cellspacing="0">
+								<tr>
+									<td style="vertical-align: middle; padding-right: 9px;">
+										<img embed="meet-logo.png" width="22" height="22" alt="" style="display: block; border: 0; width: 22px; height: 22px;" />
+									</td>
+									<td style="vertical-align: middle; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 19px; font-weight: 600; color: #171717; letter-spacing: -0.01em;">Frappe Meet</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+					<tr>
+						<td align="center" style="background-color: #ffffff; border: 1px solid #ededed; border-radius: 16px; padding: 36px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;">
+							<p style="font-size: 15px; line-height: 1.5; color: #171717; max-width: 400px; margin: 0 auto {{ '24px' if link else '0' }};">{{ description }}</p>
+							{% if link %}
+							<a class="btn" href="{{ link }}" style="display: inline-block; padding: 12px 24px; font-size: 14px; color: #ffffff; background-color: #171717; text-decoration: none; border-radius: 8px; border: 0; margin: 0;">{{ _("Open recording in Drive") }}</a>
+							{% endif %}
+						</td>
+					</tr>
+					<tr>
+						<td align="center" style="padding: 18px 8px 4px; font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; font-size: 13px; color: #7c7c7c;">This email was sent by Frappe Mail.</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- accept recorder upload query parameters and align SFU grant lifetime with startup
- make background artifact finalization safe to deserialize before site initialization
- send room owners branded, templated completion emails with Drive artifact links

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend 57.9% (+0.1%) · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | **57.9%** (22,285 / 38,462) (+0.1%) | **31.1%** (3,062 / 9,842) (+0%) |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34679638185) for commit `5d7257f`.</sub>

</details>
<!-- suite-coverage:end -->
