### PR TITLE
refactor(meet): authorize consumer mutations internally

### DIFF
--- a/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
+++ b/suite/meet/sfu-server/src/mediasoup/MediasoupManager.ts
@@ -668,7 +668,8 @@ export class MediasoupManager {
 		return closeResult;
 	}
 
-	closeConsumer(consumerId: string): void {
+	closeConsumer(consumerId: string, roomId: string, peerId: string): void {
+		this.assertConsumerAccess(consumerId, roomId, peerId);
 		this.consumerManager.closeConsumer(consumerId);
 	}
 
@@ -680,7 +681,16 @@ export class MediasoupManager {
 		return this.producerManager.resumeProducer(producerId);
 	}
 
-	async requestConsumerKeyFrame(consumerId: string): Promise<boolean> {
+	async requestConsumerKeyFrame(
+		consumerId: string,
+		roomId: string,
+		peerId: string,
+	): Promise<boolean> {
+		const data = this.consumerManager.getConsumerData(consumerId);
+		if (!data) return false;
+		if (data.roomId !== roomId || data.peerId !== peerId) {
+			throw new Error('Consumer ownership mismatch');
+		}
 		return this.consumerManager.requestConsumerKeyFrame(consumerId);
 	}
 
@@ -730,7 +740,11 @@ export class MediasoupManager {
 		return data;
 	}
 
-	assertConsumerAccess(consumerId: string, roomId: string, peerId: string) {
+	private assertConsumerAccess(
+		consumerId: string,
+		roomId: string,
+		peerId: string,
+	) {
 		const data = this.consumerManager.getConsumerData(consumerId);
 		if (!data) throw new Error(`Consumer ${consumerId} not found`);
 		if (data.roomId !== roomId || data.peerId !== peerId) {
@@ -741,6 +755,8 @@ export class MediasoupManager {
 
 	async updateConsumerPreferences(options: {
 		consumerId: string;
+		roomId: string;
+		peerId: string;
 		visible: boolean;
 		width: number;
 		height: number;
@@ -751,12 +767,11 @@ export class MediasoupManager {
 		};
 		paused: boolean;
 	}> {
-		const consumerData = this.consumerManager.getConsumerData(
+		const consumerData = this.assertConsumerAccess(
 			options.consumerId,
+			options.roomId,
+			options.peerId,
 		);
-		if (!consumerData) {
-			throw new Error(`Consumer ${options.consumerId} not found`);
-		}
 
 		const { consumer } = consumerData;
 		const wasPaused = consumer.paused;

--- a/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
+++ b/suite/meet/sfu-server/src/mediasoup/__tests__/MediasoupManager.test.ts
@@ -53,6 +53,8 @@ describe('MediasoupManager.updateConsumerPreferences', () => {
 
 		await mgr.updateConsumerPreferences({
 			consumerId: 'c1',
+			roomId: 'r1',
+			peerId: 'p1',
 			visible: true,
 			width: 640,
 			height: 360,
@@ -77,6 +79,8 @@ describe('MediasoupManager.updateConsumerPreferences', () => {
 
 		await mgr.updateConsumerPreferences({
 			consumerId: 'c1',
+			roomId: 'r1',
+			peerId: 'p1',
 			visible: true,
 			width: 640,
 			height: 360,
@@ -492,7 +496,7 @@ describe('MediasoupManager resource access', () => {
 		).toThrow('is not a recv transport');
 	});
 
-	it('requires consumer room and peer ownership to match', () => {
+	it('rejects a foreign consumer before mutating it', async () => {
 		const mgr = createManager();
 		vi.spyOn(mgr.consumerManager, 'getConsumerData').mockReturnValue({
 			roomId: 'room-1',
@@ -500,12 +504,40 @@ describe('MediasoupManager resource access', () => {
 			consumer: {},
 		} as never);
 
-		expect(() => mgr.assertConsumerAccess('c1', 'room-2', 'peer-1')).toThrow(
+		const close = vi.spyOn(mgr.consumerManager, 'closeConsumer');
+		const pause = vi.spyOn(mgr.consumerManager, 'pauseConsumer');
+
+		expect(() => mgr.closeConsumer('c1', 'room-2', 'peer-1')).toThrow(
 			'Consumer ownership mismatch',
 		);
-		expect(() => mgr.assertConsumerAccess('c1', 'room-1', 'peer-2')).toThrow(
-			'Consumer ownership mismatch',
-		);
+		expect(close).not.toHaveBeenCalled();
+		await expect(
+			mgr.updateConsumerPreferences({
+				consumerId: 'c1',
+				roomId: 'room-2',
+				peerId: 'peer-1',
+				visible: false,
+				width: 0,
+				height: 0,
+			}),
+		).rejects.toThrow('Consumer ownership mismatch');
+		expect(pause).not.toHaveBeenCalled();
+	});
+
+	it('distinguishes a missing keyframe target from a foreign consumer', async () => {
+		const mgr = createManager();
+		await expect(
+			mgr.requestConsumerKeyFrame('missing', 'room-1', 'peer-1'),
+		).resolves.toBe(false);
+
+		vi.spyOn(mgr.consumerManager, 'getConsumerData').mockReturnValue({
+			roomId: 'room-1',
+			peerId: 'peer-2',
+			consumer: {},
+		} as never);
+		await expect(
+			mgr.requestConsumerKeyFrame('foreign', 'room-1', 'peer-1'),
+		).rejects.toThrow('Consumer ownership mismatch');
 	});
 
 	it('rejects a producer from another room when creating a consumer', async () => {

--- a/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/SocketHandlerManager.test.ts
@@ -2048,7 +2048,7 @@ describe('SocketHandlerManager characterization', () => {
 		);
 	});
 
-	it('authenticates and checks consumer room ownership before updating preferences', async () => {
+	it('authenticates and passes ownership to consumer mutations', async () => {
 		const harness = createManager();
 		const socket = connectFullSocket(harness, {
 			userId: 'viewer-1',
@@ -2066,50 +2066,29 @@ describe('SocketHandlerManager characterization', () => {
 		expect(harness.authManager.ensureMediaConsumerAccess).toHaveBeenCalledWith(
 			socket,
 		);
-		expect(harness.mediasoup.assertConsumerAccess).toHaveBeenCalledWith(
-			'consumer-1',
-			'room-1',
-			'viewer-1',
-		);
+		expect(harness.mediasoup.updateConsumerPreferences).toHaveBeenCalledWith({
+			consumerId: 'consumer-1',
+			roomId: 'room-1',
+			peerId: 'viewer-1',
+			visible: true,
+			width: 640,
+			height: 360,
+		});
 		expect(callback).toHaveBeenCalledWith({
 			success: true,
 			paused: false,
 			visible: true,
 		});
-	});
 
-	it('rejects every foreign consumer mutation before side effects', async () => {
-		const harness = createManager();
-		const socket = connectFullSocket(harness, {
-			scope: 'recording',
-			recordingProofComplete: true,
-			userId: 'recorder:recording-1',
-			roomId: 'room-1',
-		});
-		harness.mediasoup.assertConsumerAccess.mockImplementation(() => {
-			throw new Error('Consumer ownership mismatch');
-		});
-
-		for (const [event, data] of [
-			['close_consumer', { consumerId: 'foreign' }],
-			[
-				'consumer:update_preferences',
-				{ consumerId: 'foreign', visible: true, width: 640, height: 360 },
-			],
-			['request_consumer_keyframe', { consumerId: 'foreign' }],
-		] as const) {
-			const callback = vi.fn();
-			socket.fire(event, data, callback);
-			await new Promise((resolve) => setImmediate(resolve));
-			expect(callback, event).toHaveBeenCalledWith({
-				success: false,
-				error: 'Consumer ownership mismatch',
-			});
-		}
-
-		expect(harness.mediasoup.closeConsumer).not.toHaveBeenCalled();
-		expect(harness.mediasoup.updateConsumerPreferences).not.toHaveBeenCalled();
-		expect(harness.mediasoup.requestConsumerKeyFrame).not.toHaveBeenCalled();
+		const closeCallback = vi.fn();
+		socket.fire('close_consumer', { consumerId: 'consumer-1' }, closeCallback);
+		await new Promise((r) => setImmediate(r));
+		expect(harness.mediasoup.closeConsumer).toHaveBeenCalledWith(
+			'consumer-1',
+			'room-1',
+			'viewer-1',
+		);
+		expect(closeCallback).toHaveBeenCalledWith({ success: true });
 	});
 
 	it('treats a keyframe request for an already-closed consumer as a no-op', async () => {
@@ -2118,9 +2097,7 @@ describe('SocketHandlerManager characterization', () => {
 			userId: 'viewer-1',
 			roomId: 'room-1',
 		});
-		harness.mediasoup.assertConsumerAccess.mockImplementation(() => {
-			throw new Error('Consumer stale-consumer not found');
-		});
+		harness.mediasoup.requestConsumerKeyFrame.mockResolvedValueOnce(false);
 		const callback = vi.fn();
 
 		socket.fire(
@@ -2134,7 +2111,11 @@ describe('SocketHandlerManager characterization', () => {
 			success: true,
 			requested: false,
 		});
-		expect(harness.mediasoup.requestConsumerKeyFrame).not.toHaveBeenCalled();
+		expect(harness.mediasoup.requestConsumerKeyFrame).toHaveBeenCalledWith(
+			'stale-consumer',
+			'room-1',
+			'viewer-1',
+		);
 	});
 
 	it('rejects an untracked WebRTC transport connect when E2EE is required', async () => {

--- a/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
+++ b/suite/meet/sfu-server/src/server/__tests__/test-helpers.ts
@@ -211,7 +211,6 @@ function createMockMediasoupManager(): MediasoupManager {
 			});
 			return result;
 		}),
-		assertConsumerAccess: vi.fn(),
 		closeConsumer: vi.fn().mockResolvedValue(undefined),
 		requestConsumerKeyFrame: vi.fn().mockResolvedValue(true),
 		updateConsumerPreferences: vi.fn().mockResolvedValue({ paused: false }),

--- a/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
+++ b/suite/meet/sfu-server/src/server/handlers/ConsumerHandlers.ts
@@ -57,12 +57,11 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 			try {
 				deps.authManager.ensureMediaConsumerAccess(socket);
 				const { consumerId } = data;
-				deps.mediasoup.assertConsumerAccess(
+				await deps.mediasoup.closeConsumer(
 					consumerId,
 					getRoomId(socket),
 					getPeerId(socket),
 				);
-				await deps.mediasoup.closeConsumer(consumerId);
 
 				callback({ success: true });
 			} catch (error) {
@@ -82,18 +81,14 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 					callback({ success: false, error: 'Missing consumerId' });
 					return;
 				}
-				deps.mediasoup.assertConsumerAccess(
-					consumerId,
-					getRoomId(socket),
-					getPeerId(socket),
-				);
-
 				const visible = Boolean(data.visible);
 				const width = Math.round(data.width);
 				const height = Math.round(data.height);
 
 				const result = await deps.mediasoup.updateConsumerPreferences({
 					consumerId,
+					roomId: getRoomId(socket),
+					peerId: getPeerId(socket),
 					visible,
 					width,
 					height,
@@ -113,23 +108,13 @@ export function registerConsumerHandlers(deps: HandlerDeps) {
 			try {
 				deps.authManager.ensureMediaConsumerAccess(socket);
 				const { consumerId } = data;
-				deps.mediasoup.assertConsumerAccess(
+				const requested = await deps.mediasoup.requestConsumerKeyFrame(
 					consumerId,
 					getRoomId(socket),
 					getPeerId(socket),
 				);
-				const requested =
-					await deps.mediasoup.requestConsumerKeyFrame(consumerId);
 				callback({ success: true, requested });
 			} catch (error) {
-				if (
-					error instanceof Error &&
-					error.message.startsWith('Consumer ') &&
-					error.message.endsWith(' not found')
-				) {
-					callback({ success: true, requested: false });
-					return;
-				}
 				loggers.socketHandler.error(
 					'Error requesting consumer key frame: %s',
 					(error as Error).message,


### PR DESCRIPTION
## Summary

- move consumer ownership checks into the SFU mutation boundary
- preserve stale keyframe requests as no-ops while rejecting foreign consumers
- simplify socket handlers to pass authenticated room and peer identity

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend unavailable</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | Unavailable | Unavailable |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34679577966) for commit `363dc15`.</sub>

</details>
<!-- suite-coverage:end -->
