### PR TITLE
refactor(meet): simplify SFU tooling and persistence

### DIFF
--- a/suite/meet/sfu-server/package-lock.json
+++ b/suite/meet/sfu-server/package-lock.json
@@ -471,30 +471,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/ansi-regex": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
-			}
-		},
-		"node_modules/ansi-styles": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-			"integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
 		"node_modules/anymatch": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -682,20 +658,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/cliui": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-			"integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^7.2.0",
-				"strip-ansi": "^7.1.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=20"
-			}
-		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -844,12 +806,6 @@
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
 			"license": "MIT"
 		},
-		"node_modules/emoji-regex": {
-			"version": "10.6.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-			"license": "MIT"
-		},
 		"node_modules/encodeurl": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -976,15 +932,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/escalade": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
 			}
 		},
 		"node_modules/escape-html": {
@@ -1160,27 +1107,6 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-caller-file": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-			"license": "ISC",
-			"engines": {
-				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -2261,38 +2187,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/strip-ansi": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^6.2.2"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
-			}
-		},
 		"node_modules/supports-color": {
 			"version": "10.2.2",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
@@ -2481,23 +2375,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/wrap-ansi": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-			"integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/ws": {
 			"version": "8.18.3",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
@@ -2527,15 +2404,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/y18n": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/yallist": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -2543,15 +2411,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/yargs-parser": {
-			"version": "22.0.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-			"integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/yn": {

--- a/suite/meet/sfu-server/package-lock.json
+++ b/suite/meet/sfu-server/package-lock.json
@@ -15,8 +15,7 @@
 				"jsonwebtoken": "^9.0.2",
 				"mediasoup": "^3.19.19",
 				"socket.io": "^4.7.5",
-				"socket.io-client": "^4.7.5",
-				"yargs": "^18.0.0"
+				"socket.io-client": "^4.7.5"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "^2.4.12",
@@ -2544,23 +2543,6 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/yargs": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
-			"integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^9.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"string-width": "^7.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^22.0.0"
-			},
-			"engines": {
-				"node": "^20.19.0 || ^22.12.0 || >=23"
 			}
 		},
 		"node_modules/yargs-parser": {

--- a/suite/meet/sfu-server/package.json
+++ b/suite/meet/sfu-server/package.json
@@ -34,8 +34,7 @@
 		"mediasoup": "^3.19.19",
 		"prom-client": "^15.1.3",
 		"socket.io": "^4.7.5",
-		"socket.io-client": "^4.7.5",
-		"yargs": "^18.0.0"
+		"socket.io-client": "^4.7.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.4.12",

--- a/suite/meet/sfu-server/scripts/spawn-fake-users.js
+++ b/suite/meet/sfu-server/scripts/spawn-fake-users.js
@@ -1,73 +1,77 @@
 const { io } = require("socket.io-client");
 const jwt = require("jsonwebtoken");
-const yargs = require("yargs/yargs");
-const { hideBin } = require("yargs/helpers");
 const { spawn } = require("child_process");
+const { parseArgs } = require("node:util");
 
-const argv = yargs(hideBin(process.argv))
-	.option("meeting", {
-		type: "string",
-		demandOption: true,
-		describe: "Meeting ID / room ID to join",
-	})
-	.option("count", {
-		type: "number",
-		default: 5,
-		describe: "Number of fake users to spawn",
-	})
-	.option("sfu-url", {
-		type: "string",
-		default: "http://localhost",
-		describe: "Base SFU URL (protocol+host)",
-	})
-	.option("sfu-port", {
-		type: "number",
-		default: 3000,
-		describe: "SFU port if not implicit in URL",
-	})
-	.option("site", {
-		type: "string",
-		describe: "Frappe site namespace for the room",
-	})
-	.option("secret", {
-		type: "string",
-		default: process.env.JWT_SECRET,
-		describe: "JWT signing secret used by SFU (required)",
-	})
-	.option("with-producers", {
-		type: "boolean",
-		default: false,
-		describe: "Create real fake audio/video producers using FFmpeg",
-	})
-	.option("all-producers", {
-		type: "boolean",
-		default: false,
-		describe: "Create producers for every fake user instead of odd-indexed users",
-	})
-	.option("auto-toggle", {
-		type: "boolean",
-		default: false,
-		describe: "Periodically send media_control events",
-	})
-	.option("lifetime", {
-		type: "number",
-		default: 0,
-		describe: "Milliseconds before disconnecting (0 = keep alive)",
-	})
-	.help().argv;
+const help = `Usage: spawn-fake-users.js --meeting <id> [options]
+
+Options:
+  --meeting <id>          Meeting ID / room ID to join (required)
+  --count <number>        Number of fake users to spawn (default: 5)
+  --sfu-url <url>         Base SFU URL (protocol+host) (default: http://localhost)
+  --sfu-port <number>     SFU port if not implicit in URL (default: 3000)
+  --site <name>           Frappe site namespace for the room
+  --secret <secret>       JWT signing secret used by SFU (required)
+  --with-producers        Create real fake audio/video producers using FFmpeg
+  --all-producers         Create producers for every fake user instead of odd-indexed users
+  --auto-toggle           Periodically send media_control events
+  --lifetime <ms>         Milliseconds before disconnecting (default: 0)
+  --help                  Show help`;
+
+let values;
+try {
+	({ values } = parseArgs({
+		options: {
+			meeting: { type: "string" },
+			count: { type: "string", default: "5" },
+			"sfu-url": { type: "string", default: "http://localhost" },
+			"sfu-port": { type: "string", default: "3000" },
+			site: { type: "string" },
+			secret: { type: "string" },
+			"with-producers": { type: "boolean", default: false },
+			"all-producers": { type: "boolean", default: false },
+			"auto-toggle": { type: "boolean", default: false },
+			lifetime: { type: "string", default: "0" },
+			help: { type: "boolean", default: false },
+		},
+		allowNegative: true,
+	}));
+} catch (error) {
+	console.error(`Error: ${error.message}`);
+	process.exit(1);
+}
+
+if (values.help) {
+	console.log(help);
+	process.exit(0);
+}
+
+if (!values.meeting) {
+	console.error("Error: --meeting is required");
+	process.exit(1);
+}
+
+const numberOption = (name) => {
+	const value = Number(values[name]);
+	if (!Number.isFinite(value)) {
+		console.error(`Error: --${name} must be a number`);
+		process.exit(1);
+	}
+	return value;
+};
 
 const {
 	meeting: meetingId,
-	count,
-	sfuUrl,
-	sfuPort,
 	site,
-	secret,
-	withProducers,
-	allProducers,
-	autoToggle,
-	lifetime,
-} = argv;
+	"with-producers": withProducers,
+	"all-producers": allProducers,
+	"auto-toggle": autoToggle,
+} = values;
+const count = numberOption("count");
+const sfuUrl = values["sfu-url"];
+const sfuPort = numberOption("sfu-port");
+const lifetime = numberOption("lifetime");
+const secret = values.secret ?? process.env.JWT_SECRET;
 
 if (!secret) {
 	console.error("Error: JWT secret is required. Provide --secret or set JWT_SECRET environment variable.");

--- a/suite/meet/sfu-server/scripts/spawn-fake-users.js
+++ b/suite/meet/sfu-server/scripts/spawn-fake-users.js
@@ -11,7 +11,7 @@ Options:
   --sfu-url <url>         Base SFU URL (protocol+host) (default: http://localhost)
   --sfu-port <number>     SFU port if not implicit in URL (default: 3000)
   --site <name>           Frappe site namespace for the room
-  --secret <secret>       JWT signing secret used by SFU (required)
+  --secret <secret>       JWT signing secret used by SFU (or JWT_SECRET)
   --with-producers        Create real fake audio/video producers using FFmpeg
   --all-producers         Create producers for every fake user instead of odd-indexed users
   --auto-toggle           Periodically send media_control events

--- a/suite/meet/sfu-server/src/server/E2eeCoordinatorPersistence.ts
+++ b/suite/meet/sfu-server/src/server/E2eeCoordinatorPersistence.ts
@@ -59,23 +59,6 @@ export interface E2eeCoordinatorPersistence {
 	clearRoom(roomId: string): Promise<void>;
 }
 
-function cloneRoomState(
-	state: PersistedE2eeRoomCoordinatorState,
-): PersistedE2eeRoomCoordinatorState {
-	return {
-		currentEpoch: state.currentEpoch,
-		commits: state.commits.map((commit) => ({ ...commit })),
-		welcomes: state.welcomes.map((welcome) => ({ ...welcome })),
-		acks: state.acks.map((ack) => ({ ...ack })),
-		pendingCommitRequests: state.pendingCommitRequests.map((request) => ({
-			...request,
-			joiningSenderIds: [...request.joiningSenderIds],
-			removedSenderIds: [...request.removedSenderIds],
-			alreadyTried: [...request.alreadyTried],
-		})),
-	};
-}
-
 function emptyRoomState(): PersistedE2eeRoomCoordinatorState {
 	return {
 		commits: [],
@@ -94,11 +77,7 @@ export class InMemoryE2eeCoordinatorPersistence
 		now: number = Date.now(),
 	): Promise<Map<string, PersistedE2eeRoomCoordinatorState>> {
 		this.pruneExpired(now);
-		const out = new Map<string, PersistedE2eeRoomCoordinatorState>();
-		for (const [roomId, state] of this.rooms) {
-			out.set(roomId, cloneRoomState(state));
-		}
-		return out;
+		return structuredClone(this.rooms);
 	}
 
 	async setCurrentEpoch(roomId: string, epochNumber: number): Promise<void> {
@@ -153,12 +132,7 @@ export class InMemoryE2eeCoordinatorPersistence
 		room.pendingCommitRequests = room.pendingCommitRequests.filter(
 			(existing) => existing.epochNumber !== request.epochNumber,
 		);
-		room.pendingCommitRequests.push({
-			...request,
-			joiningSenderIds: [...request.joiningSenderIds],
-			removedSenderIds: [...request.removedSenderIds],
-			alreadyTried: [...request.alreadyTried],
-		});
+		room.pendingCommitRequests.push(structuredClone(request));
 	}
 
 	async removePendingCommitRequest(

--- a/suite/meet/sfu-server/src/server/E2eeRosterPersistence.ts
+++ b/suite/meet/sfu-server/src/server/E2eeRosterPersistence.ts
@@ -45,10 +45,11 @@ export class InMemoryRosterPersistence implements RosterPersistence {
 			this.rooms.set(roomId, entries);
 		}
 		const idx = entries.findIndex((e) => e.senderId === entry.senderId);
+		const storedEntry = structuredClone(entry);
 		if (idx >= 0) {
-			entries[idx] = entry;
+			entries[idx] = storedEntry;
 		} else {
-			entries.push(entry);
+			entries.push(storedEntry);
 		}
 	}
 

--- a/suite/meet/sfu-server/src/server/E2eeRosterPersistence.ts
+++ b/suite/meet/sfu-server/src/server/E2eeRosterPersistence.ts
@@ -35,15 +35,7 @@ export class InMemoryRosterPersistence implements RosterPersistence {
 	private readonly rooms = new Map<string, RosterEntry[]>();
 
 	async loadAll(): Promise<Map<string, RosterEntry[]>> {
-		// Deep-clone so callers can't mutate the underlying arrays.
-		const out = new Map<string, RosterEntry[]>();
-		for (const [roomId, entries] of this.rooms) {
-			out.set(
-				roomId,
-				entries.map((e) => ({ ...e })),
-			);
-		}
-		return out;
+		return structuredClone(this.rooms);
 	}
 
 	async addEntry(roomId: string, entry: RosterEntry): Promise<void> {

--- a/suite/meet/sfu-server/yarn.lock
+++ b/suite/meet/sfu-server/yarn.lock
@@ -2163,18 +2163,6 @@ yargs-parser@^22.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
   integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
-yargs@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.0.0.tgz#6c84259806273a746b09f579087b68a3c2d25bd1"
-  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
-  dependencies:
-    cliui "^9.0.1"
-    escalade "^3.1.1"
-    get-caller-file "^2.0.5"
-    string-width "^7.2.0"
-    y18n "^5.0.5"
-    yargs-parser "^22.0.0"
-
 yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"

--- a/suite/meet/sfu-server/yarn.lock
+++ b/suite/meet/sfu-server/yarn.lock
@@ -654,16 +654,6 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
-ansi-regex@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.2.2.tgz#60216eea464d864597ce2832000738a0589650c1"
-  integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
-
-ansi-styles@^6.2.1:
-  version "6.2.3"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.3.tgz#c044d5dcc521a076413472597a1acb1f103c4041"
-  integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
-
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz"
@@ -809,15 +799,6 @@ cjs-module-lexer@^2.2.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz#b3ca5101843389259ade7d88c77bd06ce55849ca"
   integrity sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==
 
-cliui@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-9.0.1.tgz#6f7890f386f6f1f79953adc1f78dec46fcc2d291"
-  integrity sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==
-  dependencies:
-    string-width "^7.2.0"
-    strip-ansi "^7.1.0"
-    wrap-ansi "^9.0.0"
-
 content-disposition@~0.5.4:
   version "0.5.4"
   resolved "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz"
@@ -918,11 +899,6 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-emoji-regex@^10.3.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-10.6.0.tgz#bf3d6e8f7f8fd22a65d9703475bc0147357a6b0d"
-  integrity sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==
-
 encodeurl@~2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz"
@@ -986,11 +962,6 @@ es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
-
-escalade@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
-  integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -1127,16 +1098,6 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
-
-get-caller-file@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
-  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
-
-get-east-asian-width@^1.0.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz#216900f91df11a8b2c198c3e1d93d6c035a776b9"
-  integrity sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==
 
 get-intrinsic@^1.2.5, get-intrinsic@^1.3.0:
   version "1.3.0"
@@ -1917,22 +1878,6 @@ std-env@^4.0.0-rc.1:
   resolved "https://registry.yarnpkg.com/std-env/-/std-env-4.1.0.tgz#45899abc590d86d682e87f0acd1033a75084cd3f"
   integrity sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==
 
-string-width@^7.0.0, string-width@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-7.2.0.tgz#b5bb8e2165ce275d4d43476dd2700ad9091db6dc"
-  integrity sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==
-  dependencies:
-    emoji-regex "^10.3.0"
-    get-east-asian-width "^1.0.0"
-    strip-ansi "^7.1.0"
-
-strip-ansi@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.2.0.tgz#d22a269522836a627af8d04b5c3fd2c7fa3e32e3"
-  integrity sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==
-  dependencies:
-    ansi-regex "^6.2.2"
-
 supports-color@^10.2.2:
   version "10.2.2"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz"
@@ -2129,15 +2074,6 @@ why-is-node-running@^2.3.0:
     siginfo "^2.0.0"
     stackback "0.0.2"
 
-wrap-ansi@^9.0.0:
-  version "9.0.2"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-9.0.2.tgz#956832dea9494306e6d209eb871643bb873d7c98"
-  integrity sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==
-  dependencies:
-    ansi-styles "^6.2.1"
-    string-width "^7.0.0"
-    strip-ansi "^7.1.0"
-
 ws@~8.18.3:
   version "8.18.3"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
@@ -2148,20 +2084,10 @@ xmlhttprequest-ssl@~2.1.1:
   resolved "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz"
   integrity sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==
 
-y18n@^5.0.5:
-  version "5.0.8"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
-  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
-
 yallist@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz"
   integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
-
-yargs-parser@^22.0.0:
-  version "22.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
-  integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary
- replace the fake-user CLI's yargs dependency with Node's built-in argument parser
- use structured cloning for isolated in-memory E2EE persistence snapshots
- remove the obsolete dependency from both lockfiles

This reduces SFU tooling dependencies and replaces manual persistence cloning with the platform primitive.

<!-- suite-coverage:start -->
<details>
<summary><strong>Test coverage</strong>: Backend unavailable · Frontend 35.6% (+0%)</summary>

| Suite | Lines | Branches |
| --- | ---: | ---: |
| Backend | Unavailable | Unavailable |
| Frontend | **35.6%** (14,346 / 40,293) (+0%) | **30.1%** (9,261 / 30,785) (+0%) |

<sub>Delta is against the latest available `develop` coverage. Coverage is informational. [Workflow run](https://github.com/frappe/suite/actions/runs/34682288143) for commit `edb5e33`.</sub>

</details>
<!-- suite-coverage:end -->
