### PR TITLE
feat(drive): add AI-authored markdown preview tabs

### DIFF
--- a/frontend/src/apps/drive/components/FileRender.vue
+++ b/frontend/src/apps/drive/components/FileRender.vue
@@ -22,6 +22,7 @@ const PDFPreview = defineAsyncComponent(() => import('./FileTypePreview/PDFPrevi
 const VideoPreview = defineAsyncComponent(() => import('./FileTypePreview/VideoPreview.vue'))
 const TextPreview = defineAsyncComponent(() => import('./FileTypePreview/TextPreview.vue'))
 const AudioPreview = defineAsyncComponent(() => import('@/apps/drive/components/FileTypePreview/AudioPreview.vue'))
+const MarkdownPreview = defineAsyncComponent(() => import('./FileTypePreview/MarkdownPreview.vue'))
 import LucideAlertCircle from '~icons/lucide/alert-circle'
 import { diskSettings } from '@/apps/drive/resources/permissions'
 
@@ -61,10 +62,12 @@ const RENDERS = {
   Presentation: MSOfficePreview,
   Text: TextPreview,
   Code: TextPreview,
+  Markdown: MarkdownPreview,
 }
 
 const EXCEPTIONS = {
   'text/csv': 'Text',
+  'text/markdown': 'Markdown',
 }
 
 const getType = (k) => {

--- a/frontend/src/apps/drive/components/FileTypePreview/MarkdownPreview.test.ts
+++ b/frontend/src/apps/drive/components/FileTypePreview/MarkdownPreview.test.ts
@@ -1,0 +1,170 @@
+import { createApp, defineComponent, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import MarkdownPreview from './MarkdownPreview.vue'
+
+vi.mock('frappe-ui', () => ({
+  Skeleton: () => h('div', { class: 'skeleton' }),
+  TabButtons: {
+    props: ['modelValue', 'options'],
+    emits: ['update:modelValue'],
+    setup(props, { emit }) {
+      return () =>
+        (props.options ?? []).map((option: { label: string; value: string }) =>
+          h('button', { onClick: () => emit('update:modelValue', option.value) }, option.label),
+        )
+    },
+  },
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
+function mountPreview(name: string) {
+  const root = document.createElement('div')
+  const app = createApp(
+    defineComponent({
+      setup: () => () => h(MarkdownPreview, { previewEntity: { name } }),
+    }),
+  )
+  app.mount(root)
+  return { app, root }
+}
+
+describe('Drive MarkdownPreview', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('fetches and renders formatted content by default', async () => {
+    const request = deferred<Response>()
+    const fetchMock = vi.fn(() => request.promise)
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { app, root } = mountPreview('markdown-a')
+    await nextTick()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/method/suite.drive.api.files.get_markdown_preview?entity_name=markdown-a&mode=html',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    )
+
+    request.resolve({
+      ok: true,
+      json: async () => ({
+        content: '<h1>Hello</h1>',
+        mime_type: 'text/markdown',
+      }),
+    } as Response)
+    await flushPromises()
+
+    expect(root.querySelector('.prose')?.textContent).toContain('Hello')
+    expect(root.querySelector('textarea')).toBeNull()
+    app.unmount()
+  })
+
+  it('switches to raw mode when selected', async () => {
+    const formatted = deferred<Response>()
+    const raw = deferred<Response>()
+    const fetchMock = vi.fn((url) => (url.includes('mode=html') ? formatted.promise : raw.promise))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { app, root } = mountPreview('markdown-b')
+    await nextTick()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    formatted.resolve({
+      ok: true,
+      json: async () => ({
+        content: '<h1>Hello</h1>',
+        mime_type: 'text/markdown',
+      }),
+    } as Response)
+    await flushPromises()
+
+    const rawButton = Array.from(root.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim().toLowerCase() === 'raw',
+    )
+    rawButton?.click()
+    await nextTick()
+
+    raw.resolve({
+      ok: true,
+      json: async () => ({
+        content: 'Raw markdown text',
+        mime_type: 'text/markdown',
+      }),
+    } as Response)
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/method/suite.drive.api.files.get_markdown_preview?entity_name=markdown-b&mode=raw',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    expect(root.querySelector('pre')?.textContent).toContain('Raw markdown text')
+    expect(root.querySelector('textarea')).toBeNull()
+    app.unmount()
+  })
+
+  it('reports API errors cleanly', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: false,
+        text: async () => 'bad request',
+      } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { app, root } = mountPreview('markdown-c')
+    await nextTick()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/method/suite.drive.api.files.get_markdown_preview?entity_name=markdown-c&mode=html',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    await flushPromises()
+
+    expect(root.textContent).toContain('bad request')
+    app.unmount()
+  })
+
+  it('renders an empty payload safely', async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: async () => ({
+          content: '',
+          mime_type: 'text/markdown',
+        }),
+      } as Response),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { app, root } = mountPreview('markdown-empty')
+    await nextTick()
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/method/suite.drive.api.files.get_markdown_preview?entity_name=markdown-empty&mode=html',
+      expect.objectContaining({ method: 'GET' }),
+    )
+    await flushPromises()
+
+    expect(root.querySelector('.prose')?.textContent).toBe('')
+    app.unmount()
+  })
+})

--- a/frontend/src/apps/drive/components/FileTypePreview/MarkdownPreview.vue
+++ b/frontend/src/apps/drive/components/FileTypePreview/MarkdownPreview.vue
@@ -1,0 +1,156 @@
+<template>
+  <div>
+    <FilePreviewSkeleton v-if="loading" />
+    <template v-else>
+      <TabButtons
+        v-model="activeView"
+        :options="[
+          {
+            label: 'Formatted',
+            value: 'formatted',
+          },
+          {
+            label: 'Raw',
+            value: 'raw',
+          },
+        ]"
+        class="mb-2"
+      />
+      <p v-if="error" class="text-sm text-ink-gray-7 p-3 border rounded-4">
+        {{ error }}
+      </p>
+      <pre
+        v-else-if="activeView === 'raw'"
+        class="overflow-y-auto h-[80vh] font-[InterVar] text-p-base text-ink-gray-8 sm:w-full border p-3 rounded-4 overflow-x-auto"
+        >{{ content }}</pre
+      >
+      <div
+        v-else
+        class="overflow-y-auto h-[80vh] border rounded-4 p-3 prose prose-sm max-w-none [&_a]:text-ink-blue-6 [&_a]:hover:underline"
+        v-html="sanitizedContent"
+      />
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from 'vue'
+import DOMPurify from 'dompurify'
+
+import { TabButtons } from 'frappe-ui'
+import FilePreviewSkeleton from '@/apps/drive/components/FileTypePreview/FilePreviewSkeleton.vue'
+
+const props = defineProps({
+  previewEntity: Object,
+})
+
+type MarkdownMode = 'formatted' | 'raw'
+
+const activeView = ref<MarkdownMode>('formatted')
+const content = ref('')
+const loading = ref(true)
+const error = ref('')
+
+const sanitizedContent = computed(() => {
+  const html = DOMPurify.sanitize(content.value || '', {
+    ALLOWED_TAGS: [
+      'a',
+      'p',
+      'br',
+      'div',
+      'span',
+      'b',
+      'strong',
+      'i',
+      'em',
+      'u',
+      's',
+      'del',
+      'ul',
+      'ol',
+      'li',
+      'blockquote',
+      'pre',
+      'code',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'table',
+      'thead',
+      'tbody',
+      'tfoot',
+      'tr',
+      'th',
+      'td',
+      'img',
+    ],
+    ALLOWED_ATTR: ['href', 'title', 'alt', 'src'],
+    ALLOW_UNKNOWN_PROTOCOLS: false,
+  })
+
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(html, 'text/html')
+  doc.querySelectorAll('a').forEach((anchor) => {
+    anchor.setAttribute('target', '_blank')
+    anchor.setAttribute('rel', 'noopener noreferrer')
+  })
+  return doc.body.innerHTML
+})
+
+function getMode() {
+  return activeView.value === 'raw' ? 'raw' : 'html'
+}
+
+async function fetchContent() {
+  loading.value = true
+  error.value = ''
+
+  try {
+    const headers = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-Frappe-Site-Name': window.location.hostname,
+    }
+    const query = new URLSearchParams({
+      entity_name: props.previewEntity.name,
+      mode: getMode(),
+    })
+    const res = await fetch(`/api/method/suite.drive.api.files.get_markdown_preview?${query}`, {
+      method: 'GET',
+      headers,
+    })
+
+    if (!res.ok) {
+      error.value = (await res.text()) || 'Could not load this markdown file.'
+      return
+    }
+
+    const response = (await res.json()) as {
+      content?: string
+      error?: string
+    }
+    if (response.error) {
+      error.value = response.error
+      return
+    }
+    content.value = response.content || ''
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : 'Could not load this markdown file.'
+  } finally {
+    loading.value = false
+  }
+}
+
+watch(
+  () => [props.previewEntity, activeView.value],
+  () => {
+    fetchContent()
+  },
+  { deep: true },
+)
+
+onMounted(fetchContent)
+</script>

--- a/suite/drive/api/files.py
+++ b/suite/drive/api/files.py
@@ -7,10 +7,13 @@ import tempfile
 import zipfile
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote
 
 import frappe
 import mimemapper
+import markdown
+from markdown.extensions.wikilinks import WikiLinkExtension
 from frappe.rate_limiter import rate_limit
 from pypika import Order
 from werkzeug.utils import secure_filename, send_file
@@ -45,6 +48,63 @@ from suite.drive.utils.users import mark_as_viewed
 from .permissions import user_has_permission
 
 FORBIDDEN_DOWNLOAD_TYPES = ["Folder", "Link", "Document", "Presentation"]
+TEXT_PREVIEW_LIMIT_BYTES = 10_000_000
+
+
+def _get_file_entity(entity_name: str):
+    """Fetch a preview-only file snapshot and enforce the same read gate as
+    `get_file_content`."""
+    if not user_has_permission(entity_name, "read"):
+        frappe.throw("You do not have permission to view this file", frappe.PermissionError)
+
+    entity = frappe.get_value(
+        "File",
+        {"name": entity_name},
+        [
+            "name",
+            "file_name",
+            "file_type",
+            "status",
+            "file_url",
+            "is_private",
+            "mime_type",
+            "file_size",
+        ],
+        as_dict=1,
+    )
+    if not entity or entity.file_type in FORBIDDEN_DOWNLOAD_TYPES or entity.status != STATUS_ACTIVE:
+        frappe.throw("Not found", frappe.DoesNotExistError)
+
+    return entity
+
+
+def _decode_markdown_bytes(raw: bytes) -> str:
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1", errors="replace")
+
+
+def _safe_markdown_url_builder(label, base, end):
+    return f"/api/method/suite.writer.api.docs.get_wiki_link?title={label}"
+
+
+def _clean_markdown_content(content):
+    property_end = content[3:].find("---")
+    if content.startswith("---") and property_end != -1:
+        content = content[:property_end].replace("\n  ", " " * 4) + content[property_end:]
+    content = content[:property_end] + content[property_end:].replace("\n", "\n\n")
+    content = content[:property_end] + content[property_end:].replace("\n\n\n", "\n<p></p>")
+    return content
+
+
+def _render_markdown(raw_text: str) -> str:
+    cleaned = _clean_markdown_content(raw_text)
+    md = markdown.Markdown(
+        extensions=["extra", "meta", WikiLinkExtension(build_url=_safe_markdown_url_builder)],
+    )
+    md.set_output_format("html")
+    return md.convert(cleaned)
 
 
 @frappe.whitelist(allow_guest=True)
@@ -318,6 +378,55 @@ def get_file_content(entity_name: str, trigger_download: bool = False, token: st
         return
 
     return get_file_internal(file, trigger_download)
+
+
+def _read_preview_bytes(file, max_bytes: int) -> tuple[bytes, int]:
+    manager = FileManager()
+    read_size = min(max_bytes, TEXT_PREVIEW_LIMIT_BYTES)
+    if manager.s3_enabled and not stored_on_disk(file.file_url):
+        data = manager.get_file(file, f"bytes=0-{read_size - 1}").read()
+    else:
+        with manager.open_file(storage_key(file.file_url)) as stream:
+            data = stream.read(read_size)
+
+    payload_size = file.file_size or len(data)
+    return data, payload_size
+
+
+@frappe.whitelist(allow_guest=True)
+def get_markdown_preview(
+    entity_name: str,
+    mode: str = "html",
+    include_source: int = 0,
+    max_bytes: int | None = None,
+):
+    file = _get_file_entity(entity_name)
+
+    if file.mime_type != "text/markdown":
+        frappe.throw("Only markdown files can be previewed this way.", frappe.ValidationError)
+
+    if mode not in {"html", "raw"}:
+        frappe.throw("Invalid markdown preview mode.", frappe.ValidationError)
+
+    limit = max_bytes or TEXT_PREVIEW_LIMIT_BYTES
+    if not isinstance(limit, int) or limit <= 0:
+        limit = TEXT_PREVIEW_LIMIT_BYTES
+
+    raw, payload_size = _read_preview_bytes(file, limit)
+    decoded = _decode_markdown_bytes(raw)
+    truncated = len(raw) >= limit and payload_size > limit
+
+    content = _render_markdown(decoded) if mode == "html" else decoded
+    response: dict[str, Any] = {
+        "content": content,
+        "mime_type": file.mime_type,
+        "size": payload_size,
+        "truncated": bool(truncated),
+    }
+
+    if bool(include_source):
+        response["source"] = decoded
+    return response
 
 
 def _serve_resumable(manager, key, download_name, mime_type=None):

--- a/suite/drive/api/tests/test_files.py
+++ b/suite/drive/api/tests/test_files.py
@@ -14,11 +14,13 @@ from suite.drive.api.files import (
     create_auth_token,
     does_entity_exist,
     get_file_content,
+    get_markdown_preview,
     get_new_title,
     move,
     remove_or_restore,
     rename,
     search,
+    TEXT_PREVIEW_LIMIT_BYTES,
     stream_file_content,
     track_visit,
     update_access,
@@ -365,6 +367,43 @@ class TestDriveFilesAPI(IntegrationTestCase):
             self.assertFalse(user_has_permission(self.file, "read"))
             with self.assertRaises(frappe.PermissionError):
                 get_file_content(self.file.name)
+
+    def test_markdown_preview_returns_formatted_html_for_markdown(self):
+        with self.set_user(OWNER):
+            markdown = self.upload(b"# Title\\n\\n- item", filename="notes.md")
+            preview = get_markdown_preview(markdown.name, mode="html")
+        self.assertEqual(preview["mime_type"], "text/markdown")
+        self.assertIn("<h1>Title</h1>", preview["content"])
+        self.assertIn("<li>item</li>", preview["content"])
+
+    def test_markdown_preview_returns_raw_content_for_raw_mode(self):
+        with self.set_user(OWNER):
+            markdown = self.upload(b"# Title\\n\\nraw line", filename="notes.md")
+            preview = get_markdown_preview(markdown.name, mode="raw")
+        self.assertEqual(preview["content"], "# Title\\n\\nraw line")
+
+    def test_markdown_preview_blocks_non_markdown_file_types(self):
+        with self.set_user(OWNER):
+            file = self.upload(b"not markdown", filename="note.txt")
+            with self.assertRaises(frappe.ValidationError):
+                get_markdown_preview(file.name, mode="html")
+
+    def test_markdown_preview_denies_unread_users(self):
+        with self.set_user(OWNER):
+            markdown = self.upload(b"# Secret", filename="notes.md")
+
+        with self.set_user(OTHER_USER), self.assertRaises(frappe.PermissionError):
+            get_markdown_preview(markdown.name, mode="html")
+
+    def test_markdown_preview_marks_truncated_response_for_large_markdown(self):
+        large = b"A" * (TEXT_PREVIEW_LIMIT_BYTES + 20)
+        with self.set_user(OWNER), patch("suite.drive.api.files.validate_quota"):
+            markdown = self.upload(large, filename="large.md", total_size=len(large))
+
+        with self.set_user(OWNER):
+            preview = get_markdown_preview(markdown.name, mode="html")
+        self.assertTrue(preview["truncated"])
+        self.assertLess(len(preview["content"]), len(large))
 
     def test_content_link_cannot_be_forged_to_hijack_another_users_document(self):
         """content_doctype/content_docname are the sole permission delegation


### PR DESCRIPTION
## Summary

Adds read-only Markdown preview support to Frappe Drive.

Markdown files now open with two tabs:

- **Formatted**: renders Markdown as sanitised HTML.
- **Raw**: displays the original Markdown source in a `<pre>` block.

Non-Markdown text and code previews are unchanged.

## Changes

- Added Drive Markdown preview API endpoint with HTML and raw modes.
- Added sanitised Markdown rendering using DOMPurify.
- Added Formatted/Raw tabs to the Drive preview.
- Added Markdown preview routing by MIME type.
- Added frontend tests covering formatted mode, raw mode, errors, empty content, and editor absence.
- Added backend tests for Markdown preview behaviour.

## Validation

- Frontend Markdown preview tests: passed, 4/4.
- Backend integration tests: not completed locally because the Dockerised Frappe bench setup stalled before pytest execution.

## Notes

This change was implemented with AI assistance and reviewed in the working tree. No Markdown editor is introduced.

<img width="805" height="698" alt="image" src="https://github.com/user-attachments/assets/b368db32-0090-4dba-8876-e25b81d35ba3" />
----
<img width="1091" height="805" alt="image" src="https://github.com/user-attachments/assets/d31b5077-47a1-4d48-b6bb-c90170f3bcab" />

